### PR TITLE
feat(auth): add client-side auth interceptors

### DIFF
--- a/.changeset/feat-auth-client-interceptors.md
+++ b/.changeset/feat-auth-client-interceptors.md
@@ -1,0 +1,9 @@
+---
+"@connectum/auth": minor
+---
+
+feat(auth): add client-side auth interceptors (bearer, gateway)
+
+Added two client interceptor factories:
+- `createClientBearerInterceptor()` — sets Authorization header with static or async token
+- `createClientGatewayInterceptor()` — sets gateway secret and auth context headers for service-to-service communication

--- a/packages/auth/src/client-bearer-interceptor.ts
+++ b/packages/auth/src/client-bearer-interceptor.ts
@@ -1,0 +1,59 @@
+/**
+ * Client-side Bearer token interceptor
+ *
+ * Sets the Authorization header with a Bearer token on outgoing requests.
+ * Supports both static tokens and async token factories for refresh flows.
+ *
+ * @module client-bearer-interceptor
+ */
+
+import type { Interceptor } from "@connectrpc/connect";
+import type { ClientBearerInterceptorOptions } from "./types.ts";
+
+/**
+ * Create a client interceptor that attaches a Bearer token to outgoing requests.
+ *
+ * The interceptor sets the `Authorization: Bearer <token>` header on every
+ * outgoing request. If a token factory function is provided instead of a
+ * static string, it is called before each request to support token refresh.
+ *
+ * @param options - Configuration with a static token or async token factory
+ * @returns A ConnectRPC client Interceptor
+ *
+ * @example Static token
+ * ```typescript
+ * import { createClientBearerInterceptor } from '@connectum/auth';
+ * import { createConnectTransport } from '@connectrpc/connect-node';
+ *
+ * const transport = createConnectTransport({
+ *     baseUrl: 'http://localhost:5000',
+ *     interceptors: [createClientBearerInterceptor({
+ *         token: 'my-static-jwt-token',
+ *     })],
+ * });
+ * ```
+ *
+ * @example Async token factory (refresh)
+ * ```typescript
+ * import { createClientBearerInterceptor } from '@connectum/auth';
+ *
+ * const transport = createConnectTransport({
+ *     baseUrl: 'http://localhost:5000',
+ *     interceptors: [createClientBearerInterceptor({
+ *         token: async () => {
+ *             const { accessToken } = await refreshTokenIfNeeded();
+ *             return accessToken;
+ *         },
+ *     })],
+ * });
+ * ```
+ */
+export function createClientBearerInterceptor(options: ClientBearerInterceptorOptions): Interceptor {
+    const { token } = options;
+
+    return (next) => async (req) => {
+        const resolvedToken = typeof token === "function" ? await token() : token;
+        req.header.set("authorization", `Bearer ${resolvedToken}`);
+        return await next(req);
+    };
+}

--- a/packages/auth/src/client-gateway-interceptor.ts
+++ b/packages/auth/src/client-gateway-interceptor.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Interceptor } from "@connectrpc/connect";
+import { MAX_HEADER_BYTES, sanitizeHeaderValue } from "./headers.ts";
 import type { ClientGatewayInterceptorOptions } from "./types.ts";
 import { AUTH_HEADERS } from "./types.ts";
 
@@ -53,10 +54,13 @@ export function createClientGatewayInterceptor(options: ClientGatewayInterceptor
 
     return (next) => async (req) => {
         req.header.set(GATEWAY_SECRET_HEADER, secret);
-        req.header.set(AUTH_HEADERS.SUBJECT, subject);
+        req.header.set(AUTH_HEADERS.SUBJECT, sanitizeHeaderValue(subject, 512));
 
         if (roles && roles.length > 0) {
-            req.header.set(AUTH_HEADERS.ROLES, JSON.stringify(roles));
+            const rolesValue = JSON.stringify(roles);
+            if (rolesValue.length <= MAX_HEADER_BYTES) {
+                req.header.set(AUTH_HEADERS.ROLES, rolesValue);
+            }
         }
 
         return await next(req);

--- a/packages/auth/src/client-gateway-interceptor.ts
+++ b/packages/auth/src/client-gateway-interceptor.ts
@@ -1,0 +1,64 @@
+/**
+ * Client-side gateway service-to-service auth interceptor
+ *
+ * Sets gateway authentication headers on outgoing requests for
+ * service-to-service communication behind an API gateway.
+ *
+ * @module client-gateway-interceptor
+ */
+
+import type { Interceptor } from "@connectrpc/connect";
+import type { ClientGatewayInterceptorOptions } from "./types.ts";
+import { AUTH_HEADERS } from "./types.ts";
+
+/**
+ * Header name for the gateway shared secret.
+ *
+ * This is the standard header used by Connectum gateway interceptors
+ * to establish trust between services.
+ */
+const GATEWAY_SECRET_HEADER = "x-gateway-secret";
+
+/**
+ * Create a client interceptor that attaches gateway auth headers to outgoing requests.
+ *
+ * Sets the following headers for service-to-service communication:
+ * - `x-gateway-secret` — shared secret for trust verification
+ * - `x-auth-subject` — authenticated subject identifier
+ * - `x-auth-roles` — JSON-encoded roles array (optional)
+ *
+ * These headers are consumed by the server-side {@link createGatewayAuthInterceptor}
+ * to reconstruct the auth context without re-authentication.
+ *
+ * @param options - Gateway auth configuration
+ * @returns A ConnectRPC client Interceptor
+ *
+ * @example Service-to-service call
+ * ```typescript
+ * import { createClientGatewayInterceptor } from '@connectum/auth';
+ * import { createConnectTransport } from '@connectrpc/connect-node';
+ *
+ * const transport = createConnectTransport({
+ *     baseUrl: 'http://internal-service:5000',
+ *     interceptors: [createClientGatewayInterceptor({
+ *         secret: process.env.GATEWAY_SECRET!,
+ *         subject: 'order-service',
+ *         roles: ['service', 'order-writer'],
+ *     })],
+ * });
+ * ```
+ */
+export function createClientGatewayInterceptor(options: ClientGatewayInterceptorOptions): Interceptor {
+    const { secret, subject, roles } = options;
+
+    return (next) => async (req) => {
+        req.header.set(GATEWAY_SECRET_HEADER, secret);
+        req.header.set(AUTH_HEADERS.SUBJECT, subject);
+
+        if (roles && roles.length > 0) {
+            req.header.set(AUTH_HEADERS.ROLES, JSON.stringify(roles));
+        }
+
+        return await next(req);
+    };
+}

--- a/packages/auth/src/headers.ts
+++ b/packages/auth/src/headers.ts
@@ -10,12 +10,13 @@
 import type { AuthContext } from "./types.ts";
 import { AUTH_HEADERS } from "./types.ts";
 
-const MAX_HEADER_BYTES = 8192;
+/** Maximum byte length for a single header value (shared with client interceptors). */
+export const MAX_HEADER_BYTES = 8192;
 
 /**
  * Sanitize a header value by removing control characters and enforcing length limits.
  */
-function sanitizeHeaderValue(value: string, maxLength: number): string {
+export function sanitizeHeaderValue(value: string, maxLength: number): string {
     // Remove control characters (except tab/LF/CR which are valid in headers)
     // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control char removal for header sanitization
     const cleaned = value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,12 +3,14 @@
  *
  * Authentication and authorization interceptors for Connectum.
  *
- * Provides five interceptor factories:
+ * Provides seven interceptor factories:
  * - createAuthInterceptor() — generic, pluggable authentication
  * - createJwtAuthInterceptor() — JWT convenience with jose
  * - createGatewayAuthInterceptor() — gateway-injected headers
  * - createSessionAuthInterceptor() — session-based auth (better-auth, etc.)
  * - createAuthzInterceptor() — declarative rules-based authorization
+ * - createClientBearerInterceptor() — client-side Bearer token
+ * - createClientGatewayInterceptor() — client-side gateway service-to-service auth
  *
  * Plus context propagation via AsyncLocalStorage and request headers.
  *
@@ -16,11 +18,14 @@
  * @mergeModuleWith <project>
  */
 
-// Interceptor factories
+// Interceptor factories (server-side)
 export { createAuthInterceptor } from "./auth-interceptor.ts";
 export { createAuthzInterceptor } from "./authz-interceptor.ts";
 // Cache
 export { LruCache } from "./cache.ts";
+// Interceptor factories (client-side)
+export { createClientBearerInterceptor } from "./client-bearer-interceptor.ts";
+export { createClientGatewayInterceptor } from "./client-gateway-interceptor.ts";
 // Context management
 export { authContextStorage, getAuthContext, requireAuthContext } from "./context.ts";
 export type { AuthzDeniedDetails } from "./errors.ts";
@@ -44,6 +49,8 @@ export type {
     AuthzInterceptorOptions,
     AuthzRule,
     CacheOptions,
+    ClientBearerInterceptorOptions,
+    ClientGatewayInterceptorOptions,
     GatewayAuthInterceptorOptions,
     GatewayHeaderMapping,
     InterceptorFactory,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,12 +3,13 @@
  *
  * Authentication and authorization interceptors for Connectum.
  *
- * Provides seven interceptor factories:
+ * Provides eight interceptor factories:
  * - createAuthInterceptor() — generic, pluggable authentication
  * - createJwtAuthInterceptor() — JWT convenience with jose
  * - createGatewayAuthInterceptor() — gateway-injected headers
  * - createSessionAuthInterceptor() — session-based auth (better-auth, etc.)
  * - createAuthzInterceptor() — declarative rules-based authorization
+ * - createProtoAuthzInterceptor() — proto-option-driven authorization
  * - createClientBearerInterceptor() — client-side Bearer token
  * - createClientGatewayInterceptor() — client-side gateway service-to-service auth
  *

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -360,6 +360,36 @@ export interface SessionAuthInterceptorOptions {
 }
 
 /**
+ * Client-side Bearer token interceptor options.
+ *
+ * @see {@link createClientBearerInterceptor}
+ */
+export interface ClientBearerInterceptorOptions {
+    /**
+     * Bearer token value or async factory function.
+     *
+     * When a string is provided, the same token is sent with every request.
+     * When a function is provided, it is called before each request to
+     * support token refresh flows.
+     */
+    readonly token: string | (() => Promise<string>);
+}
+
+/**
+ * Client-side gateway service-to-service auth interceptor options.
+ *
+ * @see {@link createClientGatewayInterceptor}
+ */
+export interface ClientGatewayInterceptorOptions {
+    /** Shared secret for gateway trust verification */
+    readonly secret: string;
+    /** Authenticated subject identifier (e.g., service name) */
+    readonly subject: string;
+    /** Optional roles to propagate (JSON-encoded in header) */
+    readonly roles?: string[] | undefined;
+}
+
+/**
  * Proto-based authorization interceptor options.
  *
  * Uses proto custom options (connectum.auth.v1) for declarative authorization

--- a/packages/auth/tests/unit/client-bearer-interceptor.test.ts
+++ b/packages/auth/tests/unit/client-bearer-interceptor.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the client-side Bearer token interceptor
+ *
+ * Tests createClientBearerInterceptor() for static tokens,
+ * async token factories, and header overwrite behavior.
+ */
+
+import assert from "node:assert";
+import { describe, it, mock } from "node:test";
+import { createMockNext, createMockRequest } from "@connectum/testing";
+import { createClientBearerInterceptor } from "../../src/client-bearer-interceptor.ts";
+
+const MOCK_REQUEST_DEFAULTS = { service: "test.Service", method: "Method" } as const;
+
+describe("client-bearer-interceptor", () => {
+    describe("createClientBearerInterceptor()", () => {
+        it("should set Authorization header with static token", async () => {
+            const interceptor = createClientBearerInterceptor({ token: "my-static-token" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            assert.strictEqual(req.header.get("authorization"), "Bearer my-static-token");
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("should call async token factory and set Authorization header", async () => {
+            const tokenFactory = mock.fn(async () => "async-refreshed-token");
+
+            const interceptor = createClientBearerInterceptor({ token: tokenFactory as () => Promise<string> });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            assert.strictEqual(tokenFactory.mock.calls.length, 1);
+            assert.strictEqual(req.header.get("authorization"), "Bearer async-refreshed-token");
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("should overwrite existing Authorization header", async () => {
+            const interceptor = createClientBearerInterceptor({ token: "new-token" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+            req.header.set("authorization", "Bearer old-token");
+
+            await handler(req);
+
+            assert.strictEqual(req.header.get("authorization"), "Bearer new-token");
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+    });
+});

--- a/packages/auth/tests/unit/client-gateway-interceptor.test.ts
+++ b/packages/auth/tests/unit/client-gateway-interceptor.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the client-side gateway auth interceptor
+ *
+ * Tests createClientGatewayInterceptor() for header propagation,
+ * roles serialization, and omission of optional headers.
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { createMockNext, createMockRequest } from "@connectum/testing";
+import { createClientGatewayInterceptor } from "../../src/client-gateway-interceptor.ts";
+import { AUTH_HEADERS } from "../../src/types.ts";
+
+const MOCK_REQUEST_DEFAULTS = { service: "test.Service", method: "Method" } as const;
+
+describe("client-gateway-interceptor", () => {
+    describe("createClientGatewayInterceptor()", () => {
+        it("should set all three headers (secret, subject, roles)", async () => {
+            const interceptor = createClientGatewayInterceptor({
+                secret: "gateway-secret-123",
+                subject: "order-service",
+                roles: ["service", "order-writer"],
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            assert.strictEqual(req.header.get("x-gateway-secret"), "gateway-secret-123");
+            assert.strictEqual(req.header.get(AUTH_HEADERS.SUBJECT), "order-service");
+            assert.strictEqual(req.header.get(AUTH_HEADERS.ROLES), JSON.stringify(["service", "order-writer"]));
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("should JSON.stringify the roles array", async () => {
+            const interceptor = createClientGatewayInterceptor({
+                secret: "secret",
+                subject: "svc",
+                roles: ["admin", "user", "editor"],
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            const rolesHeader = req.header.get(AUTH_HEADERS.ROLES);
+            assert.ok(rolesHeader);
+            const parsed: unknown = JSON.parse(rolesHeader);
+            assert.deepStrictEqual(parsed, ["admin", "user", "editor"]);
+        });
+
+        it("should not set x-auth-roles header when roles are not provided", async () => {
+            const interceptor = createClientGatewayInterceptor({
+                secret: "gateway-secret",
+                subject: "user-service",
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            assert.strictEqual(req.header.get("x-gateway-secret"), "gateway-secret");
+            assert.strictEqual(req.header.get(AUTH_HEADERS.SUBJECT), "user-service");
+            assert.strictEqual(req.header.get(AUTH_HEADERS.ROLES), null);
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("should not set x-auth-roles header when roles array is empty", async () => {
+            const interceptor = createClientGatewayInterceptor({
+                secret: "gateway-secret",
+                subject: "user-service",
+                roles: [],
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const req = createMockRequest(MOCK_REQUEST_DEFAULTS);
+
+            await handler(req);
+
+            assert.strictEqual(req.header.get(AUTH_HEADERS.ROLES), null);
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Added `createClientBearerInterceptor()` — sets Authorization header with static or async token factory for refresh flows
- Added `createClientGatewayInterceptor()` — sets x-gateway-secret, x-auth-subject, and x-auth-roles headers for service-to-service communication

## Test plan

- [x] 7 new unit tests (3 bearer + 4 gateway)
- [x] 304 auth tests pass total
- [x] Biome lint clean
- [x] Cross-runtime: all runtimes pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added client-side authentication interceptors to the `@connectum/auth` package
  * New `createClientBearerInterceptor()` enables Bearer token-based authentication with support for both static and dynamically-resolved tokens
  * New `createClientGatewayInterceptor()` enables service-to-service authentication with configurable secret, subject, and optional roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->