### PR TITLE
fix(testing): replace node:test mock with portable implementation

### DIFF
--- a/.changeset/fix-testing-portable-mock.md
+++ b/.changeset/fix-testing-portable-mock.md
@@ -1,0 +1,11 @@
+---
+"@connectum/testing": patch
+---
+
+fix(testing): replace node:test mock with portable implementation
+
+Replaced `mock.fn()` from `node:test` with a portable `createMockFn()`
+implementation that works across Node.js, Bun, and bundler environments.
+The public API surface (`.mock.calls`, `.mock.callCount()`) is preserved.
+
+This unblocks Bun users from using `@connectum/testing` utilities.

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -9,6 +9,9 @@
 
 export { assertConnectError } from "./assertions.ts";
 export { createFakeMethod, createFakeService } from "./fake-service.ts";
+export type { MockCall, MockFn } from "./mock-compat.ts";
+// Portable mock function factory
+export { createMockFn } from "./mock-compat.ts";
 // Phase 2 (P1): Protobuf descriptor mocks & streaming
 export { createMockDescField, createMockDescMessage, createMockDescMethod } from "./mock-desc.ts";
 export { createMockNext, createMockNextError, createMockNextSlow } from "./mock-next.ts";

--- a/packages/testing/src/mock-compat.ts
+++ b/packages/testing/src/mock-compat.ts
@@ -1,0 +1,69 @@
+/**
+ * Portable mock function factory.
+ *
+ * Provides a lightweight spy that is API-compatible with `node:test`
+ * `mock.fn()` (`.mock.calls`, `.mock.callCount()`) but does **not**
+ * depend on `node:test`, making it safe for Node.js, Bun, Deno,
+ * and bundler environments.
+ *
+ * @module
+ */
+
+/**
+ * A single recorded invocation of a {@link MockFn}.
+ */
+export interface MockCall<Args extends readonly unknown[] = readonly unknown[]> {
+    /** The arguments passed to the mock function. */
+    readonly arguments: Args;
+}
+
+/**
+ * A callable spy that records every invocation.
+ *
+ * The shape intentionally mirrors the subset of `node:test` `mock.fn()`
+ * that Connectum testing utilities rely on.
+ */
+export interface MockFn<F extends (...args: any[]) => any> {
+    (...args: Parameters<F>): ReturnType<F>;
+    /** Spy metadata. */
+    readonly mock: {
+        /** Ordered list of recorded calls. */
+        readonly calls: ReadonlyArray<MockCall<Parameters<F>>>;
+        /** Returns the total number of recorded calls. */
+        callCount(): number;
+    };
+}
+
+/**
+ * Create a portable mock function that wraps `impl` and records every call.
+ *
+ * @param impl - The underlying implementation to delegate to.
+ * @returns A spy-enabled wrapper whose `.mock` property exposes call metadata.
+ *
+ * @example
+ * ```ts
+ * const add = createMockFn((a: number, b: number) => a + b);
+ * add(1, 2);
+ * add(3, 4);
+ * add.mock.callCount(); // 2
+ * add.mock.calls[0].arguments; // [1, 2]
+ * ```
+ */
+export function createMockFn<F extends (...args: any[]) => any>(impl: F): MockFn<F> {
+    const calls: Array<MockCall<Parameters<F>>> = [];
+
+    const fn = ((...args: Parameters<F>) => {
+        calls.push({ arguments: args });
+        return impl(...args);
+    }) as MockFn<F>;
+
+    Object.defineProperty(fn, "mock", {
+        value: {
+            calls,
+            callCount: () => calls.length,
+        },
+        writable: false,
+    });
+
+    return fn;
+}

--- a/packages/testing/src/mock-next.ts
+++ b/packages/testing/src/mock-next.ts
@@ -1,23 +1,23 @@
 /**
  * Factories for mock ConnectRPC `next` handler functions.
  *
- * These helpers produce spy-enabled mock functions (via `node:test` `mock.fn`)
+ * These helpers produce spy-enabled mock functions (via {@link createMockFn})
  * that simulate the downstream handler in an interceptor chain, allowing tests
  * to verify that interceptors correctly invoke (or skip) the next handler.
  *
  * @module
  */
 
-import { mock } from "node:test";
 import { setTimeout } from "node:timers/promises";
 import { type Code, ConnectError } from "@connectrpc/connect";
+import { createMockFn } from "./mock-compat.ts";
 import type { MockNextOptions } from "./types.ts";
 
 /**
  * Create a mock `next` handler that resolves with a successful response.
  *
- * The returned function is a `mock.fn()` spy, so callers can inspect
- * `next.mock.calls` and `next.mock.callCount()` after the test.
+ * The returned function is a spy (via {@link createMockFn}), so callers can
+ * inspect `next.mock.calls` and `next.mock.callCount()` after the test.
  *
  * @param options - Optional overrides for the response payload and stream flag.
  * @returns A spy-enabled async function matching the ConnectRPC `next` signature.
@@ -37,7 +37,7 @@ export function createMockNext(options?: MockNextOptions): any {
     const stream = options?.stream ?? false;
     const baseMessage = options?.message ?? { result: "success" };
 
-    return mock.fn(async (_req: unknown) => ({
+    return createMockFn(async (_req: unknown) => ({
         stream,
         message: { ...baseMessage },
     }));
@@ -66,7 +66,7 @@ export function createMockNext(options?: MockNextOptions): any {
  */
 // biome-ignore lint/suspicious/noExplicitAny: ConnectRPC next() signature varies by context
 export function createMockNextError(code: Code, message?: string): any {
-    return mock.fn(async (_req: unknown) => {
+    return createMockFn(async (_req: unknown) => {
         throw new ConnectError(message ?? "Mock error", code);
     });
 }
@@ -91,7 +91,7 @@ export function createMockNextError(code: Code, message?: string): any {
  */
 // biome-ignore lint/suspicious/noExplicitAny: ConnectRPC next() signature varies by context
 export function createMockNextSlow(delay: number, options?: MockNextOptions): any {
-    return mock.fn(async (_req: unknown) => {
+    return createMockFn(async (_req: unknown) => {
         await setTimeout(delay);
         return {
             stream: options?.stream ?? false,

--- a/packages/testing/tests/unit/mock-compat.test.ts
+++ b/packages/testing/tests/unit/mock-compat.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { createMockFn } from "../../src/mock-compat.ts";
+
+describe("createMockFn", () => {
+  it("tracks calls correctly", () => {
+    const fn = createMockFn((x: number) => x * 2);
+    fn(5);
+
+    assert.strictEqual(fn.mock.calls.length, 1);
+
+    const call = fn.mock.calls[0];
+    assert.ok(call, "expected at least one recorded call");
+    assert.deepStrictEqual(call.arguments, [5]);
+  });
+
+  it("callCount returns correct number", () => {
+    const fn = createMockFn(() => "ok");
+
+    assert.strictEqual(fn.mock.callCount(), 0);
+
+    fn();
+    assert.strictEqual(fn.mock.callCount(), 1);
+
+    fn();
+    fn();
+    assert.strictEqual(fn.mock.callCount(), 3);
+  });
+
+  it("preserves return value", () => {
+    const fn = createMockFn((a: number, b: number) => a + b);
+    const result = fn(3, 4);
+
+    assert.strictEqual(result, 7);
+  });
+
+  it("preserves async return value", async () => {
+    const fn = createMockFn(async (name: string) => `hello ${name}`);
+    const result = await fn("world");
+
+    assert.strictEqual(result, "hello world");
+  });
+
+  it("arguments are captured correctly", () => {
+    const fn = createMockFn((a: string, b: number, c: boolean) => `${a}-${b}-${c}`);
+    fn("foo", 42, true);
+
+    const call = fn.mock.calls[0];
+    assert.ok(call, "expected at least one recorded call");
+    assert.deepStrictEqual(call.arguments, ["foo", 42, true]);
+  });
+
+  it("works with multiple calls", () => {
+    const fn = createMockFn((x: number) => x);
+    fn(1);
+    fn(2);
+    fn(3);
+
+    assert.strictEqual(fn.mock.callCount(), 3);
+    assert.strictEqual(fn.mock.calls.length, 3);
+
+    const call0 = fn.mock.calls[0];
+    const call1 = fn.mock.calls[1];
+    const call2 = fn.mock.calls[2];
+    assert.ok(call0 && call1 && call2, "expected three recorded calls");
+    assert.deepStrictEqual(call0.arguments, [1]);
+    assert.deepStrictEqual(call1.arguments, [2]);
+    assert.deepStrictEqual(call2.arguments, [3]);
+  });
+});

--- a/packages/testing/tsup.config.ts
+++ b/packages/testing/tsup.config.ts
@@ -8,12 +8,4 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
-    async onSuccess() {
-        // Restore `node:` prefix for `node:test` (esbuild strips it)
-        const fs = await import("node:fs");
-        const distUrl = new URL("./dist/index.js", import.meta.url);
-        let code = fs.readFileSync(distUrl, "utf-8");
-        code = code.replace(/from "test"/g, 'from "node:test"');
-        fs.writeFileSync(distUrl, code);
-    },
 });


### PR DESCRIPTION
## Summary

- Replaced `mock.fn()` from `node:test` with portable `createMockFn()` that works across Node.js, Bun, and bundler environments
- Removed tsup `onSuccess` hack that patched `node:test` imports in built output
- Public API surface (`.mock.calls`, `.mock.callCount()`) preserved

Unblocks Bun users from using `@connectum/testing` utilities (P4 from feedback report).

## Test plan

- [x] 6 new mock-compat tests
- [x] 102 testing tests pass total (all existing tests unchanged)
- [x] `dist/index.js` contains zero runtime references to `node:test`
- [x] Cross-runtime: all runtimes pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced portable mock function creation with improved cross-environment compatibility (Node.js, Bun, and bundlers)
  * Exported `createMockFn` function and related types (`MockCall`, `MockFn`) for direct access from the testing module

* **Bug Fixes**
  * Fixed platform-specific mock dependencies to ensure consistent behavior across different runtime environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->