### PR TITLE
fix: normalize repository.url to git+https format

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git"
+    "url": "git+https://github.com/Connectum-Framework/connectum.git"
   },
   "homepage": "https://github.com/Connectum-Framework/connectum#readme",
   "bugs": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/auth"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/cli"
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/core"
   },
   "scripts": {

--- a/packages/healthcheck/package.json
+++ b/packages/healthcheck/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/healthcheck"
   },
   "scripts": {

--- a/packages/interceptors/package.json
+++ b/packages/interceptors/package.json
@@ -57,7 +57,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/interceptors"
   },
   "scripts": {

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -61,7 +61,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/otel"
   },
   "scripts": {

--- a/packages/reflection/package.json
+++ b/packages/reflection/package.json
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/reflection"
   },
   "scripts": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Connectum-Framework/connectum.git",
+    "url": "git+https://github.com/Connectum-Framework/connectum.git",
     "directory": "packages/testing"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- Add `git+` prefix to `repository.url` in all 9 `package.json` files
- Fixes `npm warn publish npm auto-corrected some errors in your package.json` during `npm publish`

## Context

npm expects `repository.url` in `git+https://...` format per the [package.json spec](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository). Without the prefix, npm auto-corrects and emits a warning on every publish.

## Test plan

- [x] `pnpm install` — no lockfile changes
- [x] All 9 package.json files have `git+https://github.com/Connectum-Framework/connectum.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository URLs in package manifests across the monorepo to use the standardized git+ protocol prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->