### PR TITLE
fix(events): handler typing, topic auto-resolve, per-handler middleware

### DIFF
--- a/.changeset/feat-events-per-handler-middleware.md
+++ b/.changeset/feat-events-per-handler-middleware.md
@@ -1,0 +1,14 @@
+---
+"@connectum/events": minor
+---
+
+feat(events): support per-handler middleware configuration
+
+Event handlers registered via `router.service()` can now specify per-handler
+middleware that overrides the global EventBus middleware pipeline.
+
+Handlers support two forms:
+- Simple function: `onEvent: async (msg, ctx) => { ... }` (uses global middleware)
+- Config object: `onEvent: { handler: async (msg, ctx) => { ... }, middleware: [...] }` (per-handler override)
+
+Closes #49

--- a/.changeset/feat-events-topic-auto-resolve.md
+++ b/.changeset/feat-events-topic-auto-resolve.md
@@ -1,0 +1,15 @@
+---
+"@connectum/events": minor
+---
+
+feat(events): auto-resolve publish topic from proto annotations
+
+EventBus.publish() now automatically resolves the topic from proto
+`(connectum.events.v1.event).topic` option when no explicit topic is
+provided in PublishOptions. This eliminates the need to manually
+duplicate topic strings between proto definitions and publish calls.
+
+Priority order:
+1. Explicit `publishOptions.topic` (override)
+2. Proto annotation topic (auto-resolved from registered routes)
+3. `schema.typeName` (fallback, backward compatible)

--- a/.changeset/fix-events-handler-typing.md
+++ b/.changeset/fix-events-handler-typing.md
@@ -1,0 +1,12 @@
+---
+"@connectum/events": patch
+---
+
+fix(events): preserve concrete input types in ServiceEventHandlers
+
+Changed `ServiceEventHandlers` mapped type to derive handler input types from
+`S["method"]` (concrete GenService record) instead of `S["methods"][number]`
+(generic DescMethod array). This preserves concrete protobuf message types
+in event handlers, eliminating the need for `as unknown as T` casts.
+
+Closes #86

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -90,6 +90,10 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
         route(router);
     }
 
+    // Publish topic lookup: message typeName → resolved topic from proto annotation.
+    // Populated in start() after routes are registered.
+    const publishTopicMap = new Map<string, string>();
+
     // Build middleware chain
     const middlewares: EventMiddleware[] = [];
 
@@ -124,6 +128,12 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                     const derivedName = deriveServiceName(router.serviceNames);
                     await adapter.connect(derivedName ? { serviceName: derivedName } : undefined);
 
+                    // Build publish topic lookup: input message typeName → resolved topic
+                    publishTopicMap.clear();
+                    for (const entry of router.entries) {
+                        publishTopicMap.set(entry.method.input.typeName, entry.topic);
+                    }
+
                     // Build topic → handler map and compose middleware per topic
                     const topicHandlerMap = new Map<string, (event: RawEvent, ctx: EventContext) => Promise<void>>();
 
@@ -131,7 +141,9 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                         if (topicHandlerMap.has(entry.topic)) {
                             throw new Error(`Duplicate event topic "${entry.topic}". Use (connectum.events.v1.event).topic option to disambiguate.`);
                         }
-                        const composedHandler = composeMiddleware(middlewares, async (rawEvent, ctx) => {
+                        // Per-handler middleware overrides global when present
+                        const effectiveMiddleware = entry.middleware !== undefined ? entry.middleware : middlewares;
+                        const composedHandler = composeMiddleware(effectiveMiddleware, async (rawEvent, ctx) => {
                             const message = fromBinary(entry.method.input, rawEvent.payload);
                             await entry.handler(message, ctx);
                         });
@@ -298,7 +310,7 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
             // Create message instance and serialize
             const message = create(schema, data);
             const payload = toBinary(schema, message);
-            const eventType = publishOptions?.topic ?? schema.typeName;
+            const eventType = publishOptions?.topic ?? publishTopicMap.get(schema.typeName) ?? schema.typeName;
 
             await adapter.publish(eventType, payload, publishOptions);
         },

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -131,7 +131,12 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                     // Build publish topic lookup: input message typeName → resolved topic
                     publishTopicMap.clear();
                     for (const entry of router.entries) {
-                        publishTopicMap.set(entry.method.input.typeName, entry.topic);
+                        const messageType = entry.method.input.typeName;
+                        const existingTopic = publishTopicMap.get(messageType);
+                        if (existingTopic !== undefined && existingTopic !== entry.topic) {
+                            throw new Error(`Ambiguous publish topic for "${messageType}": "${existingTopic}" and "${entry.topic}". Pass publishOptions.topic explicitly.`);
+                        }
+                        publishTopicMap.set(messageType, entry.topic);
                     }
 
                     // Build topic → handler map and compose middleware per topic

--- a/packages/events/src/EventRouter.ts
+++ b/packages/events/src/EventRouter.ts
@@ -9,7 +9,7 @@
 
 import type { DescService } from "@bufbuild/protobuf";
 import { resolveTopicName } from "./topic.ts";
-import type { EventRouteEntry, EventRouter, ServiceEventHandlers, TypedEventHandler } from "./types.ts";
+import type { EventHandlerConfig, EventMiddleware, EventRouteEntry, EventRouter, ServiceEventHandlers, TypedEventHandler } from "./types.ts";
 
 /**
  * EventRouter implementation that collects route entries.
@@ -21,17 +21,24 @@ export class EventRouterImpl implements EventRouter {
     service<S extends DescService>(serviceDesc: S, handlers: ServiceEventHandlers<S>): void {
         this.serviceNames.push(serviceDesc.typeName);
         for (const method of serviceDesc.methods) {
-            const handlerFn = (handlers as Record<string, TypedEventHandler<unknown>>)[method.localName];
-            if (!handlerFn) {
+            const handlerOrConfig = (handlers as Record<string, TypedEventHandler<unknown> | EventHandlerConfig<unknown>>)[method.localName];
+            if (!handlerOrConfig) {
                 throw new Error(`Missing event handler for method "${method.localName}" in service "${serviceDesc.typeName}"`);
             }
 
+            let handler: TypedEventHandler<unknown>;
+            let perHandlerMiddleware: EventMiddleware[] | undefined;
+
+            if (typeof handlerOrConfig === "function") {
+                handler = handlerOrConfig;
+            } else {
+                handler = handlerOrConfig.handler;
+                perHandlerMiddleware = handlerOrConfig.middleware;
+            }
+
             const topic = resolveTopicName(method);
-            this.entries.push({
-                topic,
-                method,
-                handler: handlerFn,
-            });
+            const entry: EventRouteEntry = perHandlerMiddleware !== undefined ? { topic, method, handler, middleware: perHandlerMiddleware } : { topic, method, handler };
+            this.entries.push(entry);
         }
     }
 }

--- a/packages/events/src/EventRouter.ts
+++ b/packages/events/src/EventRouter.ts
@@ -32,6 +32,9 @@ export class EventRouterImpl implements EventRouter {
             if (typeof handlerOrConfig === "function") {
                 handler = handlerOrConfig;
             } else {
+                if (typeof handlerOrConfig.handler !== "function") {
+                    throw new Error(`Invalid event handler config for method "${method.localName}" in service "${serviceDesc.typeName}": "handler" must be a function`);
+                }
                 handler = handlerOrConfig.handler;
                 perHandlerMiddleware = handlerOrConfig.middleware;
             }

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -43,6 +43,7 @@ export type {
     EventBusOptions,
     EventContext,
     EventContextInit,
+    EventHandlerConfig,
     EventMiddleware,
     EventMiddlewareNext,
     EventRoute,

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -169,13 +169,28 @@ export interface EventContextInit {
 export type TypedEventHandler<I> = (event: I, ctx: EventContext) => Promise<void>;
 
 /**
+ * Per-handler middleware configuration.
+ *
+ * Overrides global EventBus middleware for this specific handler.
+ * When present, the global middleware pipeline is bypassed entirely
+ * and only the per-handler middleware array is applied.
+ */
+export interface EventHandlerConfig<I> {
+    /** Event handler function */
+    readonly handler: TypedEventHandler<I>;
+    /** Per-handler middleware array (overrides global middleware for this handler) */
+    readonly middleware?: EventMiddleware[];
+}
+
+/**
  * Maps service methods to typed event handlers.
  *
- * Conditional type: for each method in the service descriptor,
- * creates a handler expecting the method's input type.
+ * Each handler can be either:
+ * - A simple function (uses global middleware)
+ * - An object with `handler` and optional `middleware` (per-handler override)
  */
 export type ServiceEventHandlers<S extends DescService> = {
-    [K in S["methods"][number] as K["localName"]]: TypedEventHandler<MessageShape<K["input"]>>;
+    [K in keyof S["method"]]: TypedEventHandler<MessageShape<S["method"][K]["input"]>> | EventHandlerConfig<MessageShape<S["method"][K]["input"]>>;
 };
 
 /**
@@ -188,6 +203,8 @@ export interface EventRouteEntry {
     readonly method: DescMethod;
     /** Typed handler function */
     readonly handler: TypedEventHandler<unknown>;
+    /** Per-handler middleware (overrides global when present) */
+    readonly middleware?: EventMiddleware[];
 }
 
 /**

--- a/packages/events/tests/unit/per-handler-middleware.test.ts
+++ b/packages/events/tests/unit/per-handler-middleware.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Tests for per-handler middleware configuration.
+ *
+ * Verifies that handlers can override global middleware with per-handler
+ * middleware via the `EventHandlerConfig` object form.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { EventOptionsSchema } from "../../gen/connectum/events/v1/options_pb.js";
+import { createEventBus } from "../../src/EventBus.ts";
+import { EventRouterImpl } from "../../src/EventRouter.ts";
+import type {
+    AdapterContext,
+    EventAdapter,
+    EventMiddleware,
+    EventSubscription,
+    PublishOptions,
+    RawEvent,
+    RawEventHandler,
+    RawSubscribeOptions,
+} from "../../src/types.ts";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Create a minimal fake DescMethod compatible with resolveTopicName().
+ */
+function fakeDescMethod(localName: string, typeName: string, realInput?: any) {
+    const input = realInput
+        ? Object.create(realInput, { typeName: { value: typeName, writable: false, enumerable: true } })
+        : { typeName };
+
+    return {
+        localName,
+        input,
+        proto: { options: undefined },
+    } as any;
+}
+
+function fakeDescService(typeName: string, methods: ReturnType<typeof fakeDescMethod>[]) {
+    return { typeName, methods } as any;
+}
+
+/**
+ * Tracking adapter that captures the RawEventHandler and records publishes.
+ */
+function createTrackingAdapter() {
+    let capturedHandler: RawEventHandler | null = null;
+    const published: Array<{ eventType: string; payload: Uint8Array; options?: PublishOptions }> = [];
+
+    const adapter: EventAdapter = {
+        name: "tracking",
+        async connect(_context?: AdapterContext): Promise<void> {},
+        async disconnect(): Promise<void> {
+            capturedHandler = null;
+        },
+        async publish(eventType: string, payload: Uint8Array, options?: PublishOptions): Promise<void> {
+            published.push({ eventType, payload, ...(options ? { options } : {}) });
+        },
+        async subscribe(_patterns: string[], handler: RawEventHandler, _options?: RawSubscribeOptions): Promise<EventSubscription> {
+            capturedHandler = handler;
+            return { async unsubscribe(): Promise<void> {} };
+        },
+    };
+
+    return {
+        adapter,
+        get published() {
+            return published;
+        },
+        deliver(event: RawEvent) {
+            const handler = capturedHandler;
+            assert.ok(handler, "No handler captured -- was subscribe() called?");
+
+            const calls: string[] = [];
+
+            const promise = handler(
+                event,
+                async () => {
+                    calls.push("ack");
+                },
+                async (requeue?: boolean) => {
+                    calls.push(requeue ? "nack-requeue" : "nack");
+                },
+            );
+
+            return { promise, calls };
+        },
+    };
+}
+
+function makeRawEvent(eventType: string, id = "evt-per-handler"): RawEvent {
+    return {
+        eventId: id,
+        eventType,
+        payload: new Uint8Array(),
+        publishedAt: new Date(),
+        attempt: 1,
+        metadata: new Map(),
+    };
+}
+
+/**
+ * Create a tracking middleware that records calls to a shared array.
+ */
+function createTrackingMiddleware(name: string, log: string[]): EventMiddleware {
+    return async (_event, _ctx, next) => {
+        log.push(`${name}:before`);
+        await next();
+        log.push(`${name}:after`);
+    };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("Per-handler middleware", () => {
+    let bus: ReturnType<typeof createEventBus> | null = null;
+
+    afterEach(async () => {
+        if (bus) {
+            await bus.stop();
+            bus = null;
+        }
+    });
+
+    it("simple function handler uses global middleware", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const method = fakeDescMethod("simpleEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.v1.SimpleService", [method]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        simpleEvent: async () => {
+                            log.push("handler");
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise } = tracker.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await promise;
+
+        assert.deepEqual(log, ["global:before", "handler", "global:after"]);
+    });
+
+    it("object form with handler + middleware uses per-handler middleware", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const method = fakeDescMethod("configEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.v1.ConfigService", [method]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        configEvent: {
+                            handler: async () => {
+                                log.push("handler");
+                            },
+                            middleware: [createTrackingMiddleware("per-handler", log)],
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise } = tracker.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await promise;
+
+        // Per-handler middleware used instead of global
+        assert.deepEqual(log, ["per-handler:before", "handler", "per-handler:after"]);
+    });
+
+    it("per-handler middleware overrides global middleware", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const method = fakeDescMethod("overrideEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.v1.OverrideService", [method]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        overrideEvent: {
+                            handler: async () => {
+                                log.push("handler");
+                            },
+                            middleware: [createTrackingMiddleware("override", log)],
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise } = tracker.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await promise;
+
+        // Global middleware should NOT appear in log
+        assert.ok(!log.includes("global:before"), "global middleware should NOT be applied");
+        assert.ok(!log.includes("global:after"), "global middleware should NOT be applied");
+        assert.deepEqual(log, ["override:before", "handler", "override:after"]);
+    });
+
+    it("mixed handlers: simple uses global, config uses per-handler", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const simpleMethod = fakeDescMethod("simpleEvent", "test.v1.SimpleEvent", EventOptionsSchema);
+        const configMethod = fakeDescMethod("configEvent", "test.v1.ConfigEvent", EventOptionsSchema);
+        const service = fakeDescService("test.v1.MixedService", [simpleMethod, configMethod]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        simpleEvent: async () => {
+                            log.push("simple-handler");
+                        },
+                        configEvent: {
+                            handler: async () => {
+                                log.push("config-handler");
+                            },
+                            middleware: [createTrackingMiddleware("per-handler", log)],
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Deliver to simple handler -- global middleware
+        const { promise: p1 } = tracker.deliver(makeRawEvent("test.v1.SimpleEvent", "evt-simple"));
+        await p1;
+
+        assert.deepEqual(log, ["global:before", "simple-handler", "global:after"]);
+
+        // Reset log
+        log.length = 0;
+
+        // Deliver to config handler -- per-handler middleware
+        const { promise: p2 } = tracker.deliver(makeRawEvent("test.v1.ConfigEvent", "evt-config"));
+        await p2;
+
+        assert.deepEqual(log, ["per-handler:before", "config-handler", "per-handler:after"]);
+    });
+
+    it("per-handler middleware with empty array bypasses global middleware", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const method = fakeDescMethod("bypassEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.v1.BypassService", [method]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        bypassEvent: {
+                            handler: async () => {
+                                log.push("handler");
+                            },
+                            middleware: [], // Empty = no middleware at all
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise } = tracker.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await promise;
+
+        // No middleware executed -- handler called directly
+        assert.deepEqual(log, ["handler"]);
+    });
+
+    it("config object without middleware field uses global middleware", async () => {
+        const tracker = createTrackingAdapter();
+        const log: string[] = [];
+
+        const method = fakeDescMethod("noMwFieldEvent", EventOptionsSchema.typeName, EventOptionsSchema);
+        const service = fakeDescService("test.v1.NoMwFieldService", [method]);
+
+        bus = createEventBus({
+            adapter: tracker.adapter,
+            middleware: {
+                custom: [createTrackingMiddleware("global", log)],
+            },
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        noMwFieldEvent: {
+                            handler: async () => {
+                                log.push("handler");
+                            },
+                            // No middleware field -- should fall back to global
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        const { promise } = tracker.deliver(makeRawEvent(EventOptionsSchema.typeName));
+        await promise;
+
+        // Global middleware should be used when middleware field is absent
+        assert.deepEqual(log, ["global:before", "handler", "global:after"]);
+    });
+});
+
+// =============================================================================
+// EventRouter unit tests for per-handler middleware parsing
+// =============================================================================
+
+describe("EventRouter per-handler middleware parsing", () => {
+    it("parses simple function handler (no middleware in entry)", () => {
+        const method = fakeDescMethod("simpleEvent", "test.v1.SimpleEvent");
+        const service = fakeDescService("test.v1.Service", [method]);
+
+        const router = new EventRouterImpl();
+        router.service(service, {
+            simpleEvent: async () => {},
+        } as any);
+
+        assert.equal(router.entries.length, 1);
+        assert.equal(router.entries[0]!.middleware, undefined);
+        assert.equal(typeof router.entries[0]!.handler, "function");
+    });
+
+    it("parses config object with handler and middleware", () => {
+        const method = fakeDescMethod("configEvent", "test.v1.ConfigEvent");
+        const service = fakeDescService("test.v1.Service", [method]);
+
+        const myMiddleware: EventMiddleware = async (_e, _c, next) => {
+            await next();
+        };
+
+        const router = new EventRouterImpl();
+        router.service(service, {
+            configEvent: {
+                handler: async () => {},
+                middleware: [myMiddleware],
+            },
+        } as any);
+
+        assert.equal(router.entries.length, 1);
+        assert.ok(router.entries[0]!.middleware);
+        assert.equal(router.entries[0]!.middleware!.length, 1);
+        assert.equal(router.entries[0]!.middleware![0], myMiddleware);
+        assert.equal(typeof router.entries[0]!.handler, "function");
+    });
+
+    it("parses config object without middleware field (undefined)", () => {
+        const method = fakeDescMethod("noMwEvent", "test.v1.NoMwEvent");
+        const service = fakeDescService("test.v1.Service", [method]);
+
+        const router = new EventRouterImpl();
+        router.service(service, {
+            noMwEvent: {
+                handler: async () => {},
+            },
+        } as any);
+
+        assert.equal(router.entries.length, 1);
+        assert.equal(router.entries[0]!.middleware, undefined);
+        assert.equal(typeof router.entries[0]!.handler, "function");
+    });
+
+    it("parses config object with empty middleware array", () => {
+        const method = fakeDescMethod("emptyMwEvent", "test.v1.EmptyMwEvent");
+        const service = fakeDescService("test.v1.Service", [method]);
+
+        const router = new EventRouterImpl();
+        router.service(service, {
+            emptyMwEvent: {
+                handler: async () => {},
+                middleware: [],
+            },
+        } as any);
+
+        assert.equal(router.entries.length, 1);
+        assert.ok(router.entries[0]!.middleware);
+        assert.equal(router.entries[0]!.middleware!.length, 0);
+        assert.equal(typeof router.entries[0]!.handler, "function");
+    });
+});

--- a/packages/events/tests/unit/service-event-handlers-type.test.ts
+++ b/packages/events/tests/unit/service-event-handlers-type.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Compile-time regression tests for ServiceEventHandlers type.
+ *
+ * Verifies that ServiceEventHandlers correctly preserves concrete protobuf
+ * input types from GenService descriptors instead of collapsing them to
+ * the generic `Message` base type.
+ *
+ * Uses `satisfies` and conditional type assertions that cause compile errors
+ * if types regress. Runtime assertions confirm the test file is executed.
+ *
+ * @see https://github.com/Connectum-Framework/connectum/issues/86
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Message } from "@bufbuild/protobuf";
+import type { GenMessage, GenService } from "@bufbuild/protobuf/codegenv2";
+import type { EventHandlerConfig, ServiceEventHandlers, TypedEventHandler } from "../../src/types.ts";
+
+// =============================================================================
+// Synthetic proto types (mimic codegen output without real .proto files)
+// =============================================================================
+
+/**
+ * Synthetic message type -- represents a concrete protobuf message
+ * like what codegen produces (e.g., OrderCreated).
+ */
+type OrderCreated = Message<"test.v1.OrderCreated"> & {
+    readonly orderId: string;
+    readonly amount: number;
+};
+
+/**
+ * Synthetic message type for a second method.
+ */
+type OrderUpdated = Message<"test.v1.OrderUpdated"> & {
+    readonly orderId: string;
+    readonly newStatus: string;
+};
+
+/**
+ * Synthetic GenMessage descriptors (mirrors codegen `const XxxSchema`).
+ * We only need the type -- these are never instantiated at runtime.
+ */
+declare const OrderCreatedSchema: GenMessage<OrderCreated>;
+declare const OrderUpdatedSchema: GenMessage<OrderUpdated>;
+
+/**
+ * Synthetic GenService -- mirrors what protoc-gen-es would generate:
+ *
+ * ```ts
+ * export declare const OrderEventService: GenService<{
+ *   orderCreated: { methodKind: "unary"; input: typeof OrderCreatedSchema; output: ... };
+ *   orderUpdated: { methodKind: "unary"; input: typeof OrderUpdatedSchema; output: ... };
+ * }>;
+ * ```
+ */
+declare const OrderEventService: GenService<{
+    orderCreated: {
+        methodKind: "unary";
+        input: typeof OrderCreatedSchema;
+        output: typeof OrderCreatedSchema; // output is irrelevant for event handlers
+    };
+    orderUpdated: {
+        methodKind: "unary";
+        input: typeof OrderUpdatedSchema;
+        output: typeof OrderUpdatedSchema;
+    };
+}>;
+
+// =============================================================================
+// Type-level helpers
+// =============================================================================
+
+/**
+ * Compile-time assertion: `A extends B` must be true.
+ * Produces a type error if A does not extend B.
+ */
+type AssertExtends<A, B> = A extends B ? true : never;
+
+/**
+ * Compile-time assertion: types A and B are exactly equal.
+ * Uses the standard bidirectional-extends trick.
+ */
+type AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+
+// =============================================================================
+// Compile-time assertions (cause build errors if ServiceEventHandlers regresses)
+// =============================================================================
+
+// Extract the handlers type for our synthetic service
+type Handlers = ServiceEventHandlers<typeof OrderEventService>;
+
+// 1. Handler keys must be the method localNames
+type _KeysCheck = AssertExact<keyof Handlers, "orderCreated" | "orderUpdated">;
+
+// 2. Each handler must accept the CONCRETE message type, not generic Message.
+//    Since per-handler middleware support (Issue #49), handlers are a union:
+//    TypedEventHandler<T> | EventHandlerConfig<T>
+type _OrderCreatedHandler = AssertExact<
+    Handlers["orderCreated"],
+    TypedEventHandler<OrderCreated> | EventHandlerConfig<OrderCreated>
+>;
+
+type _OrderUpdatedHandler = AssertExact<
+    Handlers["orderUpdated"],
+    TypedEventHandler<OrderUpdated> | EventHandlerConfig<OrderUpdated>
+>;
+
+// 3. The concrete type must NOT be the generic fallback
+type _NotGenericMessage = AssertExtends<
+    Handlers["orderCreated"],
+    TypedEventHandler<OrderCreated> | EventHandlerConfig<OrderCreated>
+>;
+
+// 4. Verify the concrete type has the domain field (orderId).
+//    Extract<> narrows the union to the function form for Parameters<>.
+type _HasOrderId = AssertExtends<
+    Parameters<Extract<Handlers["orderCreated"], (...args: any) => any>>[0],
+    { readonly orderId: string }
+>;
+
+// Force TypeScript to evaluate the assertions (unused types are not checked).
+// Use void to suppress noUnusedLocals while keeping compile-time checks.
+void ([true, true, true, true, true] satisfies [
+    _KeysCheck,
+    _OrderCreatedHandler,
+    _OrderUpdatedHandler,
+    _NotGenericMessage,
+    _HasOrderId,
+]);
+
+// =============================================================================
+// Runtime tests (verify the test file is executed by the runner)
+// =============================================================================
+
+describe("ServiceEventHandlers type", () => {
+    it("compiles with correct concrete handler types (regression #86)", () => {
+        // This test's value is in compilation -- if it compiles, the fix works.
+        // The runtime assertion confirms the test was actually executed.
+        assert.ok(true, "ServiceEventHandlers preserves concrete input types");
+    });
+
+    it("handler with concrete type compiles without casts", () => {
+        // This function would fail to compile if handlers received Message<string>
+        // instead of concrete OrderCreated -- accessing `.orderId` would be an error.
+        const handler: Handlers["orderCreated"] = async (event, _ctx) => {
+            // Access domain-specific fields without any cast
+            void (event.orderId satisfies string);
+            void (event.amount satisfies number);
+        };
+
+        assert.equal(typeof handler, "function");
+    });
+
+    it("handler object satisfies ServiceEventHandlers", () => {
+        // Full handlers object must compile with concrete types
+        const handlers = {
+            orderCreated: async (event, _ctx) => {
+                void (event.orderId satisfies string);
+            },
+            orderUpdated: async (event, _ctx) => {
+                void (event.newStatus satisfies string);
+            },
+        } satisfies Handlers;
+
+        assert.equal(Object.keys(handlers).length, 2);
+    });
+});

--- a/packages/events/tests/unit/topic-auto-resolve.test.ts
+++ b/packages/events/tests/unit/topic-auto-resolve.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for topic auto-resolve in EventBus.publish().
+ *
+ * Verifies that publish() automatically resolves the topic from proto
+ * `(connectum.events.v1.event).topic` option when no explicit topic is
+ * provided in PublishOptions. Tests the priority chain:
+ * 1. Explicit `publishOptions.topic` (override)
+ * 2. Proto annotation topic (auto-resolved from registered routes)
+ * 3. `schema.typeName` (fallback, backward compatible)
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { create, setExtension } from "@bufbuild/protobuf";
+import { MethodOptionsSchema } from "@bufbuild/protobuf/wkt";
+import { EventOptionsSchema, event } from "#gen/connectum/events/v1/options_pb.js";
+import { createEventBus } from "../../src/EventBus.ts";
+import type {
+    AdapterContext,
+    EventAdapter,
+    EventSubscription,
+    PublishOptions,
+    RawEventHandler,
+    RawSubscribeOptions,
+} from "../../src/types.ts";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Create a fake DescMethod without any custom event option.
+ * `proto.options` is undefined so hasOption() returns false,
+ * falling back to `method.input.typeName`.
+ */
+function fakeDescMethod(localName: string, typeName: string, realInput?: any) {
+    const input = realInput
+        ? Object.create(realInput, { typeName: { value: typeName, writable: false, enumerable: true } })
+        : { typeName };
+
+    return {
+        localName,
+        input,
+        proto: { options: undefined },
+    } as any;
+}
+
+/**
+ * Create a fake DescMethod with the `(connectum.events.v1.event).topic` option set.
+ * Uses real proto create + setExtension to produce valid MethodOptions.
+ */
+function fakeDescMethodWithTopic(localName: string, inputTypeName: string, topic: string, realInput?: any) {
+    const methodOptions = create(MethodOptionsSchema);
+    const eventOptions = create(EventOptionsSchema, { topic });
+    setExtension(methodOptions, event, eventOptions);
+
+    const input = realInput
+        ? Object.create(realInput, { typeName: { value: inputTypeName, writable: false, enumerable: true } })
+        : { typeName: inputTypeName };
+
+    return {
+        localName,
+        input,
+        proto: { options: methodOptions },
+    } as any;
+}
+
+function fakeDescService(typeName: string, methods: ReturnType<typeof fakeDescMethod>[]) {
+    return { typeName, methods } as any;
+}
+
+/**
+ * Tracking adapter that records all publish() calls.
+ */
+function createTrackingAdapter() {
+    const published: Array<{ eventType: string; payload: Uint8Array; options?: PublishOptions }> = [];
+
+    const adapter: EventAdapter = {
+        name: "tracking",
+        async connect(_context?: AdapterContext): Promise<void> {},
+        async disconnect(): Promise<void> {},
+        async publish(eventType: string, payload: Uint8Array, options?: PublishOptions): Promise<void> {
+            published.push({ eventType, payload, ...(options ? { options } : {}) });
+        },
+        async subscribe(_patterns: string[], _handler: RawEventHandler, _options?: RawSubscribeOptions): Promise<EventSubscription> {
+            return { async unsubscribe(): Promise<void> {} };
+        },
+    };
+
+    return { adapter, published };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("EventBus topic auto-resolve", () => {
+    it("publish without explicit topic uses topic from proto annotation", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        // Route with custom topic via proto option
+        const method = fakeDescMethodWithTopic(
+            "taskCreated",
+            EventOptionsSchema.typeName,
+            "meshai.task.created",
+            EventOptionsSchema,
+        );
+        const service = fakeDescService("meshai.v1.TaskEventService", [method]);
+
+        const bus = createEventBus({
+            adapter,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        taskCreated: async () => {},
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Publish using the same schema whose typeName matches the registered route's input
+        await bus.publish(EventOptionsSchema, {} as any);
+
+        assert.equal(published.length, 1);
+        assert.equal(
+            published[0]!.eventType,
+            "meshai.task.created",
+            "should use proto annotation topic, not schema.typeName",
+        );
+
+        await bus.stop();
+    });
+
+    it("publish with explicit topic overrides proto annotation", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        const method = fakeDescMethodWithTopic(
+            "taskCreated",
+            EventOptionsSchema.typeName,
+            "meshai.task.created",
+            EventOptionsSchema,
+        );
+        const service = fakeDescService("meshai.v1.TaskEventService", [method]);
+
+        const bus = createEventBus({
+            adapter,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        taskCreated: async () => {},
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Explicit topic override
+        await bus.publish(EventOptionsSchema, {} as any, { topic: "override.topic" });
+
+        assert.equal(published.length, 1);
+        assert.equal(
+            published[0]!.eventType,
+            "override.topic",
+            "explicit publishOptions.topic should take highest priority",
+        );
+
+        await bus.stop();
+    });
+
+    it("publish message without registered route falls back to schema.typeName", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        // Register a route for a DIFFERENT message type
+        const method = fakeDescMethod("orderCreated", "order.v1.OrderCreated", EventOptionsSchema);
+        const service = fakeDescService("order.v1.OrderEventService", [method]);
+
+        const bus = createEventBus({
+            adapter,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        orderCreated: async () => {},
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Publish using EventOptionsSchema but the route's input typeName is
+        // "order.v1.OrderCreated" (different from EventOptionsSchema.typeName).
+        // So publishTopicMap won't have a match for EventOptionsSchema.typeName,
+        // and it falls back to schema.typeName.
+        await bus.publish(EventOptionsSchema, {} as any);
+
+        assert.equal(published.length, 1);
+        assert.equal(
+            published[0]!.eventType,
+            EventOptionsSchema.typeName,
+            "should fall back to schema.typeName when no route matches the input typeName",
+        );
+
+        await bus.stop();
+    });
+
+    it("publish without routes falls back to schema.typeName (no routes registered)", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        const bus = createEventBus({
+            adapter,
+            routes: [],
+        });
+
+        await bus.start();
+
+        await bus.publish(EventOptionsSchema, {} as any);
+
+        assert.equal(published.length, 1);
+        assert.equal(
+            published[0]!.eventType,
+            EventOptionsSchema.typeName,
+            "should use schema.typeName when no routes are registered",
+        );
+
+        await bus.stop();
+    });
+
+    it("round-trip consistency: publish topic matches subscribe topic", async () => {
+        const customTopic = "meshai.task.created";
+        let capturedHandler: RawEventHandler | null = null;
+        const publishedEvents: Array<{ eventType: string; payload: Uint8Array }> = [];
+        const receivedEvents: Array<{ eventType: string }> = [];
+
+        // Adapter that captures handler and delivers published events to subscribers
+        const roundTripAdapter: EventAdapter = {
+            name: "round-trip",
+            async connect(): Promise<void> {},
+            async disconnect(): Promise<void> {},
+            async publish(eventType: string, payload: Uint8Array): Promise<void> {
+                publishedEvents.push({ eventType, payload });
+                // Deliver to subscriber if topic matches
+                if (capturedHandler) {
+                    await capturedHandler(
+                        {
+                            eventId: `evt-${publishedEvents.length}`,
+                            eventType,
+                            payload,
+                            publishedAt: new Date(),
+                            attempt: 1,
+                            metadata: new Map(),
+                        },
+                        async () => {},
+                        async () => {},
+                    );
+                }
+            },
+            async subscribe(_patterns: string[], handler: RawEventHandler): Promise<EventSubscription> {
+                capturedHandler = handler;
+                return { async unsubscribe(): Promise<void> {} };
+            },
+        };
+
+        const method = fakeDescMethodWithTopic(
+            "taskCreated",
+            EventOptionsSchema.typeName,
+            customTopic,
+            EventOptionsSchema,
+        );
+        const service = fakeDescService("meshai.v1.TaskEventService", [method]);
+
+        const bus = createEventBus({
+            adapter: roundTripAdapter,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        taskCreated: async (_event: unknown, ctx: { eventType: string }) => {
+                            receivedEvents.push({ eventType: ctx.eventType });
+                        },
+                    } as any);
+                },
+            ],
+        });
+
+        await bus.start();
+
+        // Publish without explicit topic -- should auto-resolve to proto annotation topic
+        await bus.publish(EventOptionsSchema, {} as any);
+
+        assert.equal(publishedEvents.length, 1);
+        assert.equal(
+            publishedEvents[0]!.eventType,
+            customTopic,
+            "published eventType should match proto annotation topic",
+        );
+
+        assert.equal(receivedEvents.length, 1);
+        assert.equal(
+            receivedEvents[0]!.eventType,
+            customTopic,
+            "received eventType should match published eventType",
+        );
+
+        await bus.stop();
+    });
+
+    it("publishTopicMap is repopulated on start-stop-start cycle", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        const method = fakeDescMethodWithTopic(
+            "taskCreated",
+            EventOptionsSchema.typeName,
+            "meshai.task.created",
+            EventOptionsSchema,
+        );
+        const service = fakeDescService("meshai.v1.TaskEventService", [method]);
+
+        const bus = createEventBus({
+            adapter,
+            routes: [
+                (router) => {
+                    router.service(service, {
+                        taskCreated: async () => {},
+                    } as any);
+                },
+            ],
+        });
+
+        // First cycle
+        await bus.start();
+        await bus.publish(EventOptionsSchema, {} as any);
+        assert.equal(published[0]!.eventType, "meshai.task.created");
+        await bus.stop();
+
+        // Second cycle -- publishTopicMap should be repopulated
+        await bus.start();
+        await bus.publish(EventOptionsSchema, {} as any);
+        assert.equal(published[1]!.eventType, "meshai.task.created");
+        await bus.stop();
+    });
+});


### PR DESCRIPTION
## Summary

Three interconnected improvements to `@connectum/events`:

- **Fix ServiceEventHandlers type** (P1): Changed mapped type to derive from `S["method"]` instead of `S["methods"][number]`, preserving concrete protobuf input types. Eliminates `as unknown as T` casts.
- **Auto-resolve publish topics** (P5): `EventBus.publish()` now resolves topic from proto `(event).topic` annotation automatically, preventing proto/code topic desync.
- **Per-handler middleware** (P3A): Handlers support `{ handler, middleware }` config form to override global middleware pipeline per handler.

Closes #86
Closes #49

## Test plan

- [x] 1363 monorepo tests pass (build + typecheck + test)
- [x] 19 new regression tests (3 type + 6 topic + 10 middleware)
- [x] Biome lint clean
- [x] 4/4 standalone examples e2e pass (test-pack)
- [x] Cross-runtime: 30 PASS, 0 FAIL, 3 expected SKIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event handlers can define per-handler middleware that overrides the global middleware pipeline
  * EventBus automatically resolves publish topics from registered routes when not explicitly provided

* **Bug Fixes**
  * Event handler types now preserve concrete message types, eliminating unnecessary type casts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->