### PR TITLE
feat(events): add graceful drain with active message tracking

### DIFF
--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -204,7 +204,8 @@ function createEventBus(options: EventBusOptions): EventBus
 | `middleware` | `MiddlewareConfig` | `{}` | Middleware configuration |
 | `group` | `string` | `undefined` | Consumer group name |
 | `signal` | `AbortSignal` | `undefined` | External abort signal |
-| `handlerTimeout` | `number` | `undefined` | Per-handler timeout in ms |
+| `handlerTimeout` | `number` | `30000` | Per-handler timeout in ms |
+| `drainTimeout` | `number` | `30000` | Max ms to wait for in-flight handlers during shutdown |
 
 ### EventBus Interface
 
@@ -274,6 +275,27 @@ await bus.stop();
 ```
 
 Supports wildcard subscriptions (`*` and `>` patterns).
+
+## Graceful Shutdown
+
+EventBus tracks in-flight message handlers and waits for them to complete during `stop()`:
+
+```typescript
+const bus = createEventBus({
+  adapter: NatsAdapter({ servers: 'nats://localhost:4222' }),
+  routes: [eventRoutes],
+  drainTimeout: 15_000, // Wait up to 15s for handlers (default: 30s)
+});
+
+// During stop():
+// 1. Stop accepting new messages (nack with requeue)
+// 2. Wait for in-flight handlers up to drainTimeout
+// 3. Force-abort remaining via AbortSignal
+// 4. Disconnect adapter
+await bus.stop();
+```
+
+Set `drainTimeout: 0` for immediate abort (skip drain).
 
 ## Exports Summary
 

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -52,6 +52,10 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
     let stopping = false;
     let startPromise: Promise<void> | null = null;
     let stopPromise: Promise<void> | null = null;
+    const drainTimeout = options.drainTimeout ?? 30_000;
+    const inFlight = new Set<Promise<void>>();
+    let drainController = new AbortController();
+    let draining = false;
     const defaultSignal = options.signal;
     let shutdownSignal: AbortSignal | undefined;
 
@@ -130,8 +134,16 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                                     return;
                                 }
 
-                                // Compose per-event signal: timeout + optional server shutdown (C-2, M-5)
-                                const eventSignal = shutdownSignal ? AbortSignal.any([shutdownSignal, AbortSignal.timeout(handlerTimeout)]) : AbortSignal.timeout(handlerTimeout);
+                                // Gate: nack new messages during drain
+                                if (draining) {
+                                    await nack(true);
+                                    return;
+                                }
+
+                                // Compose per-event signal: timeout + optional server shutdown + drain (C-2, M-5)
+                                const signals: AbortSignal[] = [AbortSignal.timeout(handlerTimeout), drainController.signal];
+                                if (shutdownSignal) signals.push(shutdownSignal);
+                                const eventSignal = AbortSignal.any(signals);
 
                                 // Track settlement to auto-ack if handler doesn't call ack/nack (C-1)
                                 let settled = false;
@@ -148,19 +160,27 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                                     },
                                 });
 
-                                let completed = false;
-                                try {
-                                    await handler(rawEvent, ctx);
-                                    completed = true;
-                                } finally {
-                                    // Auto-ack fallback for backward compatibility (C-1)
-                                    if (!settled && completed) {
-                                        try {
-                                            await ack();
-                                        } catch {
-                                            // Auto-ack failed — message will be redelivered by broker timeout
+                                const handlerPromise = (async () => {
+                                    let completed = false;
+                                    try {
+                                        await handler(rawEvent, ctx);
+                                        completed = true;
+                                    } finally {
+                                        // Auto-ack fallback for backward compatibility (C-1)
+                                        if (!settled && completed) {
+                                            try {
+                                                await ack();
+                                            } catch {
+                                                // Auto-ack failed — message will be redelivered by broker timeout
+                                            }
                                         }
                                     }
+                                })();
+                                inFlight.add(handlerPromise);
+                                try {
+                                    await handlerPromise;
+                                } finally {
+                                    inFlight.delete(handlerPromise);
                                 }
                             },
                             group !== undefined ? { group } : {},
@@ -197,17 +217,46 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
             if (!started) return;
 
             stopping = true;
+            draining = true;
+
             stopPromise = (async () => {
                 try {
-                    // Unsubscribe all — use allSettled so one failure doesn't block the rest.
+                    // 1. Close iterators — stop receiving new messages
                     await Promise.allSettled(subscriptions.map((sub) => sub.unsubscribe()));
                     subscriptions.length = 0;
 
+                    // 2. Drain in-flight handlers with timeout
+                    if (inFlight.size > 0 && drainTimeout > 0) {
+                        const deadline = Date.now() + drainTimeout;
+
+                        while (inFlight.size > 0) {
+                            const remaining = deadline - Date.now();
+                            if (remaining <= 0) break;
+
+                            await Promise.race([
+                                Promise.allSettled([...inFlight]),
+                                new Promise<void>((resolve) => {
+                                    globalThis.setTimeout(resolve, remaining);
+                                }),
+                            ]);
+                        }
+                    }
+
+                    // 3. Force-abort remaining handlers if still in-flight
+                    if (inFlight.size > 0) {
+                        drainController.abort("Drain timeout exceeded");
+                        // Brief settle window for abort handlers
+                        await Promise.allSettled([...inFlight]);
+                    }
+
+                    inFlight.clear();
                     await adapter.disconnect();
                 } finally {
                     started = false;
                     shutdownSignal = undefined;
                     stopping = false;
+                    draining = false;
+                    drainController = new AbortController();
                     stopPromise = null;
                 }
             })();

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -273,6 +273,14 @@ export interface EventBusOptions {
      * this duration. Default: 30000 (30 seconds).
      */
     handlerTimeout?: number;
+    /**
+     * Maximum time in milliseconds to wait for in-flight event handlers
+     * to complete during shutdown. After this timeout, remaining handlers
+     * are force-aborted via AbortSignal.
+     *
+     * Default: 30000 (30 seconds). Set to 0 for immediate abort.
+     */
+    drainTimeout?: number;
 }
 
 /**

--- a/packages/events/tests/integration/EventBus.test.ts
+++ b/packages/events/tests/integration/EventBus.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 import { EventOptionsSchema } from "../../gen/connectum/events/v1/options_pb.js";
 import { createEventBus } from "../../src/EventBus.ts";
 import { MemoryAdapter } from "../../src/MemoryAdapter.ts";
@@ -347,5 +348,317 @@ describe("EventBus handler error propagation", () => {
         assert.deepEqual(ackCalls, ["ack"]);
 
         await bus.stop();
+    });
+});
+
+// =============================================================================
+// GRACEFUL DRAIN TESTS
+// =============================================================================
+
+/**
+ * Helper: create a raw event with the given eventType.
+ */
+function makeRawEvent(eventType: string, id = "evt-drain"): RawEvent {
+    return {
+        eventId: id,
+        eventType,
+        payload: new Uint8Array(),
+        publishedAt: new Date(),
+        attempt: 1,
+        metadata: new Map(),
+    };
+}
+
+/**
+ * Manual test adapter that captures the RawEventHandler from subscribe(),
+ * allowing tests to deliver events at controlled times and inspect ack/nack.
+ */
+function createManualAdapter() {
+    let capturedHandler: RawEventHandler | null = null;
+    let connected = false;
+
+    const adapter: EventAdapter = {
+        name: "manual-test",
+        async connect() {
+            connected = true;
+        },
+        async disconnect() {
+            capturedHandler = null;
+            connected = false;
+        },
+        async publish() {},
+        async subscribe(_patterns, handler): Promise<EventSubscription> {
+            capturedHandler = handler;
+            return {
+                async unsubscribe() {
+                    // Do not null capturedHandler here -- in-flight handlers
+                    // may still be running when unsubscribe is called during drain.
+                },
+            };
+        },
+    };
+
+    return {
+        adapter,
+        /**
+         * Deliver an event through the captured handler.
+         * Returns the handler promise and ack/nack tracking.
+         */
+        deliver(event: RawEvent) {
+            const handler = capturedHandler;
+            assert.ok(handler, "No handler captured -- was subscribe() called?");
+
+            const calls: string[] = [];
+
+            const promise = handler(
+                event,
+                async () => {
+                    calls.push("ack");
+                },
+                async (requeue?: boolean) => {
+                    calls.push(requeue ? "nack-requeue" : "nack");
+                },
+            );
+
+            return { promise, calls };
+        },
+        get handler() {
+            return capturedHandler;
+        },
+        get connected() {
+            return connected;
+        },
+    };
+}
+
+describe("EventBus graceful drain", () => {
+    it("stop() waits for in-flight handlers to complete", async () => {
+        const manual = createManualAdapter();
+        let handlerCompleted = false;
+
+        const method = fakeDescMethod("drainEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.DrainService", [method]);
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 5000,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        drainEvent: async () => {
+                            await delay(200);
+                            handlerCompleted = true;
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Deliver event -- handler takes 200ms
+        const { promise: handlerPromise, calls } = manual.deliver(
+            makeRawEvent(EventOptionsSchema.typeName),
+        );
+
+        // Don't await handlerPromise; call stop() while it's in-flight
+        const stopPromise = bus.stop();
+
+        // stop() should wait for the handler
+        await stopPromise;
+
+        // Handler must have completed by now
+        assert.equal(handlerCompleted, true, "handler should have completed before stop() resolved");
+        assert.deepEqual(calls, ["ack"], "handler should have been auto-acked");
+
+        // Also make sure the handler promise resolved
+        await handlerPromise;
+    });
+
+    it("stop() force-aborts after drainTimeout", async () => {
+        const manual = createManualAdapter();
+        let signalAborted = false;
+
+        const method = fakeDescMethod("slowEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.SlowService", [method]);
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 100,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        slowEvent: async (_event: unknown, ctx: { signal: AbortSignal }) => {
+                            // Handler that respects abort signal
+                            try {
+                                await delay(5000, undefined, { signal: ctx.signal });
+                            } catch {
+                                signalAborted = ctx.signal.aborted;
+                            }
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Deliver event -- handler would take 5000ms
+        const { promise: handlerPromise } = manual.deliver(
+            makeRawEvent(EventOptionsSchema.typeName),
+        );
+
+        const start = Date.now();
+        await bus.stop();
+        const elapsed = Date.now() - start;
+
+        // stop() should resolve in ~100ms, not 5000ms
+        assert.ok(elapsed < 2000, `stop() took ${elapsed}ms, expected ~100ms`);
+        assert.equal(signalAborted, true, "handler signal should have been aborted");
+
+        // Handler promise may reject due to abort -- that's expected
+        await handlerPromise.catch(() => {});
+    });
+
+    it("new messages are nack'd during drain", async () => {
+        const manual = createManualAdapter();
+
+        const method = fakeDescMethod("drainNackEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.DrainNackService", [method]);
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 5000,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        drainNackEvent: async () => {
+                            await delay(300);
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Deliver event 1 (slow handler, 300ms)
+        const { promise: handler1Promise } = manual.deliver(
+            makeRawEvent(EventOptionsSchema.typeName, "evt-1"),
+        );
+
+        // Start stop (enters draining state) but don't await yet
+        const stopPromise = bus.stop();
+
+        // Brief delay to ensure draining flag is set
+        await delay(10);
+
+        // Deliver event 2 during drain -- should be nack'd with requeue
+        const { promise: handler2Promise, calls: calls2 } = manual.deliver(
+            makeRawEvent(EventOptionsSchema.typeName, "evt-2"),
+        );
+
+        await handler2Promise;
+        assert.deepEqual(calls2, ["nack-requeue"], "event during drain should be nack'd with requeue");
+
+        await stopPromise;
+        await handler1Promise;
+    });
+
+    it("drainTimeout: 0 means immediate abort", async () => {
+        const manual = createManualAdapter();
+        let signalAborted = false;
+
+        const method = fakeDescMethod("immediateAbortEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.ImmediateAbortService", [method]);
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 0,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        immediateAbortEvent: async (_event: unknown, ctx: { signal: AbortSignal }) => {
+                            try {
+                                await delay(5000, undefined, { signal: ctx.signal });
+                            } catch {
+                                signalAborted = ctx.signal.aborted;
+                            }
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise: handlerPromise } = manual.deliver(
+            makeRawEvent(EventOptionsSchema.typeName),
+        );
+
+        const start = Date.now();
+        await bus.stop();
+        const elapsed = Date.now() - start;
+
+        assert.ok(elapsed < 1000, `stop() took ${elapsed}ms, expected immediate`);
+        assert.equal(signalAborted, true, "handler signal should have been aborted immediately");
+
+        await handlerPromise.catch(() => {});
+    });
+
+    it("start-stop-start cycle with drain works cleanly", async () => {
+        const manual = createManualAdapter();
+
+        const method = fakeDescMethod("cycleEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.CycleService", [method]);
+
+        let handlerCallCount = 0;
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 5000,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        cycleEvent: async () => {
+                            handlerCallCount++;
+                            await delay(50);
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        // First cycle: start, deliver event, stop (drain)
+        await bus.start();
+        const { promise: p1 } = manual.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await bus.stop();
+        await p1;
+        assert.equal(handlerCallCount, 1);
+
+        // Second cycle: start again
+        await bus.start();
+        const { promise: p2 } = manual.deliver(makeRawEvent(EventOptionsSchema.typeName, "evt-cycle-2"));
+        await bus.stop();
+        await p2;
+        assert.equal(handlerCallCount, 2, "second cycle should work cleanly");
+    });
+
+    it("empty drain completes immediately", async () => {
+        const manual = createManualAdapter();
+
+        const bus = createEventBus({
+            adapter: manual.adapter,
+            drainTimeout: 5000,
+            routes: [],
+        });
+
+        await bus.start();
+
+        const start = Date.now();
+        await bus.stop();
+        const elapsed = Date.now() - start;
+
+        assert.ok(elapsed < 500, `empty drain took ${elapsed}ms, expected immediate`);
     });
 });


### PR DESCRIPTION
## Summary

Closes #47

- `EventBus.stop()` now tracks in-flight handlers and waits for completion before disconnecting
- New `drainTimeout` option (default: 30s) controls maximum wait time during shutdown
- New messages arriving during drain are `nack(true)` for requeue by broker
- After timeout, remaining handlers are force-aborted via `AbortSignal` (`drainController`)
- `drainTimeout: 0` skips drain for immediate shutdown
- Clean start-stop-start cycle support (all drain state properly reset)

## Changes

| File | Change |
|------|--------|
| `packages/events/src/types.ts` | `drainTimeout` option in `EventBusOptions` |
| `packages/events/src/EventBus.ts` | `inFlight` tracking, draining gate, signal composition, `stop()` drain loop |
| `packages/events/tests/integration/EventBus.test.ts` | 6 new tests + `ManualTestAdapter` helper |
| `packages/events/README.md` | `drainTimeout` in options table, Graceful Shutdown section |

## Test plan

- [x] `pnpm build` — 15/15 packages
- [x] `pnpm typecheck` — 0 errors
- [x] `npx biome check` — 0 warnings
- [x] `pnpm --filter @connectum/events test` — 58/58 pass (6 new drain tests)
- [x] `pnpm test` — 1018/1018 full suite
- [x] Backward compatibility: all existing lifecycle/error-propagation tests unchanged
- [x] Adapter packages (events-nats, events-kafka, events-redis) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event handler shutdown now gracefully waits for in-flight handlers to complete, with a configurable timeout before forcing abort.

* **Documentation**
  * Added graceful shutdown guidance with configuration examples and timeout behavior reference.

* **Tests**
  * Expanded test coverage for graceful shutdown and drain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->