### PR TITLE
feat(auth): prioritize publicKey over secret

### DIFF
--- a/.changeset/publickey-priority.md
+++ b/.changeset/publickey-priority.md
@@ -1,0 +1,7 @@
+---
+"@connectum/auth": minor
+---
+
+Change JWT key resolution priority from `jwksUri > secret > publicKey` to `jwksUri > publicKey > secret`.
+
+Asymmetric keys are cryptographically stronger than symmetric secrets, so `publicKey` now takes precedence over `secret` when both are provided. Also improved `publicKey` JSDoc with supported algorithms (RSA, RSA-PSS, EC, EdDSA) and `crypto.subtle.importKey()` examples.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -108,7 +108,7 @@ const auth = createAuthInterceptor({
 
 Convenience wrapper for JWT-based authentication. Handles token extraction from `Authorization: Bearer <token>`, verification via [jose](https://github.com/panva/jose), and standard claim mapping.
 
-Key resolution priority: `jwksUri` > `secret` > `publicKey`.
+Key resolution priority: `jwksUri` > `publicKey` > `secret`.
 
 A missing `sub` claim (and no `claimsMapping.subject` override) throws `ConnectError(Unauthenticated)` with message `"JWT missing subject claim"` (SEC-002).
 
@@ -133,7 +133,7 @@ const jwtAuth = createJwtAuthInterceptor({
 |--------|------|---------|-------------|
 | `jwksUri` | `string` | - | JWKS endpoint URL for remote key set |
 | `secret` | `string` | - | HMAC symmetric secret (HS256/HS384/HS512) |
-| `publicKey` | `CryptoKey` | - | Asymmetric public key |
+| `publicKey` | `CryptoKey` | - | Asymmetric public key (RSA, RSA-PSS, EC, EdDSA). Import via `crypto.subtle.importKey()`. |
 | `issuer` | `string \| string[]` | - | Expected issuer(s) |
 | `audience` | `string \| string[]` | - | Expected audience(s) |
 | `algorithms` | `string[]` | - | Allowed algorithms |

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -166,7 +166,41 @@ export interface JwtAuthInterceptorOptions {
     jwksUri?: string | undefined;
     /** HMAC symmetric secret (for HS256/HS384/HS512) */
     secret?: string | undefined;
-    /** Asymmetric public key */
+    /**
+     * Asymmetric public key for JWT signature verification.
+     *
+     * Supported algorithms:
+     * - **RSA**: RS256, RS384, RS512
+     * - **RSA-PSS**: PS256, PS384, PS512
+     * - **EC (ECDSA)**: ES256, ES384, ES512
+     * - **EdDSA**: Ed25519, Ed448
+     *
+     * Import a PEM-encoded key via Web Crypto API:
+     *
+     * @example RSA public key
+     * ```typescript
+     * const rsaKey = await crypto.subtle.importKey(
+     *   "spki",
+     *   pemToArrayBuffer(rsaPem),
+     *   { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+     *   true,
+     *   ["verify"],
+     * );
+     * ```
+     *
+     * @example EC public key
+     * ```typescript
+     * const ecKey = await crypto.subtle.importKey(
+     *   "spki",
+     *   pemToArrayBuffer(ecPem),
+     *   { name: "ECDSA", namedCurve: "P-256" },
+     *   true,
+     *   ["verify"],
+     * );
+     * ```
+     *
+     * @see {@link https://github.com/panva/jose/blob/main/docs/types/types.CryptoKey.md | jose CryptoKey documentation}
+     */
     publicKey?: CryptoKey | undefined;
     /** Expected issuer(s) */
     issuer?: string | string[] | undefined;


### PR DESCRIPTION
## Summary

- Change JWT key resolution order from `jwksUri > secret > publicKey` to `jwksUri > publicKey > secret`
- Asymmetric keys (RSA/EC) are cryptographically stronger and should take precedence over symmetric secrets
- Swap if-blocks in `buildVerifier()`, expand `publicKey` JSDoc with algorithms and examples

## Changes

- `packages/auth/src/jwt-auth-interceptor.ts` — reorder key resolution
- `packages/auth/src/types.ts` — expand JSDoc for publicKey option
- `packages/auth/README.md` — update priority documentation
- 4 unit + 1 integration test for asymmetric key verification
- Changeset included

## Test plan

- [x] Unit tests for RSA and EC key verification
- [x] Integration test for publicKey priority over secret
- [ ] CI: Build, Typecheck, Lint & Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated JWT key resolution priority order: jwksUri > publicKey > secret
  * Enhanced public key documentation with supported algorithms (RSA, RSA-PSS, EC, EdDSA) and Web Crypto API import guidance

* **Tests**
  * Added asymmetric key verification tests for ES256 and RS256
  * Added key priority validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->