### PR TITLE
chore(core): add changeset for HTTP/1.1 transport

### DIFF
--- a/.changeset/transport-http1-mode.md
+++ b/.changeset/transport-http1-mode.md
@@ -1,0 +1,9 @@
+---
+"@connectum/core": minor
+---
+
+Three transport modes: TLS (createSecureServer), h2c (http2.createServer), HTTP/1.1 (http.createServer).
+
+New exported types: `TransportServer`, `NodeRequest`, `NodeResponse`.
+
+`allowHTTP1` option now selects transport mode without TLS: `true` (default) uses HTTP/1.1, `false` uses h2c.


### PR DESCRIPTION
## Summary

- Add missing changeset for HTTP/1.1 transport mode feature (merged in PR #27)
- Changeset `transport-http1-mode`: minor bump for `@connectum/core`
- Describes: three transport modes, new exported types (`TransportServer`, `NodeRequest`, `NodeResponse`), `allowHTTP1` transport selection

No code changes — changeset file only.

## Test plan

- [ ] `pnpm changeset status` shows pending changeset
- [ ] No code changes, only `.changeset/transport-http1-mode.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multiple transport modes (TLS, h2c, and HTTP/1.1) for more flexible server connectivity and deployment options.
  * Added an `allowHTTP1` configuration option to let deployments choose HTTP/1.1 when TLS is not used.
  * Exposed three new public types in the API to support the new transport options and request/response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->