### PR TITLE
fix: resolve Biome lint warnings in events packages

### DIFF
--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -139,7 +139,7 @@ class ServerImpl extends EventEmitter implements Server {
             if (this._eventBus) {
                 await this._eventBus.start({ signal: this._abortController.signal });
                 this._shutdownManager.addHook("eventbus", async () => {
-                    await this._eventBus!.stop();
+                    await this._eventBus?.stop();
                 });
             }
 

--- a/packages/events-nats/src/NatsAdapter.ts
+++ b/packages/events-nats/src/NatsAdapter.ts
@@ -37,7 +37,6 @@ function toDeliverPolicy(policy: "new" | "all" | "last" | undefined): DeliverPol
             return DeliverPolicy.All;
         case "last":
             return DeliverPolicy.Last;
-        case "new":
         default:
             return DeliverPolicy.New;
     }

--- a/packages/events-redis/src/RedisAdapter.ts
+++ b/packages/events-redis/src/RedisAdapter.ts
@@ -261,7 +261,7 @@ export function RedisAdapter(options: RedisAdapterOptions = {}): EventAdapter {
             // Redis Streams does not support wildcard patterns.
             for (const p of patterns) {
                 if (p.includes("*") || p.includes(">")) {
-                    throw new Error(`RedisAdapter: wildcard pattern "${p}" is not supported. ` + `Redis Streams requires explicit topic names.`);
+                    throw new Error(`RedisAdapter: wildcard pattern "${p}" is not supported. Redis Streams requires explicit topic names.`);
                 }
             }
 
@@ -364,8 +364,8 @@ export function RedisAdapter(options: RedisAdapterOptions = {}): EventAdapter {
                         // Batch XPENDING: one round-trip instead of N (EFF-7).
                         const deliveryCounts = new Map<string, number>();
                         try {
-                            const [firstId] = entries[0]!;
-                            const [lastId] = entries[entries.length - 1]!;
+                            const [firstId] = entries[0] as [string, string[]];
+                            const [lastId] = entries[entries.length - 1] as [string, string[]];
                             const pendingAll = (await blockingRedis.call("XPENDING", key, group, firstId, lastId, String(entries.length))) as
                                 | [string, string, number, number][]
                                 | null;

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -9,6 +9,7 @@
 
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+// biome-ignore lint/correctness/useImportExtensions: workspace package, not a relative import
 import type { EventBusLike } from "@connectum/core";
 import { createEventContext } from "./EventContext.ts";
 import { EventRouterImpl } from "./EventRouter.ts";
@@ -98,7 +99,7 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
 
                     for (const entry of router.entries) {
                         if (topicHandlerMap.has(entry.topic)) {
-                            throw new Error(`Duplicate event topic "${entry.topic}". ` + `Use (connectum.events.v1.event).topic option to disambiguate.`);
+                            throw new Error(`Duplicate event topic "${entry.topic}". Use (connectum.events.v1.event).topic option to disambiguate.`);
                         }
                         const composedHandler = composeMiddleware(middlewares, async (rawEvent, ctx) => {
                             const message = fromBinary(entry.method.input, rawEvent.payload);


### PR DESCRIPTION
## Summary

- Remove useless switch case in NatsAdapter (`noUselessSwitchCase`)
- Merge string concatenation into template literals (`useTemplate`)
- Replace non-null assertions with optional chain/type assertions (`noNonNullAssertion`)
- Suppress false positive `useImportExtensions` on workspace import

Biome warnings: **7 → 0**

## Test plan

- [x] `pnpm build` — 15/15 successful
- [x] `pnpm test` — 274 pass, 0 fail
- [x] `npx biome check .` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved null-safety handling and type assertions in event processing components.
  * Simplified conditional logic in event policy handling.

* **Style**
  * Minor formatting improvements in error messages.

---

**Note:** This release contains internal code improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->