### PR TITLE
docs: add TODO(ADR-025) for hybrid versioning transition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         run: |
           PUBLISHED='${{ steps.changesets.outputs.publishedPackages }}'
+          # TODO(ADR-025): After 1.0.0 stable, switch to hybrid versioning:
+          # VERSION=$(echo "${PUBLISHED}" | jq -r '.[] | select(.name == "@connectum/core") | .version')
           VERSION=$(echo "${PUBLISHED}" | jq -r '.[0].version')
           TAG="v${VERSION}"
 


### PR DESCRIPTION
## Summary

- Add `TODO(ADR-025)` comment in `release.yml` marking the version extraction line for future hybrid versioning switch after 1.0.0 stable
- Include the ready-to-use `jq` command that targets `@connectum/core` specifically instead of `.[0]`

See [ADR-025: Package Versioning Strategy](https://github.com/Connectum-Framework/docs/blob/main/en/contributing/adr/025-package-versioning-strategy.md) for full context.

## Test plan

- [ ] Verify CI passes (comment-only change, no runtime impact)
- [ ] Confirm `release.yml` syntax is valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow version extraction logic to streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->