### PR TITLE
fix(ci): remove duplicate app token step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,6 @@ jobs:
       - name: Test
         run: pnpm test:unit
 
-      - name: Generate App token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0


### PR DESCRIPTION
## Summary

Remove duplicate `Generate App token` step caused by merging PR #15 and #16 — both added the step in different positions, resulting in two steps with the same `id: app-token`. GitHub Actions rejects duplicate step IDs.

## Test plan

- [ ] Merge → Release workflow starts successfully
- [ ] Changeset PR #14 gets updated
- [ ] CI runs on changeset PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal release workflow efficiency by removing duplicate process steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->