### PR TITLE
fix(interceptors): stabilize circuit breaker tests for esbuild runtime

### DIFF
--- a/packages/interceptors/tests/integration/resilience.test.ts
+++ b/packages/interceptors/tests/integration/resilience.test.ts
@@ -76,7 +76,7 @@ describe('Resilience Pattern Integration', () => {
         // Setup: circuit breaker threshold 2 (will open after 2 failures)
         const circuitBreakerInterceptor = createCircuitBreakerInterceptor({
             threshold: 2,
-            halfOpenAfter: 10,
+            halfOpenAfter: 60_000,
         });
 
         const mockReq = {

--- a/packages/interceptors/tests/unit/circuit-breaker.test.ts
+++ b/packages/interceptors/tests/unit/circuit-breaker.test.ts
@@ -54,7 +54,7 @@ describe("circuit breaker interceptor", () => {
     });
 
     it("should reject requests when circuit open", async () => {
-        const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 10 });
+        const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 60_000 });
 
         const mockReq = createMockRequest({ service: "test.Service", method: "Method", message: { field: "value" } });
 
@@ -183,7 +183,7 @@ describe("circuit breaker interceptor", () => {
     });
 
     it("should handle custom threshold", async () => {
-        const interceptor = createCircuitBreakerInterceptor({ threshold: 5, halfOpenAfter: 10 });
+        const interceptor = createCircuitBreakerInterceptor({ threshold: 5, halfOpenAfter: 60_000 });
 
         const mockReq = createMockRequest({ service: "test.Service", method: "Method", message: { field: "value" } });
 


### PR DESCRIPTION
## Summary

Fixed flaky `@connectum/interceptors#test:esbuild` CI failure caused by race condition in circuit breaker tests.

**Root cause**: Three tests used `halfOpenAfter: 10` (10ms). Under esbuild transpilation overhead, 10ms was enough for cockatiel to transition from Open → Half-Open before the assertion ran, causing the test to receive `Code.Internal` (13, from mock next) instead of `Code.Unavailable` (14, from circuit breaker).

**Fix**: Increased `halfOpenAfter` to `60_000` in tests that assert on Open state. Tests that intentionally verify half-open behavior retain original timing.

**Files changed**:
- `packages/interceptors/tests/unit/circuit-breaker.test.ts` (lines 57, 186)
- `packages/interceptors/tests/integration/resilience.test.ts` (line 79)

## Test plan

- [x] 146 interceptors tests pass (was 143 — 3 new tests from prior merges)
- [x] Verified locally with esbuild runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated circuit breaker test timing configurations to extend half-open transition duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->