### PR TITLE
chore: raise minimum supported Node.js to 22.13.0

### DIFF
--- a/.changeset/require-node-22.md
+++ b/.changeset/require-node-22.md
@@ -1,0 +1,28 @@
+---
+"@connectum/core": major
+"@connectum/interceptors": major
+"@connectum/auth": major
+"@connectum/healthcheck": major
+"@connectum/reflection": major
+"@connectum/otel": major
+"@connectum/cli": major
+"@connectum/testing": major
+"@connectum/events": major
+"@connectum/events-nats": major
+"@connectum/events-kafka": major
+"@connectum/events-redis": major
+"@connectum/events-amqp": major
+---
+
+chore: raise minimum supported Node.js to 22.13.0
+
+The `engines.node` requirement for all packages is raised from `>=20.0.0` to
+`>=22.13.0`. Node.js 20 reached end-of-life on 2026-04-30 and no longer receives
+security updates.
+
+Node.js 22 is the current LTS line. Consumers on Node.js 20 or earlier must
+upgrade to Node.js 22.13.0 or later. Packages continue to ship compiled
+JavaScript, so no build-step changes are required on the consumer side.
+
+Marked as a major change because raising the runtime floor is breaking for
+consumers on Node.js 20; it lands in the upcoming 1.0.0 baseline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20", "22", "25.2.0"]
+        node-version: ["22", "25.2.0"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -66,17 +66,12 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      # Node 20 lacks native type stripping — use esbuild transpilation
-      - name: Tests (esbuild)
-        if: matrix.node-version == '20'
-        run: pnpm test:esbuild
-
+      # Node 22.18+ and 25.x run TypeScript directly via native type stripping.
+      # esbuild transpilation is covered by the dedicated test-esbuild job below.
       - name: Unit tests
-        if: matrix.node-version != '20'
         run: pnpm test:unit
 
       - name: Integration tests
-        if: matrix.node-version != '20'
         run: pnpm test:integration
 
   # ── Bun runtime tests ──────────────────────────────────────────────────

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -578,7 +578,7 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ## License

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -60,7 +60,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "imports": {
     "#gen/*": "./gen/*",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,7 +8,7 @@ CLI tools for the Connectum gRPC/ConnectRPC framework.
 pnpm add @connectum/cli
 ```
 
-Requires Node.js >= 20.0.0.
+Requires Node.js >= 22.13.0.
 
 ## Commands
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -651,18 +651,18 @@ None — `@connectum/core` is Layer 0 with zero internal dependencies.
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **pnpm**: >=10.0.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ### Alternative Runtimes
 
-`@connectum/core` ships compiled JavaScript and type declarations, so it works on any Node.js 20+ without additional configuration. Your own `.ts` source files can be executed with:
+`@connectum/core` ships compiled JavaScript and type declarations, so it works on any Node.js 22+ without additional configuration. Your own `.ts` source files can be executed with:
 
 - **Node.js 22.6--22.17** -- native type stripping (experimental). Run `node --experimental-strip-types src/index.ts`.
 - **Node.js 22.18+** -- native type stripping enabled by default. Run `node src/index.ts`.
 - **Bun** -- built-in TypeScript support. Run `bun src/index.ts`.
-- **[tsx](https://tsx.is)** -- esbuild-powered TypeScript execution, works on Node.js 20+. Run `npx tsx src/index.ts`.
+- **[tsx](https://tsx.is)** -- esbuild-powered TypeScript execution, works on Node.js 22+. Run `npx tsx src/index.ts`.
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -4,7 +4,7 @@ AMQP/RabbitMQ adapter for `@connectum/events`.
 
 **@connectum/events-amqp** connects the Connectum EventBus to [RabbitMQ](https://www.rabbitmq.com/) (AMQP 0-9-1) for durable, at-least-once event delivery with topic exchanges, consumer groups, and dead-letter support.
 
-**Layer**: 2 (Tools) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 2 (Tools) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Features
 
@@ -183,7 +183,7 @@ When `publishOptions.sync: true`, the adapter uses `ConfirmChannel.waitForConfir
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **RabbitMQ**: >=3.8
 
 ## Documentation

--- a/packages/events-amqp/package.json
+++ b/packages/events-amqp/package.json
@@ -42,7 +42,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events-kafka/README.md
+++ b/packages/events-kafka/README.md
@@ -4,7 +4,7 @@ Kafka/Redpanda adapter for `@connectum/events`.
 
 **@connectum/events-kafka** connects the Connectum EventBus to [Apache Kafka](https://kafka.apache.org/) or [Redpanda](https://redpanda.com/) via [KafkaJS](https://kafka.js.org/) for high-throughput, partitioned event streaming.
 
-**Layer**: 2 (Tools) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 2 (Tools) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Features
 
@@ -150,7 +150,7 @@ Event metadata is transmitted as Kafka message headers (Buffer-encoded).
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **Kafka**: >=2.0 (or Redpanda)
 
 ## Documentation

--- a/packages/events-kafka/package.json
+++ b/packages/events-kafka/package.json
@@ -42,7 +42,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events-nats/README.md
+++ b/packages/events-nats/README.md
@@ -4,7 +4,7 @@ NATS JetStream adapter for `@connectum/events`.
 
 **@connectum/events-nats** connects the Connectum EventBus to [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) for durable, at-least-once event delivery with automatic stream management.
 
-**Layer**: 2 (Tools) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 2 (Tools) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Features
 
@@ -130,7 +130,7 @@ Event metadata is transmitted as NATS message headers. Internal headers (prefixe
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **NATS Server**: >=2.9 with JetStream enabled
 
 ## Documentation

--- a/packages/events-nats/package.json
+++ b/packages/events-nats/package.json
@@ -42,7 +42,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events-redis/README.md
+++ b/packages/events-redis/README.md
@@ -4,7 +4,7 @@ Redis Streams adapter for `@connectum/events`.
 
 **@connectum/events-redis** connects the Connectum EventBus to [Redis Streams](https://redis.io/docs/data-types/streams/) via [ioredis](https://github.com/redis/ioredis) for lightweight, low-latency event streaming with consumer group support.
 
-**Layer**: 2 (Tools) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 2 (Tools) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Features
 
@@ -142,7 +142,7 @@ Stream entry fields:
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **Redis**: >=6.2 (for XAUTOCLAIM support)
 
 ## Documentation

--- a/packages/events-redis/package.json
+++ b/packages/events-redis/package.json
@@ -42,7 +42,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -4,7 +4,7 @@ Universal event adapter layer for Connectum: proto-first pub/sub with pluggable 
 
 **@connectum/events** provides a transport-agnostic EventBus for publishing and subscribing to events using protobuf schemas. Swap between NATS, Kafka, Redis Streams, or in-memory adapter without changing application code.
 
-**Layer**: 1 (Extension) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 1 (Extension) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Features
 
@@ -356,7 +356,7 @@ Set `drainTimeout: 0` for immediate abort (skip drain).
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **pnpm**: >=10.0.0
 - **TypeScript**: >=5.7.2 (for type checking)
 

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -53,7 +53,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "imports": {
     "#gen/*": "./gen/*",

--- a/packages/healthcheck/README.md
+++ b/packages/healthcheck/README.md
@@ -283,7 +283,7 @@ describe('health check', () => {
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **pnpm**: >=10.0.0
 
 ## License

--- a/packages/healthcheck/package.json
+++ b/packages/healthcheck/package.json
@@ -53,7 +53,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/interceptors/README.md
+++ b/packages/interceptors/README.md
@@ -780,7 +780,7 @@ Resilience interceptors (timeout, bulkhead, circuitBreaker, retry, fallback) are
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ## License

--- a/packages/interceptors/package.json
+++ b/packages/interceptors/package.json
@@ -83,7 +83,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -757,7 +757,7 @@ If you export more than ~10,000 spans/sec via OTLP/protobuf, plan around the cur
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ## License

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -87,7 +87,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/reflection/README.md
+++ b/packages/reflection/README.md
@@ -158,7 +158,7 @@ await server.start();
 
 ## Requirements
 
-- **Node.js**: >=20.0.0
+- **Node.js**: >=22.13.0
 - **pnpm**: >=10.0.0
 
 ## License

--- a/packages/reflection/package.json
+++ b/packages/reflection/package.json
@@ -43,7 +43,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,7 +2,7 @@
 
 Testing utilities for the Connectum framework. Provides mock factories, assertion helpers, and a test server utility to eliminate boilerplate in ConnectRPC interceptor and service tests.
 
-**Layer**: 2 (Testing Utilities) | **Node.js**: >=20.0.0 | **License**: Apache-2.0
+**Layer**: 2 (Testing Utilities) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
 ## Installation
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -43,7 +43,7 @@
   "author": "Highload.Zone",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Raises the minimum supported Node.js runtime from `>=20.0.0` to **`>=22.13.0`** across all packages.

Node.js 20 reached [end-of-life on 2026-04-30](https://nodejs.org/en/about/previous-releases) and no longer receives security updates. Node.js 22 is the current LTS line. This change lands in the upcoming 1.0.0 baseline.

## Changes

- **`engines.node`**: `>=20.0.0` → `>=22.13.0` in all 13 packages.
- **CI** (`ci.yml`): drop Node 20 from the test matrix (now `[22, 25.2.0]`); remove the Node-20-only esbuild branch. Node 22.18+ and 25.x run TypeScript directly via native type stripping, and esbuild coverage remains in the dedicated `test-esbuild` job.
- **README**: update consumer Node.js references to 22+.
- **Changeset** (`major`): raising the runtime floor is breaking for consumers on Node.js 20.

Development and release/snapshot tooling stays on Node.js 25.2.0 (unchanged).

## Validation

- Local (dev Node.js 25.2.0): `pnpm build` (16/16), `pnpm typecheck`, `@connectum/core` tests (203/203), `pnpm lint` — all green. CI workflow YAML validated. `changeset status` recognizes the change (aggregates to a major bump).
- The Node 22 matrix job runs only in CI (cannot be reproduced on the dev runtime locally).

## Notes

The auto-generated API Reference under `en/api/` regenerates from JSDoc in the release pipeline; documentation updates are in a separate docs PR.
