### PR TITLE
fix(ci): ignore catalog-managed deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,25 @@ updates:
         dependency-type: production
       development:
         dependency-type: development
+    # Ignore all pnpm catalog-managed dependencies.
+    # Dependabot corrupts catalog: specifiers in pnpm-lock.yaml,
+    # replacing them with exact versions, which breaks --frozen-lockfile.
+    # Upstream bugs:
+    #   https://github.com/dependabot/dependabot-core/issues/12445
+    #   https://github.com/dependabot/dependabot-core/issues/12244
+    # These dependencies are managed via pnpm-workspace.yaml catalog.
+    # TODO: remove ignore rules when the upstream bug is fixed.
+    ignore:
+      - dependency-name: "@biomejs/*"
+      - dependency-name: "@bufbuild/*"
+      - dependency-name: "@commitlint/*"
+      - dependency-name: "@connectrpc/*"
+      - dependency-name: "@opentelemetry/*"
+      - dependency-name: "c8"
+      - dependency-name: "env-var"
+      - dependency-name: "husky"
+      - dependency-name: "typescript"
+      - dependency-name: "zod"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps):"


### PR DESCRIPTION
## Summary

- Add `ignore` rules for all pnpm catalog-managed dependencies in `dependabot.yml`
- Closes broken PR #20 (TypeScript bump that corrupted `catalog:` specifier)

## Problem

Dependabot doesn't properly support pnpm `catalog:` protocol — it replaces `specifier: 'catalog:'` with exact versions in `pnpm-lock.yaml`, breaking `--frozen-lockfile` in CI.

**Upstream bugs:**
- https://github.com/dependabot/dependabot-core/issues/12445
- https://github.com/dependabot/dependabot-core/issues/12244

## Solution

Ignore all catalog-managed dependencies (29 packages across 10 ignore rules). Non-catalog dependencies (`turbo`, `@changesets/*`, `cockatiel`, etc.) remain under Dependabot management.

Catalog dependencies are managed centrally via `pnpm-workspace.yaml` — manual updates only until upstream bug is fixed.

## Test plan

- [ ] Verify no new broken Dependabot PRs appear for catalog deps
- [ ] Non-catalog deps (turbo, changesets) still get Dependabot updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to exclude specified packages from automatic update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->