### PR TITLE
fix(events-amqp): add missing typedoc.json config

### DIFF
--- a/packages/events-amqp/typedoc.json
+++ b/packages/events-amqp/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "entryPoints": ["src/index.ts", "src/types.ts"],
+
+  "tsconfig": "../../tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- Adds the missing `packages/events-amqp/typedoc.json` config file
- Without it, root TypeDoc `entryPointStrategy: "packages"` silently skipped events-amqp during `pnpm docs:api` runs
- Mirrors `packages/events-nats/typedoc.json` for consistency
- Discovered during a documentation drift audit when events-amqp was missing from regenerated API Reference

## Test plan
- [ ] `pnpm docs:api` from connectum root generates `docs/en/api/@connectum/events-amqp/`
- [ ] Generated API Reference includes AmqpAdapter, toAmqpPattern functions and Amqp* type interfaces
- [ ] No regressions in other 12 packages' API Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documentation generation configuration for the AMQP events package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->