### PR TITLE
fix(ci): pass app token to checkout for git push credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,16 @@ jobs:
     name: Release & Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
@@ -45,13 +54,6 @@ jobs:
 
       - name: Test
         run: pnpm test:unit
-
-      - name: Generate App token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Create Release Pull Request or Publish
         id: changesets


### PR DESCRIPTION
## Summary

- Move `actions/create-github-app-token` step before `actions/checkout`
- Pass app token to `actions/checkout` via `token` parameter

**Problem:** PR #15 fixed the `GITHUB_TOKEN` env var for changesets/action, but `actions/checkout` still configured git credentials with the default `GITHUB_TOKEN`. When changesets/action pushed to `changeset-release/main`, git used the checkout-configured credentials (GITHUB_TOKEN), so the push was attributed to `github-actions[bot]` and didn't trigger CI.

**Fix:** Generate app token first, pass it to both `actions/checkout` (for git credentials) and `changesets/action` (for GitHub API). Now git push will be attributed to the GitHub App, which triggers subsequent workflows.

## Test plan

- [ ] Merge this PR
- [ ] Release workflow runs on main
- [ ] Verify changeset PR #14 gets updated with new commit
- [ ] Verify CI (`Typecheck, Lint & Test`) and Snapshot run on PR #14
- [ ] Verify push actor is the GitHub App bot (not `github-actions[bot]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use enhanced authentication for improved security during code checkout and release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->