### PR TITLE
fix(ci): disable per-package GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           publish: pnpm changeset:publish
           title: "chore: version packages"
           commit: "chore: version packages"
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

Add `createGithubReleases: false` to changesets/action to stop creating per-package GitHub releases (e.g. `@connectum/core@1.0.0-rc.3`).

The custom `Create GitHub Release` step already creates a single overall release (`Connectum v1.0.0-rc.3`).

Also cleaned up 6 existing per-package releases from rc.3.

## Test plan

- [ ] Next publish creates only one GitHub Release (`Connectum vX.Y.Z`)
- [ ] No per-package releases created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration.

---

**Note:** This change is an internal workflow adjustment with no direct user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->