### PR TITLE
feat(core): expose jsonOptions in CreateServerOptions

### DIFF
--- a/.changeset/core-json-options.md
+++ b/.changeset/core-json-options.md
@@ -1,0 +1,24 @@
+---
+"@connectum/core": minor
+---
+
+feat(core): expose `jsonOptions` in `createServer()` to control Connect JSON serialization
+
+`CreateServerOptions` now accepts an optional `jsonOptions` field
+(`Partial<JsonReadOptions & JsonWriteOptions>`) that is threaded through to the
+underlying `connectNodeAdapter`. It applies server-wide, so it also covers
+protocol services registered by the framework (healthcheck, reflection).
+
+The most common use is emitting fields with implicit presence (proto3 scalar
+`0`, empty string/list, enum default) in JSON responses instead of omitting
+them:
+
+```typescript
+const server = createServer({
+  services: [routes],
+  jsonOptions: { alwaysEmitImplicit: true },
+});
+```
+
+For per-service control, the same option can still be passed as the third
+argument of `router.service()` inside a service route.

--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -133,6 +133,7 @@ class ServerImpl extends EventEmitter implements Server {
                 protocols: this._protocols,
                 interceptors: this._interceptors,
                 shutdownSignal: this._abortController.signal,
+                ...(this._options.jsonOptions ? { jsonOptions: this._options.jsonOptions } : {}),
             });
             this._registry.push(...registry);
 

--- a/packages/core/src/buildRoutes.ts
+++ b/packages/core/src/buildRoutes.ts
@@ -7,7 +7,7 @@
  * @module buildRoutes
  */
 
-import type { DescFile } from "@bufbuild/protobuf";
+import type { DescFile, JsonReadOptions, JsonWriteOptions } from "@bufbuild/protobuf";
 import type { ConnectRouter, Interceptor } from "@connectrpc/connect";
 import { connectNodeAdapter } from "@connectrpc/connect-node";
 import type { NodeRequest, NodeResponse, ProtocolContext, ProtocolRegistration, ServiceRoute } from "./types.ts";
@@ -20,6 +20,8 @@ export interface BuildRoutesOptions {
     protocols: ProtocolRegistration[];
     interceptors: Interceptor[];
     shutdownSignal: AbortSignal;
+    /** Connect JSON serialization options applied server-wide (passed to connectNodeAdapter). */
+    jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
 }
 
 /**
@@ -41,7 +43,7 @@ export interface BuildRoutesResult {
  * @returns The HTTP handler and collected DescFile registry
  */
 export function buildRoutes(options: BuildRoutesOptions): BuildRoutesResult {
-    const { services, protocols, interceptors, shutdownSignal } = options;
+    const { services, protocols, interceptors, shutdownSignal, jsonOptions } = options;
 
     const registry: DescFile[] = [];
 
@@ -75,6 +77,7 @@ export function buildRoutes(options: BuildRoutesOptions): BuildRoutesResult {
         routes,
         interceptors,
         shutdownSignal,
+        ...(jsonOptions ? { jsonOptions } : {}),
         fallback(req, res) {
             // Delegate to protocol HTTP handlers
             for (const httpHandler of httpHandlers) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,7 +8,7 @@ import type { EventEmitter } from "node:events";
 import type { Server as HttpServer, IncomingMessage, ServerResponse } from "node:http";
 import type { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse, SecureServerOptions } from "node:http2";
 import type { AddressInfo } from "node:net";
-import type { DescFile } from "@bufbuild/protobuf";
+import type { DescFile, JsonReadOptions, JsonWriteOptions } from "@bufbuild/protobuf";
 import type { ConnectRouter, Interceptor } from "@connectrpc/connect";
 
 // =============================================================================
@@ -307,6 +307,31 @@ export interface CreateServerOptions {
      * Additional HTTP/2 server options
      */
     http2Options?: SecureServerOptions;
+
+    /**
+     * Connect JSON serialization options applied server-wide.
+     *
+     * Passed through to the underlying `connectNodeAdapter`, so it affects every
+     * registered service and protocol (e.g. healthcheck, reflection). The most
+     * common use is `alwaysEmitImplicit: true`, which includes fields with
+     * implicit presence (proto3 scalar `0`, empty string/list, enum default) in
+     * JSON responses instead of omitting them.
+     *
+     * For per-service control, pass the same option as the third argument of
+     * `router.service()` inside a {@link ServiceRoute} instead.
+     *
+     * Note: the relevant `JsonWriteOptions` field in `@bufbuild/protobuf` v2 is
+     * `alwaysEmitImplicit` (named `emitDefaultValues` in v1).
+     *
+     * @example
+     * ```typescript
+     * const server = createServer({
+     *   services: [routes],
+     *   jsonOptions: { alwaysEmitImplicit: true },
+     * });
+     * ```
+     */
+    jsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>;
 }
 
 /**

--- a/packages/core/tests/integration/jsonOptions.test.ts
+++ b/packages/core/tests/integration/jsonOptions.test.ts
@@ -1,0 +1,174 @@
+/**
+ * jsonOptions integration tests
+ *
+ * Verifies that `CreateServerOptions.jsonOptions` is threaded through to the
+ * underlying connectNodeAdapter and actually changes the JSON serialization of
+ * responses. The oracle is the real HTTP response body, not the implementation:
+ * a field with implicit presence (proto3 `int32 = 0`) must be present in the
+ * JSON body when `alwaysEmitImplicit: true` and omitted when it is not set.
+ *
+ * The proto schema is built at runtime (no buf codegen in @connectum/core), so
+ * the test stays self-contained and depends only on @bufbuild/protobuf.
+ */
+
+import assert from "node:assert";
+import { afterEach, describe, it } from "node:test";
+import type { DescService, JsonReadOptions, JsonValue, JsonWriteOptions } from "@bufbuild/protobuf";
+import { create, createFileRegistry } from "@bufbuild/protobuf";
+import { FileDescriptorProtoSchema } from "@bufbuild/protobuf/wkt";
+import type { ConnectRouter, ServiceImpl } from "@connectrpc/connect";
+import { createServer } from "../../src/Server.ts";
+import type { Server, ServiceRoute } from "../../src/types.ts";
+
+// =============================================================================
+// RUNTIME PROTO SCHEMA
+// =============================================================================
+
+const PACKAGE = "connectum.test.v1";
+const SERVICE_TYPE = `${PACKAGE}.EchoService`;
+
+/**
+ * Build a minimal proto3 schema at runtime:
+ *
+ *   package connectum.test.v1;
+ *   message EchoRequest {}
+ *   message EchoResponse { int32 value = 1; } // implicit presence
+ *   service EchoService { rpc Echo(EchoRequest) returns (EchoResponse); }
+ */
+function buildEchoService(): DescService {
+    const fileDescriptor = create(FileDescriptorProtoSchema, {
+        name: "connectum/test/v1/echo.proto",
+        package: PACKAGE,
+        syntax: "proto3",
+        messageType: [
+            { name: "EchoRequest" },
+            {
+                name: "EchoResponse",
+                field: [
+                    {
+                        name: "value",
+                        jsonName: "value",
+                        number: 1,
+                        // LABEL_OPTIONAL = 1 (singular field with implicit presence in proto3)
+                        label: 1,
+                        // TYPE_INT32 = 5
+                        type: 5,
+                    },
+                ],
+            },
+        ],
+        service: [
+            {
+                name: "EchoService",
+                method: [
+                    {
+                        name: "Echo",
+                        inputType: `.${PACKAGE}.EchoRequest`,
+                        outputType: `.${PACKAGE}.EchoResponse`,
+                    },
+                ],
+            },
+        ],
+    });
+
+    const registry = createFileRegistry(fileDescriptor, () => undefined);
+    const service = registry.getService(SERVICE_TYPE);
+    assert.ok(service, `service ${SERVICE_TYPE} should be resolvable from the runtime registry`);
+    return service;
+}
+
+/**
+ * ServiceRoute that always responds with `value` left at its zero default.
+ *
+ * @param perServiceJsonOptions - When provided, passed as the third argument of
+ *   `router.service()` (the per-service lever), independent of the server-level option.
+ */
+function createEchoRoute(service: DescService, perServiceJsonOptions?: Partial<JsonReadOptions & JsonWriteOptions>): ServiceRoute {
+    return (router: ConnectRouter) => {
+        const method = service.methods[0];
+        assert.ok(method, "EchoService should expose its Echo method");
+        // Respond with the message left at defaults (value = 0).
+        // The schema is dynamic, so the typed ServiceImpl shape cannot be inferred here.
+        const impl = { [method.localName]: () => create(method.output, {}) } as unknown as Partial<ServiceImpl<DescService>>;
+        if (perServiceJsonOptions) {
+            router.service(service, impl, { jsonOptions: perServiceJsonOptions });
+        } else {
+            router.service(service, impl);
+        }
+    };
+}
+
+// =============================================================================
+// HTTP HELPER
+// =============================================================================
+
+/** Send a Connect unary JSON request and return the parsed response body. */
+async function callEcho(port: number): Promise<JsonValue> {
+    const response = await fetch(`http://127.0.0.1:${port}/${SERVICE_TYPE}/Echo`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+    });
+    assert.strictEqual(response.status, 200, `expected HTTP 200, got ${response.status}`);
+    return (await response.json()) as JsonValue;
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("CreateServerOptions.jsonOptions", () => {
+    const service = buildEchoService();
+    let server: Server | null = null;
+
+    afterEach(async () => {
+        if (server) {
+            await server.stop();
+            server = null;
+        }
+    });
+
+    it("omits implicit-presence fields by default", async () => {
+        server = createServer({
+            services: [createEchoRoute(service)],
+            port: 0,
+        });
+        await server.start();
+
+        const port = server.address?.port;
+        assert.ok(port, "server should expose a bound port");
+
+        const body = await callEcho(port);
+        assert.deepStrictEqual(body, {}, "zero-valued int32 must be omitted from the JSON body by default");
+    });
+
+    it("emits implicit-presence fields when alwaysEmitImplicit is enabled", async () => {
+        server = createServer({
+            services: [createEchoRoute(service)],
+            port: 0,
+            jsonOptions: { alwaysEmitImplicit: true },
+        });
+        await server.start();
+
+        const port = server.address?.port;
+        assert.ok(port, "server should expose a bound port");
+
+        const body = await callEcho(port);
+        assert.deepStrictEqual(body, { value: 0 }, "zero-valued int32 must be present when alwaysEmitImplicit is true");
+    });
+
+    it("supports the per-service lever (router.service options) without the server-level option", async () => {
+        server = createServer({
+            // No server-level jsonOptions -- the option is set per service instead.
+            services: [createEchoRoute(service, { alwaysEmitImplicit: true })],
+            port: 0,
+        });
+        await server.start();
+
+        const port = server.address?.port;
+        assert.ok(port, "server should expose a bound port");
+
+        const body = await callEcho(port);
+        assert.deepStrictEqual(body, { value: 0 }, "per-service jsonOptions must emit the zero-valued int32");
+    });
+});

--- a/packages/core/tests/integration/jsonOptions.test.ts
+++ b/packages/core/tests/integration/jsonOptions.test.ts
@@ -49,7 +49,11 @@ function buildEchoService(): DescService {
                         name: "value",
                         jsonName: "value",
                         number: 1,
-                        // LABEL_OPTIONAL = 1 (singular field with implicit presence in proto3)
+                        // LABEL_OPTIONAL = 1 marks a singular field. In proto3 this label covers
+                        // both implicit-presence fields and explicit `optional` fields; the
+                        // distinction is the `proto3_optional` flag, not the label. Here it is
+                        // left unset, so `value` is a regular singular scalar with implicit
+                        // presence (omitted from JSON when zero).
                         label: 1,
                         // TYPE_INT32 = 5
                         type: 5,


### PR DESCRIPTION
## Summary

Exposes Connect's JSON serialization options at the server level. `CreateServerOptions` gains an optional `jsonOptions` field (`Partial<JsonReadOptions & JsonWriteOptions>`) that is threaded through `buildRoutes()` into the underlying `connectNodeAdapter`.

Previously this lever was unreachable through the public API: `buildRoutes()` called `connectNodeAdapter()` with a fixed set of options. `ConnectNodeAdapterOptions` extends `ConnectRouterOptions` (→ `Partial<UniversalHandlerOptions>`), which carries `jsonOptions`, but `CreateServerOptions` had no matching field.

The most common use is emitting fields with implicit presence (proto3 scalar `0`, empty string/list, enum default) in JSON responses instead of omitting them:

```typescript
const server = createServer({
  services: [routes],
  jsonOptions: { alwaysEmitImplicit: true },
});
```

Because it is applied at the adapter level, it also covers framework-registered protocol services (healthcheck, reflection). The per-service form — `router.service(MyService, impl, { jsonOptions })` — keeps working for finer-grained control.

> Note: the relevant `JsonWriteOptions` field in `@bufbuild/protobuf` v2 is `alwaysEmitImplicit` (it was `emitDefaultValues` in v1, which does not apply here).

## Changes

- `CreateServerOptions.jsonOptions` added (`types.ts`) with JSDoc.
- `BuildRoutesOptions.jsonOptions` threaded into `connectNodeAdapter` (`buildRoutes.ts`).
- `createServer()` passes the option through (`Server.ts`).
- Integration test asserting the actual JSON response body.
- Changeset (`minor`).

## Testing

Build (all packages), typecheck, and the full `@connectum/core` test suite pass (206 tests). Biome lint clean.

The integration test starts a real server, sends a real Connect request, and asserts the **actual JSON response body** (the oracle is the documented serialization behavior, not the implementation) across three paths:

1. omitted by default — `{}`;
2. emitted with the server-level option — `{ "value": 0 }`;
3. emitted with the per-service `router.service()` option — `{ "value": 0 }`.

The API Reference regenerates from JSDoc in the release pipeline; no generated docs are hand-edited here.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-level `jsonOptions` setting to control JSON serialization across the server.
  * Allows emitting zero-valued fields with implicit presence (proto3 defaults) in JSON responses.
  * Per-service JSON configuration remains supported.

* **Tests**
  * Added integration tests validating server-level and per-service JSON serialization behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->