### PR TITLE
feat(release): auto-create draft GitHub release after changesets publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,54 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
 
+      - name: Create draft GitHub release
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=$(jq -r '.version' packages/core/package.json)
+          TAG="v${VERSION}"
+
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::notice::Release ${TAG} already exists, skipping draft creation"
+            exit 0
+          fi
+
+          NOTES_FILE="$(mktemp)"
+          ver_re=$(printf '%s' "${VERSION}" | sed 's/[.[\*^$/]/\\&/g')
+          for pkg_dir in packages/*/; do
+            changelog_file="${pkg_dir}CHANGELOG.md"
+            [ -f "$changelog_file" ] || continue
+            pkg_name=$(jq -r '.name' "${pkg_dir}package.json")
+            section=$(awk "/^## ${ver_re}\$/{found=1; next} /^## [0-9]/{if(found) exit} found" "$changelog_file")
+            if [ -n "$(echo "$section" | tr -d '[:space:]')" ]; then
+              {
+                echo "## ${pkg_name}@${VERSION}"
+                echo "$section"
+                echo ""
+              } >> "$NOTES_FILE"
+            fi
+          done
+
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::warning::No changelog entries found for ${VERSION}; creating draft release with empty notes"
+          fi
+
+          PRERELEASE_FLAG=""
+          if echo "${VERSION}" | grep -qE "(alpha|beta|rc)"; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${TAG}" \
+            --title "Connectum ${TAG}" \
+            --notes-file "$NOTES_FILE" \
+            --target "${{ github.sha }}" \
+            --draft \
+            ${PRERELEASE_FLAG}
+
+          echo "::notice::Created draft release ${TAG} — review and publish at https://github.com/${{ github.repository }}/releases"
+
       - name: Check proto changes
         id: proto-changes
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

Adds a single step after `changesets/action` that automatically creates a **draft** GitHub release when packages were published to npm. The maintainer reviews the draft in the GitHub UI and clicks "Publish release" — at that moment GitHub creates the tag and emits the release.

## Problem this solves

After the changesets PR (\`chore: version packages\`) is merged, \`release.yml\` publishes packages to npm but does not create any GitHub release. To make the release visible in the UI, the maintainer had to manually trigger \`create-release.yml\` via \`workflow_dispatch\`. This step is easy to forget — it happened for v1.0.0-rc.11 (npm published, no GitHub release).

## Behavior

- Runs only when \`steps.changesets.outputs.published == 'true'\`
- Reads version from \`packages/core/package.json\` (same convention as \`create-release.yml\`)
- **Idempotent**: skips if a release for \`v<version>\` already exists
- Aggregates \`## <version>\` sections from every \`packages/*/CHANGELOG.md\`
- Creates a **draft** release — no git tag is pushed by CI
- Tag is materialized by GitHub when the maintainer publishes the draft via UI
- Auto-detects \`--prerelease\` from \`alpha\`/\`beta\`/\`rc\` in the version

## Why draft, not immediate publish

- Allows human review of the aggregated changelog before exposing it to users
- Sidesteps the \`creations being restricted\` org ruleset that blocks direct tag pushes from this workflow path (visible in the failed \`create-release.yml\` run that triggered this work)
- Mirrors the \`dry_run\` review pattern already used by \`create-release.yml\`

## Relationship to create-release.yml

\`create-release.yml\` stays as a manual recovery tool (e.g. re-running for an older version). This step covers the happy path so the maintainer never has to remember a second manual workflow.

## Test plan

- [ ] Next changesets-driven release triggers the step and creates a draft release at \`https://github.com/Connectum-Framework/connectum/releases\`
- [ ] Draft contains aggregated CHANGELOG sections from all updated packages
- [ ] Maintainer can publish the draft via UI; GitHub creates the tag and the release becomes visible
- [ ] Released author shows as \`github-actions\` (uses \`secrets.GITHUB_TOKEN\`)
- [ ] Re-running the workflow on the same version is a no-op (idempotent)