### PR TITLE
fix(deps): add missing catalog deps to dependabot ignore and bump jose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
       - dependency-name: "env-var"
       - dependency-name: "husky"
       - dependency-name: "typescript"
+      - dependency-name: "@types/node"
+      - dependency-name: "tsup"
       - dependency-name: "zod"
     open-pull-requests-limit: 10
     commit-message:

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -73,7 +73,7 @@
     "@bufbuild/protobuf": "catalog:",
     "@connectrpc/connect": "catalog:",
     "@connectum/core": "workspace:^",
-    "jose": "^6.0.0"
+    "jose": "^6.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
         specifier: workspace:^
         version: link:../core
       jose:
-        specifier: ^6.0.0
-        version: 6.1.3
+        specifier: ^6.2.1
+        version: 6.2.1
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -2371,8 +2371,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -5287,7 +5287,7 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@6.1.3: {}
+  jose@6.2.1: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Add `@types/node` and `tsup` to dependabot ignore list — these are managed via pnpm catalog and Dependabot corrupts `catalog:` specifiers in the lockfile ([dependabot-core#12445](https://github.com/dependabot/dependabot-core/issues/12445), [#12244](https://github.com/dependabot/dependabot-core/issues/12244))
- Bump `jose` 6.1.3 → 6.2.1 (minor: re-introduce JWE zip support + internal refactor for smaller footprint)
- Closes PR #57 which was broken by the catalog specifier corruption

## Context

PR #57 (Dependabot production group bump) failed CI with:
```
ERR_PNPM_OUTDATED_LOCKFILE
@types/node (lockfile: 25.3.5, manifest: catalog:)
```

The catalog specifier `^25.3.0` already satisfies 25.3.5, so no catalog change is needed — only the ignore rule was missing.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm build` — all 15 tasks successful
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 274 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication library dependencies to the latest patch version.
  * Refined dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->