### PR TITLE
ci: add BSR proto publishing to release workflow

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
     paths:
       - "packages/auth/proto/**"
+      - "packages/auth/buf.yaml"
       - "packages/events/proto/**"
+      - "packages/events/buf.yaml"
       - ".github/workflows/buf.yml"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
@@ -95,9 +96,9 @@ jobs:
         if: steps.proto-changes.outputs.changed == 'true'
         run: |
           # Assemble proto into a single directory matching package structure
-          mkdir -p .bsr/connectum/auth/v1 .bsr/connectum/events/v1
-          cp packages/auth/proto/connectum/auth/v1/options.proto .bsr/connectum/auth/v1/
-          cp packages/events/proto/connectum/events/v1/options.proto .bsr/connectum/events/v1/
+          mkdir -p .bsr/connectum
+          cp -R packages/auth/proto/connectum/auth .bsr/connectum/
+          cp -R packages/events/proto/connectum/events .bsr/connectum/
 
           cat > .bsr/buf.yaml <<'YAML'
           version: v2


### PR DESCRIPTION
## Summary

- Add `buf.yml` workflow for proto lint/breaking checks on PRs (path-filtered, matrix strategy for auth + events packages)
- Add BSR push step to `release.yml` using CI assembly pattern (inspired by [Redpanda's approach](https://github.com/redpanda-data/redpanda/blob/dev/.github/workflows/buf.yml))
- Proto files assembled into `.bsr/` directory matching protobuf package structure before `buf push`

## How it works

BSR push triggers only when **both** conditions are met:
1. npm packages published via changesets (`published == 'true'`)
2. Proto files changed since last git tag (`packages/auth/proto/` or `packages/events/proto/`)

### CI assembly pattern

buf requires a single directory where file paths match proto package declarations. Since our proto files live inside separate packages (`packages/auth/proto/`, `packages/events/proto/`), the release workflow assembles them into a temporary `.bsr/` directory:

```
.bsr/
├── buf.yaml (name: buf.build/connectum-framework/connectum)
└── connectum/
    ├── auth/v1/options.proto
    └── events/v1/options.proto
```

This publishes as a single BSR module: [`buf.build/connectum-framework/connectum`](https://buf.build/connectum-framework/connectum)

## Prerequisites

- `BUF_TOKEN` secret added to repository settings ✅

## Test plan

- [ ] Verify `buf.yml` triggers on PR with proto changes (lint + breaking)
- [ ] Verify `release.yml` BSR push step runs only when both conditions met
- [ ] Verify BSR module appears at buf.build/connectum-framework/connectum after first release with proto changes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Protocol Buffer linting on pull requests to validate proto changes before merge.
  * Added conditional publishing of Protocol Buffers to the Buf Schema Registry during releases; publishing runs only when proto changes are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->