### PR TITLE
fix(ci): pass provenance via env var instead of CLI argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,12 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm changeset:version
-          publish: pnpm changeset:publish -- --provenance
+          publish: pnpm changeset:publish
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

- Fix `changeset publish -- --provenance` error: "Too many arguments passed to changesets"
- Use `NPM_CONFIG_PROVENANCE=true` env var instead, which pnpm/npm picks up during publish

**This was blocking all npm publishes.** The error was silent because it only triggers when there are new changesets to publish.

## Test plan

- [x] CI passes
- [ ] Next "Version Packages" PR merge triggers successful npm publish with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process in release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->