### PR TITLE
chore: add changeset for rc.3 release

### DIFF
--- a/.changeset/ci-oidc-provenance.md
+++ b/.changeset/ci-oidc-provenance.md
@@ -1,0 +1,17 @@
+---
+"@connectum/core": patch
+"@connectum/healthcheck": patch
+"@connectum/reflection": patch
+---
+
+CI/CD and documentation improvements
+
+**CI/CD:**
+- Switch to OIDC trusted publishers (no NPM_TOKEN)
+- Add PR snapshot publishing via pkg-pr-new
+- Fix provenance: use NPM_CONFIG_PROVENANCE env var instead of CLI argument
+
+**Docs:**
+- Fix healthcheck README: clarify Check/Watch (standard) + List (extension), license MIT → Apache-2.0
+- Fix httpHandler.ts JSDoc: HTTP_HEALTH_ENABLED → HealthcheckOptions.httpEnabled
+- Add comprehensive reflection README (API, grpcurl, buf curl usage)


### PR DESCRIPTION
## Summary

Add changeset for `1.0.0-rc.3` release covering changes since rc.2:

- **CI/CD**: OIDC trusted publishers, PR snapshots, provenance fix
- **Docs**: healthcheck/reflection README improvements

After merge, the Release workflow will create a "Version Packages" PR that bumps all packages to `1.0.0-rc.3`.

## What happens next

```
1. This PR merges → Release workflow runs
2. Changesets Action detects new changeset → creates "Version Packages" PR
3. Review + merge "Version Packages" PR → npm publish (OIDC + provenance)
4. GitHub Release v1.0.0-rc.3 created automatically
```

## Test plan

- [x] CI passes
- [x] After merge: "Version Packages" PR appears within ~1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated healthcheck documentation with clarified functionality and license information.
  * Added comprehensive reflection API guide with usage examples.

* **Chores**
  * Enhanced CI/CD security with OIDC trusted publishers.
  * Added PR snapshot publishing capability for improved testing workflows.
  * Fixed provenance configuration in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->