### PR TITLE
fix(ci): use GitHub App token for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Test
         run: pnpm test:unit
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
@@ -55,7 +62,7 @@ jobs:
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

- Use `actions/create-github-app-token` to generate a token for the changesets action
- Replace `secrets.GITHUB_TOKEN` with the app token in the changesets step

**Problem:** `GITHUB_TOKEN` events don't trigger subsequent workflow runs (GitHub limitation to prevent infinite loops). This caused CI (`Typecheck, Lint & Test`) and Snapshot to not run on `changeset-release/main` PRs (e.g. PR #14), making them unmergeable due to branch protection.

**Fix:** GitHub App tokens are not subject to this limitation — pushes and PRs created with an app token will trigger CI normally.

## Test plan

- [ ] Merge this PR
- [ ] Push a changeset to main → Release workflow creates `changeset-release/main` PR
- [ ] Verify CI and Snapshot workflows run on the changeset PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow security infrastructure to improve the reliability and safety of the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->