### PR TITLE
ci: trusted publishers (OIDC) + PR snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm changeset:version
           publish: pnpm changeset:publish -- --provenance
@@ -56,8 +56,6 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,31 @@
+name: Snapshot
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  snapshot:
+    name: Publish PR Snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "25.2.0"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpx pkg-pr-new publish --pnpm './packages/*'


### PR DESCRIPTION
## Summary

- Add `snapshot.yml` — per-PR package preview via `pkg-pr-new` (publishes all `./packages/*`)
- Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` from `release.yml` — switch to npm trusted publishers via OIDC (`id-token: write` already configured)
- Fix lockfile specifier for typescript (`catalog:` instead of literal version)

## Manual step required after merge

Configure **npm trusted publishers** on https://www.npmjs.com for each of 6 packages:

| Package | Repository | Workflow |
|---------|------------|----------|
| @connectum/core | Connectum-Framework/connectum | release.yml |
| @connectum/interceptors | Connectum-Framework/connectum | release.yml |
| @connectum/healthcheck | Connectum-Framework/connectum | release.yml |
| @connectum/reflection | Connectum-Framework/connectum | release.yml |
| @connectum/otel | Connectum-Framework/connectum | release.yml |
| @connectum/testing | Connectum-Framework/connectum | release.yml |

## Test plan

- [ ] CI passes (lockfile fix resolves frozen-lockfile error)
- [ ] Merge PR → verify snapshot comment appears on next PR
- [ ] Configure trusted publishers on npmjs.com
- [ ] Test release flow: changeset → version packages PR → merge → npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated snapshot publishing for pull requests to main (cancels concurrent runs).
  * Configured CI job to install dependencies with pnpm and publish PR snapshots.
  * Updated CI action versions for pnpm and changesets.
  * Removed certain environment variables from the release workflow to streamline authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->