### PR TITLE
feat(events-amqp): external AMQP contracts, recovery, reliable publishing

### DIFF
--- a/.changeset/events-amqp-external-contract.md
+++ b/.changeset/events-amqp-external-contract.md
@@ -1,0 +1,19 @@
+---
+"@connectum/events-amqp": minor
+---
+
+External AMQP contracts, automatic recovery, and reliable per-message publishing.
+
+The adapter can now implement an externally agreed AMQP contract (AsyncAPI-style) and survive broker outages:
+
+- **Serialization**: `serialization: { contentType, encode, decode }` — set the message `contentType` (e.g. `application/json` for JSON contracts; default stays `application/protobuf`) and optionally transcode the wire body.
+- **Explicit topology**: `topology: { exchanges, queues, bindings }` with arbitrary external names and raw AMQP `arguments` (incl. `x-dead-letter-exchange`), exchange-to-exchange bindings, plus `topologyMode: "assert" | "check" | "skip"` for app-owned topology with fail-fast existence checks.
+- **queueOverrides**: attach a consumer group to an externally named queue instead of `${exchange}.${group}`.
+- **Automatic recovery** (amqplib v2 native opt-in recovery, enabled by default): reconnect with backoff/jitter, re-created channels, re-applied topology, replayed subscriptions. `lifecycle` callbacks (`onConnected` / `onDisconnected` / `onReconnecting` / `onReconnectFailed`) replace console-only error reporting. With recovery enabled `connect()` waits for the broker (docker-compose friendly); `recovery: false` restores fail-fast.
+- **Reliable publishing**: every `publish()` resolves on its own broker ack and rejects with a typed error — `AmqpUnroutableError` (mandatory + `basic.return`, correlated via a private `x-connectum-publish-id` header; opt-out `correlationHeader: false` switches to single-flight), `AmqpPublishNackError`, `AmqpPublishTimeoutError` (`publishTimeoutMs`, default 30 s), `AmqpConnectionError`, `AmqpTopologyError`, `AmqpSerializationError`.
+
+Deprecations / behavioral notes:
+
+- The `sync` publish flag is now a no-op in this adapter — confirms are always per-message.
+- `mandatory: true` publishes stamp the `x-connectum-publish-id` header on the wire (visible to external consumers; documented; opt-out available).
+- Dependency: `amqplib` upgraded `^1.0.3` → `^2.0.1`.

--- a/.changeset/remove-publish-sync.md
+++ b/.changeset/remove-publish-sync.md
@@ -1,0 +1,12 @@
+---
+"@connectum/events": minor
+---
+
+Remove `PublishOptions.sync`.
+
+The flag was a no-op: every adapter already confirms publishes per-message
+(NATS `PubAck`, Kafka `producer.send`, Redis `XADD`, AMQP per-message broker
+ack with typed errors on nack/return/timeout). A resolved `publish()` already
+means the broker accepted the message — there was no fire-and-forget mode to
+opt out of. Removed ahead of the first stable release; drop `sync` from any
+`publish()` calls (no behavior change).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,70 @@ jobs:
       - name: Integration tests
         run: pnpm test:integration
 
+  # ── AMQP broker integration (happy path, required) ─────────────────────
+  # Runs the events-amqp happy-path integration tests against a real RabbitMQ
+  # service container. Recovery scenarios live in the non-blocking job below.
+  test-amqp-broker:
+    name: AMQP broker integration
+    runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:4-alpine
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "25.2.0"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: AMQP happy-path integration tests
+        env:
+          AMQP_TEST_URL: amqp://guest:guest@localhost:5672
+        run: pnpm --filter @connectum/events-amqp test:integration
+
+  # ── AMQP connection recovery (testcontainers, non-blocking) ────────────
+  # Recovery scenarios crash/drop the broker mid-test via testcontainers
+  # (programmatic container control). Non-blocking: broker-restart timing can
+  # be environment-sensitive, so a failure here must not gate merges.
+  test-amqp-recovery:
+    name: AMQP recovery (testcontainers)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "25.2.0"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: AMQP recovery tests (testcontainers)
+        env:
+          RUN_RECOVERY_TESTS: "1"
+        run: pnpm --filter @connectum/events-amqp test:integration
+
   # ── Bun runtime tests ──────────────────────────────────────────────────
   test-bun:
     name: Bun (latest)

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -2,7 +2,7 @@
 
 AMQP/RabbitMQ adapter for `@connectum/events`.
 
-**@connectum/events-amqp** connects the Connectum EventBus to [RabbitMQ](https://www.rabbitmq.com/) (AMQP 0-9-1) for durable, at-least-once event delivery with topic exchanges, consumer groups, and dead-letter support.
+**@connectum/events-amqp** connects the Connectum EventBus to [RabbitMQ](https://www.rabbitmq.com/) (AMQP 0-9-1) for durable, at-least-once event delivery with topic exchanges, consumer groups, dead-letter support, explicit external topology, automatic connection recovery, and per-message publisher confirms.
 
 **Layer**: 2 (Tools) | **Node.js**: >=22.13.0 | **License**: Apache-2.0
 
@@ -10,7 +10,12 @@ AMQP/RabbitMQ adapter for `@connectum/events`.
 
 - **Topic Exchange** -- flexible routing via AMQP topic exchange with wildcard patterns
 - **Consumer Groups** -- load-balanced consumption via named queues (competing consumers)
-- **Publisher Confirms** -- optional synchronous publishing with broker acknowledgement
+- **Per-Message Publisher Confirms** -- every publish resolves on its own broker ack and rejects on nack
+- **Explicit Topology** -- declare external exchanges, queues (raw `arguments`, e.g. `x-dead-letter-exchange`), and bindings (including exchange-to-exchange)
+- **Queue Overrides** -- attach a consumer group to an externally named queue from a contract
+- **Automatic Recovery** -- native amqplib v2 connection recovery with backoff and jitter (enabled by default)
+- **Typed Errors** -- every terminal publish/topology outcome is a distinct error class
+- **Serialization Control** -- `contentType` label and optional wire transcoding hooks
 - **Dead Letter Exchange** -- built-in DLX support for rejected messages
 - **Metadata as Headers** -- event metadata mapped to AMQP message headers
 - **Prefetch Control** -- configurable QoS prefetch count per consumer
@@ -67,7 +72,21 @@ const bus = createEventBus({
     },
     publisherOptions: {
       persistent: true,
+      mandatory: false,
     },
+    recovery: {
+      initialDelay: 100,
+      maxDelay: 30000,
+      factor: 2,
+      jitter: 0.2,
+    },
+    lifecycle: {
+      onConnected: () => console.log('AMQP connected'),
+      onDisconnected: (cause) => console.error('AMQP disconnected', cause),
+      onReconnecting: ({ attempt, delay }) => console.warn(`Reconnect #${attempt} in ${delay}ms`),
+      onReconnectFailed: (cause) => console.error('AMQP recovery exhausted', cause),
+    },
+    publishTimeoutMs: 30000,
   }),
   routes: [eventRoutes],
   group: 'worker-group',
@@ -97,9 +116,16 @@ function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter
 | `exchange` | `string` | `'connectum.events'` | Exchange name |
 | `exchangeType` | `'topic' \| 'direct' \| 'fanout' \| 'headers'` | `'topic'` | Exchange type |
 | `exchangeOptions` | `AmqpExchangeOptions` | `{}` | Exchange assertion options |
-| `queueOptions` | `AmqpQueueOptions` | `{}` | Queue assertion options |
+| `queueOptions` | `AmqpQueueOptions` | `{}` | Default queue assertion options |
 | `consumerOptions` | `AmqpConsumerOptions` | `{}` | Consumer options |
 | `publisherOptions` | `AmqpPublisherOptions` | `{}` | Publisher options |
+| `serialization` | `AmqpSerializationOptions` | `{}` | `contentType` label and optional wire transcoding |
+| `topology` | `AmqpTopology` | `undefined` | Explicit topology declared on connect (and after recovery) |
+| `topologyMode` | `'assert' \| 'check' \| 'skip'` | `'assert'` | How topology is established |
+| `queueOverrides` | `Record<string, AmqpQueueOverride>` | `undefined` | Map a consumer group to an externally named queue |
+| `recovery` | `boolean \| AmqpRecoveryOptions` | `true` | Automatic connection recovery (amqplib native); `false` disables |
+| `lifecycle` | `AmqpLifecycleCallbacks` | `undefined` | Connection lifecycle callbacks |
+| `publishTimeoutMs` | `number` | `30000` | Per-publish broker-outcome deadline |
 
 ### AmqpExchangeOptions
 
@@ -130,7 +156,75 @@ function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `persistent` | `boolean` | `true` | Persist messages (deliveryMode=2) |
-| `mandatory` | `boolean` | `false` | Return unroutable messages |
+| `mandatory` | `boolean` | `false` | Reject the publish with `AmqpUnroutableError` if the broker cannot route the message |
+| `correlationHeader` | `boolean` | `true` | Correlate `basic.return` frames via a private `x-connectum-publish-id` header on mandatory publishes; `false` switches to single-flight serialization |
+
+### AmqpSerializationOptions
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `contentType` | `string` | `'application/protobuf'` | AMQP `contentType` message property |
+| `encode` | `(payload: Uint8Array) => Uint8Array` | `undefined` | Transform the outgoing wire body; failures reject the publish with `AmqpSerializationError` |
+| `decode` | `(content: Uint8Array) => Uint8Array` | `undefined` | Transform the incoming wire body before the handler; failures nack the message without requeue |
+
+> The adapter receives payloads as bytes -- the EventBus serializes protobuf upstream. `contentType` is a label, not a converter: setting `'application/json'` does not make the EventBus emit JSON. For external JSON contracts the application publishes pre-serialized bytes through the adapter directly and sets `contentType` accordingly (see [External AMQP Contract](#external-amqp-contract)).
+
+### AmqpTopology
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `exchanges` | `AmqpExchangeDeclaration[]` | Exchanges to declare: `name`, `type`, `durable`, `autoDelete`, raw `arguments` |
+| `queues` | `AmqpQueueDeclaration[]` | Queues to declare: `name`, `durable`, `autoDelete`, `exclusive`, raw `arguments` (e.g. `x-dead-letter-exchange`) |
+| `bindings` | `AmqpBindingDeclaration[]` | Bindings: `source` exchange + `routingKey` to either a `queue` or another `exchange` (exchange-to-exchange) |
+
+Queues declared in `topology.queues` are asserted once (with their full arguments) when topology is applied. `subscribe()` does **not** re-assert them -- it only binds patterns. Re-asserting without the original arguments would be a conflicting redeclare (`PRECONDITION_FAILED` 406).
+
+### Topology Modes
+
+| Mode | Behavior |
+|------|----------|
+| `'assert'` (default) | Declare topology idempotently (`assertExchange` / `assertQueue` / bind) |
+| `'check'` | Existence-only verification (`checkExchange` / `checkQueue`); fails fast with `AmqpTopologyError` on missing objects |
+| `'skip'` | No topology operations; the application owns topology |
+
+> **`check` limitations**: AMQP has no passive introspection. `check` mode verifies only that exchanges and queues *exist* -- argument equivalence and binding presence are NOT verifiable. A conflicting redeclare elsewhere still fails with `PRECONDITION_FAILED` (406).
+
+### AmqpQueueOverride
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `queue` | `string` | required | Externally defined queue name to consume from |
+| `arguments` | `Record<string, unknown>` | `undefined` | Raw AMQP arguments used when asserting the queue (assert mode only) |
+| `durable` | `boolean` | `true` | Queue durability |
+
+By default a consumer group consumes from `${exchange}.${group}`. A `queueOverrides` entry attaches the subscription to a queue from an external contract instead:
+
+```typescript
+queueOverrides: {
+  'partner': { queue: 'partner.inbound.v1' },
+}
+```
+
+### AmqpRecoveryOptions
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `initialDelay` | `number` | `100` | First reconnect delay in ms |
+| `maxDelay` | `number` | `30000` | Delay cap in ms |
+| `factor` | `number` | `2` | Exponential backoff factor |
+| `jitter` | `number` | `0.2` | Randomization factor (0..1) |
+| `maxRetries` | `number` | `Infinity` | Give up after this many attempts |
+
+### AmqpLifecycleCallbacks
+
+| Callback | Signature | Fires when |
+|----------|-----------|------------|
+| `onConnected` | `() => void` | Connection established (initial and after recovery) |
+| `onDisconnected` | `(cause: Error) => void` | Connection lost |
+| `onReconnecting` | `(info: { attempt, delay, error }) => void` | A reconnect attempt is scheduled |
+| `onReconnectFailed` | `(cause: Error) => void` | Recovery exhausted (`maxRetries` reached) |
+
+Connection errors are surfaced through these callbacks -- never console-only.
 
 ## How It Works
 
@@ -160,22 +254,119 @@ Example: "order.>"  →  "order.#"
 
 | Mode | Queue Name | Behavior |
 |------|-----------|----------|
+| With `group` + `queueOverrides[group]` | override `queue` | External contract queue (bound, consumed) |
 | With `group` | `{exchange}.{group}` | Shared, durable, competing consumers |
 | Without `group` | `{exchange}.sub-{uuid}` | Exclusive, auto-delete (fan-out) |
 
 ### Metadata
 
-Event metadata is transmitted as AMQP message headers. Internal headers (`x-event-id`, `x-published-at`) are set on publish and stripped from metadata on delivery.
+Event metadata is transmitted as AMQP message headers. Internal headers (`x-event-id`, `x-published-at`, `x-connectum-publish-id`) are set on publish and stripped from metadata on delivery.
 
-### Publisher Confirms
+### Reliable Publishing (Per-Message Confirms)
 
-When `publishOptions.sync: true`, the adapter uses `ConfirmChannel.waitForConfirms()` to wait for broker acknowledgement before returning.
+The adapter publishes on a confirm channel with **per-message confirms**: every `publish()` resolves when the broker acks that specific message and rejects when the broker nacks it. There is no batching and no `waitForConfirms()` -- each publish has its own outcome.
+
+- A publish with no broker outcome (ack/nack/return/connection loss) within `publishTimeoutMs` (default 30000 ms) rejects with `AmqpPublishTimeoutError`. The message state is then UNKNOWN -- it may or may not have been routed; an at-least-once producer should republish.
+- A publish during a disconnected window (or while recovery is in progress) fails fast with `AmqpConnectionError`. In-flight publishes at the moment of a connection loss also reject with `AmqpConnectionError`.
+
+> **Note**: confirms are always per-message — every `publish()` resolves on its own broker ack (or rejects with a typed error). There is no fire-and-forget mode. (The legacy `sync` flag was removed from `PublishOptions` ahead of the first stable release.)
+
+### Mandatory Publishing and basic.return Correlation
+
+With `publisherOptions.mandatory: true`, an unroutable message (no queue bound for the routing key) rejects the publish with `AmqpUnroutableError` (carries `.routingKey`). The AMQP `basic.return` frame has no delivery tag, so the adapter must correlate returns to publishes:
+
+- **`correlationHeader: true` (default)** -- mandatory publishes are stamped with a private `x-connectum-publish-id` header and returns are matched by it. **The header is visible on the wire to external consumers** -- document it in external contracts.
+- **`correlationHeader: false`** -- no header on the wire; mandatory publishes are serialized (single-flight, at most one outstanding at a time) so correlation stays unambiguous at the cost of throughput.
+
+### Connection Recovery
+
+Recovery is delegated to amqplib v2 native opt-in recovery and is **enabled by default** (`recovery: false` restores single-shot, no-reconnect behavior). On every successful (re)connect the adapter:
+
+1. Re-creates its publish and consumer channels.
+2. Re-applies topology (per `topologyMode`).
+3. Replays all active subscriptions.
+
+Connection behavior:
+
+- **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering.
+- **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable, and a lost connection is not restored.
+
+### Error Taxonomy
+
+Every terminal publish/topology outcome is distinguishable by error class -- what an at-least-once producer needs for an "advance cursor after confirm" pattern:
+
+| Error | Meaning |
+|-------|---------|
+| `AmqpAdapterError` | Base class for all adapter errors |
+| `AmqpConnectionError` | Connection absent, lost, or recovery in progress / exhausted |
+| `AmqpUnroutableError` | Broker returned a `mandatory` message as unroutable (`basic.return`); has `.routingKey` |
+| `AmqpPublishNackError` | Broker negatively acknowledged (nacked) a published message |
+| `AmqpPublishTimeoutError` | No broker outcome within `publishTimeoutMs`; message state UNKNOWN |
+| `AmqpTopologyError` | Topology declaration or verification failed (missing object in `check` mode, conflicting redeclare in `assert` mode) |
+| `AmqpSerializationError` | Payload encoding failed in a custom `serialization.encode` hook |
+
+## External AMQP Contract
+
+A complete recipe for integrating with an externally defined AMQP contract (AsyncAPI-style): direct exchange, named durable queue with DLQ arguments, JSON `contentType`, mandatory routing, and per-message confirms. The application serializes JSON itself and publishes through the adapter directly:
+
+```typescript
+import { AmqpAdapter, AmqpUnroutableError } from '@connectum/events-amqp';
+
+const adapter = AmqpAdapter({
+  url: 'amqp://broker:5672',
+  exchange: 'partner.direct',
+  exchangeType: 'direct',
+  serialization: { contentType: 'application/json' },
+  topology: {
+    exchanges: [{ name: 'partner.dlx', type: 'direct' }],
+    queues: [
+      { name: 'partner.dead.v1', durable: true },
+      {
+        name: 'partner.inbound.v1',
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': 'partner.dlx',
+          'x-dead-letter-routing-key': 'inbound.dead',
+        },
+      },
+    ],
+    bindings: [
+      { queue: 'partner.dead.v1', source: 'partner.dlx', routingKey: 'inbound.dead' },
+      { queue: 'partner.inbound.v1', source: 'partner.direct', routingKey: 'inbound' },
+    ],
+  },
+  queueOverrides: {
+    partner: { queue: 'partner.inbound.v1' },
+  },
+  publisherOptions: { persistent: true, mandatory: true },
+});
+
+await adapter.connect();
+
+// Consume from the external queue (group "partner" → partner.inbound.v1)
+await adapter.subscribe(
+  ['inbound'],
+  async (event, ack) => {
+    const message = JSON.parse(new TextDecoder().decode(event.payload));
+    // ...
+    await ack();
+  },
+  { group: 'partner' },
+);
+
+// Publish pre-serialized JSON bytes; resolves on broker ack,
+// rejects with AmqpUnroutableError if no queue is bound
+const body = new TextEncoder().encode(JSON.stringify({ code: '0104603...' }));
+await adapter.publish('inbound', body);
+```
+
+> **Wire-visible header**: with `mandatory: true` and the default `correlationHeader: true`, every mandatory publish carries a private `x-connectum-publish-id` header that external consumers will see. Either document it in the contract, or set `publisherOptions.correlationHeader: false` for a clean wire (single-flight throughput trade-off).
 
 ## Dependencies
 
 ### External
 
-- `amqplib` -- AMQP 0-9-1 client for Node.js
+- `amqplib` (^2.0.1) -- AMQP 0-9-1 client for Node.js with native connection recovery
 
 ### Peer
 

--- a/packages/events-amqp/package.json
+++ b/packages/events-amqp/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc --noEmit",
     "test": "exodus-test --typescript tests/**/*.test.ts",
     "test:unit": "exodus-test --typescript tests/unit/**/*.test.ts",
+    "test:integration": "exodus-test --typescript tests/integration/**/*.test.ts",
     "test:bun": "exodus-test --engine bun:pure tests/unit/**/*.test.ts",
     "test:esbuild": "exodus-test --esbuild tests/unit/**/*.test.ts",
     "lint": "biome check src",
@@ -48,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "amqplib": "^1.0.3"
+    "amqplib": "^2.0.1"
   },
   "peerDependencies": {
     "@connectum/events": "workspace:^"
@@ -64,6 +65,7 @@
     "@exodus/test": "catalog:",
     "@types/amqplib": "^0.10.8",
     "c8": "catalog:",
+    "testcontainers": "^12.0.1",
     "tsup": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -3,7 +3,9 @@
  *
  * Implements the {@link EventAdapter} interface on top of AMQP 0-9-1 (RabbitMQ),
  * providing at-least-once delivery with topic exchanges, consumer groups via
- * named queues, and dead-letter exchange support.
+ * named queues, dead-letter exchange support, explicit external topology,
+ * automatic connection recovery (amqplib opt-in recovery), and per-message
+ * publisher confirms with `mandatory`/`basic.return` correlation.
  *
  * @module AmqpAdapter
  */
@@ -11,7 +13,9 @@
 import { randomUUID } from "node:crypto";
 import type { AdapterContext, EventAdapter, EventSubscription, PublishOptions, RawEvent, RawEventHandler, RawSubscribeOptions } from "@connectum/events";
 import type amqp from "amqplib";
-import type { AmqpAdapterOptions } from "./types.ts";
+import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
+import type { AmqpAdapterOptions, AmqpQueueOverride } from "./types.ts";
+import { AmqpTopologyMode } from "./types.ts";
 
 /** Default exchange name when none is provided. */
 const DEFAULT_EXCHANGE = "connectum.events";
@@ -21,6 +25,20 @@ const DEFAULT_EXCHANGE_TYPE = "topic";
 
 /** Default prefetch count. */
 const DEFAULT_PREFETCH = 10;
+
+/** Default contentType message property. */
+const DEFAULT_CONTENT_TYPE = "application/protobuf";
+
+/** Default broker-outcome deadline for a single publish (ms). */
+const DEFAULT_PUBLISH_TIMEOUT_MS = 30_000;
+
+/**
+ * Private header used to correlate `basic.return` frames to publishes when
+ * `mandatory: true` (the return frame carries no deliveryTag). Visible on
+ * the wire — documented for external contracts; disable via
+ * `publisherOptions.correlationHeader: false` (switches to single-flight).
+ */
+const PUBLISH_ID_HEADER = "x-connectum-publish-id";
 
 /**
  * Convert an EventBus wildcard pattern to an AMQP routing key pattern.
@@ -56,6 +74,24 @@ function parseHeaders(headers: Record<string, unknown> | undefined): Map<string,
     return map;
 }
 
+/** Internal record of an active subscription, replayable after recovery. */
+interface SubscriptionRecord {
+    readonly patterns: string[];
+    readonly handler: RawEventHandler;
+    readonly subOptions: RawSubscribeOptions | undefined;
+    /** Channel of the CURRENT incarnation (replaced on recovery). */
+    channel: amqp.Channel | null;
+    consumerTag: string | null;
+    queueName: string;
+    isAutoGroup: boolean;
+    active: boolean;
+}
+
+/** Pending mandatory publish awaiting its confirm, keyed by publish id. */
+interface PendingReturn {
+    returned: boolean;
+}
+
 /**
  * Create an AMQP/RabbitMQ adapter for @connectum/events.
  *
@@ -73,159 +109,198 @@ function parseHeaders(headers: Record<string, unknown> | undefined): Map<string,
  * });
  * await bus.start();
  * ```
+ *
+ * @example External AMQP contract (AsyncAPI-style)
+ * ```typescript
+ * const adapter = AmqpAdapter({
+ *     url: "amqp://broker:5672",
+ *     exchange: "partner.direct",
+ *     exchangeType: "direct",
+ *     serialization: { contentType: "application/json" },
+ *     topology: {
+ *         queues: [{
+ *             name: "partner.inbound.v1",
+ *             durable: true,
+ *             arguments: {
+ *                 "x-dead-letter-exchange": "partner.dlx",
+ *                 "x-dead-letter-routing-key": "inbound.dead",
+ *             },
+ *         }],
+ *         bindings: [{ queue: "partner.inbound.v1", source: "partner.direct", routingKey: "inbound" }],
+ *     },
+ *     queueOverrides: { partner: { queue: "partner.inbound.v1" } },
+ *     publisherOptions: { persistent: true, mandatory: true },
+ * });
+ * ```
  */
 export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
     const exchange = options.exchange ?? DEFAULT_EXCHANGE;
     const exchangeType = options.exchangeType ?? DEFAULT_EXCHANGE_TYPE;
+    const topologyMode = options.topologyMode ?? AmqpTopologyMode.ASSERT;
+    const contentType = options.serialization?.contentType ?? DEFAULT_CONTENT_TYPE;
+    const publishTimeoutMs = options.publishTimeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS;
+    const correlationHeader = options.publisherOptions?.correlationHeader ?? true;
+    const lifecycle = options.lifecycle;
 
+    /** The recovering connection wrapper (amqplib opt-in recovery) or a plain connection. */
     let connection: amqp.ChannelModel | null = null;
     let publishChannel: amqp.ConfirmChannel | null = null;
+    let closing = false;
 
-    /** Active subscription handles for cleanup on disconnect. */
-    const activeSubs: EventSubscription[] = [];
+    /** Pending mandatory publishes awaiting confirm (publish-id → return flag). */
+    const pendingReturns = new Map<string, PendingReturn>();
 
-    return {
-        name: "amqp",
+    /** Single-flight chain for mandatory publishes when the header is disabled. */
+    let mandatoryChain: Promise<unknown> = Promise.resolve();
 
-        async connect(context?: AdapterContext): Promise<void> {
-            if (connection) {
-                throw new Error("AmqpAdapter: already connected");
-            }
+    /** Replayable registry of subscriptions (source of truth across recoveries). */
+    const subscriptionRecords: SubscriptionRecord[] = [];
 
-            // Dynamic import to avoid top-level require issues with ESM
-            const amqplib = await import("amqplib");
+    /** Wrap a broker/channel error into AmqpTopologyError with context. */
+    function topologyError(message: string, cause: unknown): AmqpTopologyError {
+        return new AmqpTopologyError(`${message}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause });
+    }
 
-            const clientProperties: Record<string, string> = {};
-            if (context?.serviceName) {
-                clientProperties.connection_name = context.serviceName;
-            }
+    /**
+     * Apply declarative topology on a channel according to `topologyMode`.
+     *
+     * In `check` mode only existence is verifiable (checkExchange/checkQueue);
+     * argument equivalence and bindings cannot be passively inspected (AMQP
+     * has no introspection — a conflicting redeclare is PRECONDITION_FAILED).
+     */
+    async function applyTopology(ch: amqp.ConfirmChannel | amqp.Channel): Promise<void> {
+        if (topologyMode === AmqpTopologyMode.SKIP) {
+            return;
+        }
 
-            const conn = await amqplib.connect(
-                options.url,
-                options.socketOptions
-                    ? {
-                          ...options.socketOptions,
-                          clientProperties: Object.keys(clientProperties).length > 0 ? clientProperties : undefined,
-                      }
-                    : Object.keys(clientProperties).length > 0
-                      ? { clientProperties }
-                      : undefined,
-            );
+        const topo = options.topology;
 
-            // Handle connection-level errors to prevent unhandled rejections
-            conn.on("error", (err: Error) => {
-                console.error("[AmqpAdapter] connection error:", err.message);
-            });
-
-            // Reset closure state on broker-initiated close to prevent stale references
-            conn.on("close", () => {
-                connection = null;
-                publishChannel = null;
-            });
-
+        if (topologyMode === AmqpTopologyMode.CHECK) {
             try {
-                // Create a ConfirmChannel for publisher confirms (sync mode)
-                const ch = await conn.createConfirmChannel();
-
-                // Assert exchange
-                await ch.assertExchange(exchange, exchangeType, {
-                    durable: options.exchangeOptions?.durable ?? true,
-                    autoDelete: options.exchangeOptions?.autoDelete ?? false,
-                });
-
-                // Commit to closure state
-                connection = conn;
-                publishChannel = ch;
+                await ch.checkExchange(exchange);
+                for (const ex of topo?.exchanges ?? []) {
+                    await ch.checkExchange(ex.name);
+                }
+                for (const q of topo?.queues ?? []) {
+                    await ch.checkQueue(q.name);
+                }
             } catch (err) {
-                await conn.close().catch(() => undefined);
+                throw topologyError("Topology check failed (missing broker object)", err);
+            }
+            return;
+        }
+
+        // assert mode
+        try {
+            await ch.assertExchange(exchange, exchangeType, {
+                durable: options.exchangeOptions?.durable ?? true,
+                autoDelete: options.exchangeOptions?.autoDelete ?? false,
+            });
+
+            for (const ex of topo?.exchanges ?? []) {
+                await ch.assertExchange(ex.name, ex.type, {
+                    durable: ex.durable ?? true,
+                    autoDelete: ex.autoDelete ?? false,
+                    arguments: ex.arguments,
+                });
+            }
+            for (const q of topo?.queues ?? []) {
+                await ch.assertQueue(q.name, {
+                    durable: q.durable ?? true,
+                    autoDelete: q.autoDelete ?? false,
+                    exclusive: q.exclusive ?? false,
+                    arguments: q.arguments,
+                });
+            }
+            for (const b of topo?.bindings ?? []) {
+                if (b.queue !== undefined) {
+                    await ch.bindQueue(b.queue, b.source, b.routingKey, b.arguments);
+                } else if (b.exchange !== undefined) {
+                    await ch.bindExchange(b.exchange, b.source, b.routingKey, b.arguments);
+                } else {
+                    throw new Error(`Binding for source '${b.source}' must declare either 'queue' or 'exchange'`);
+                }
+            }
+        } catch (err) {
+            if (err instanceof AmqpTopologyError) {
                 throw err;
             }
-        },
+            throw topologyError("Topology declaration failed", err);
+        }
+    }
 
-        async disconnect(): Promise<void> {
-            // Unsubscribe all active subscriptions first (with error isolation).
-            const unsubResults = await Promise.allSettled([...activeSubs].map((sub) => sub.unsubscribe()));
-            for (const r of unsubResults) {
-                if (r.status === "rejected") {
-                    console.error("[AmqpAdapter] unsubscribe error:", r.reason);
+    /** Reject every pending mandatory-return record (connection lost). */
+    function failPendingReturns(): void {
+        pendingReturns.clear();
+    }
+
+    /**
+     * (Re)create the publish channel with its `return` listener.
+     * Called on every successful (re)connect via the recovery setup hook.
+     */
+    async function setupPublishChannel(model: amqp.ChannelModel): Promise<void> {
+        const ch = await model.createConfirmChannel();
+
+        ch.on("return", (msg: amqp.ConsumeMessage) => {
+            const id = (msg.properties.headers as Record<string, unknown> | undefined)?.[PUBLISH_ID_HEADER];
+            if (typeof id === "string") {
+                const pending = pendingReturns.get(id);
+                if (pending) {
+                    pending.returned = true;
                 }
+                return;
             }
-            activeSubs.length = 0;
-
-            if (publishChannel) {
-                await publishChannel.close().catch(() => undefined);
-                publishChannel = null;
+            // Single-flight mode: at most one mandatory publish is outstanding —
+            // mark the only pending record.
+            for (const pending of pendingReturns.values()) {
+                pending.returned = true;
             }
+        });
 
-            if (connection) {
-                await connection.close().catch(() => undefined);
-                connection = null;
-            }
-        },
+        ch.on("error", () => {
+            // Channel-level errors surface through the connection lifecycle
+            // and through rejected confirm callbacks; nothing to do here, but
+            // the listener prevents unhandled 'error' crashes.
+        });
 
-        async publish(eventType: string, payload: Uint8Array, publishOptions?: PublishOptions): Promise<void> {
-            const ch = publishChannel;
-            if (!ch) {
-                throw new Error("AmqpAdapter: not connected");
-            }
+        publishChannel = ch;
+    }
 
-            const routingKey = eventType;
-            const eventId = randomUUID();
+    /** Start (or re-start after recovery) a consumer for a subscription record. */
+    async function startConsumer(model: amqp.ChannelModel, record: SubscriptionRecord): Promise<void> {
+        const group = record.subOptions?.group;
+        const isAutoGroup = !group;
+        const override: AmqpQueueOverride | undefined = group ? options.queueOverrides?.[group] : undefined;
 
-            // Build headers: user metadata first, then internal
-            const headers: Record<string, string> = {};
+        const ch = await model.createChannel();
+        ch.on("error", () => {
+            // Prevent unhandled 'error' events on consumer channels; failures
+            // surface through recovery or through nacked deliveries.
+        });
 
-            if (publishOptions?.metadata) {
-                for (const [key, value] of Object.entries(publishOptions.metadata)) {
-                    // Skip only internal EventBus headers to prevent spoofing
-                    if (key === "x-event-id" || key === "x-published-at") {
-                        continue;
-                    }
-                    headers[key] = String(value);
+        const prefetch = options.consumerOptions?.prefetch ?? DEFAULT_PREFETCH;
+        await ch.prefetch(prefetch);
+
+        // Resolve queue name: explicit override → external contract queue;
+        // named group → `${exchange}.${group}`; no group → exclusive auto queue.
+        const queueName = override?.queue ?? (group ? `${exchange}.${group}` : `${exchange}.sub-${randomUUID()}`);
+
+        // A queue declared in the explicit topology was already asserted with
+        // its full arguments by applyTopology — re-asserting it here without
+        // those arguments would be PRECONDITION_FAILED (406). Only bind.
+        const declaredInTopology = options.topology?.queues?.some((q) => q.name === queueName) ?? false;
+
+        if (topologyMode === AmqpTopologyMode.ASSERT && declaredInTopology) {
+            try {
+                for (const amqpPattern of record.patterns.map(toAmqpPattern)) {
+                    await ch.bindQueue(queueName, exchange, amqpPattern);
                 }
+            } catch (err) {
+                await ch.close().catch(() => undefined);
+                throw topologyError(`Failed to bind topology-declared queue '${queueName}'`, err);
             }
-
-            headers["x-event-id"] = eventId;
-            headers["x-published-at"] = new Date().toISOString();
-
-            const persistent = options.publisherOptions?.persistent ?? true;
-            const mandatory = options.publisherOptions?.mandatory ?? false;
-
-            const written = ch.publish(exchange, routingKey, Buffer.from(payload), {
-                persistent,
-                mandatory,
-                headers,
-                contentType: "application/protobuf",
-                messageId: eventId,
-                timestamp: Math.trunc(Date.now() / 1000),
-            });
-
-            // Handle back-pressure: wait for channel drain if buffer is full
-            if (!written) {
-                await new Promise<void>((resolve) => ch.once("drain", resolve));
-            }
-
-            if (publishOptions?.sync) {
-                // Wait for broker confirmation
-                await ch.waitForConfirms();
-            }
-        },
-
-        async subscribe(patterns: string[], handler: RawEventHandler, subOptions?: RawSubscribeOptions): Promise<EventSubscription> {
-            if (!connection) {
-                throw new Error("AmqpAdapter: not connected");
-            }
-
-            const isAutoGroup = !subOptions?.group;
-            const group = subOptions?.group;
-
-            // Create a dedicated channel for this subscription
-            const ch = await connection.createChannel();
-
-            const prefetch = options.consumerOptions?.prefetch ?? DEFAULT_PREFETCH;
-            await ch.prefetch(prefetch);
-
-            // Build queue options
+        } else if (topologyMode === AmqpTopologyMode.ASSERT) {
+            // Build queue arguments: global defaults + per-override arguments
             const queueArgs: Record<string, unknown> = {};
             if (options.queueOptions?.messageTtl !== undefined) {
                 queueArgs["x-message-ttl"] = options.queueOptions.messageTtl;
@@ -239,32 +314,43 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             if (options.queueOptions?.deadLetterRoutingKey !== undefined) {
                 queueArgs["x-dead-letter-routing-key"] = options.queueOptions.deadLetterRoutingKey;
             }
-
-            // Named queue for group (shared, competing consumers) or
-            // auto-delete queue for non-group (exclusive fan-out)
-            const queueName = group ? `${exchange}.${group}` : `${exchange}.sub-${randomUUID()}`;
-
-            const queueDurable = options.queueOptions?.durable ?? true;
-            const exclusive = options.consumerOptions?.exclusive ?? false;
-
-            await ch.assertQueue(queueName, {
-                durable: group ? queueDurable : false,
-                autoDelete: isAutoGroup,
-                exclusive: isAutoGroup ? exclusive : false,
-                arguments: Object.keys(queueArgs).length > 0 ? queueArgs : undefined,
-            });
-
-            // Bind queue to exchange for each pattern
-            const amqpPatterns = patterns.map(toAmqpPattern);
-            for (const amqpPattern of amqpPatterns) {
-                await ch.bindQueue(queueName, exchange, amqpPattern);
+            if (override?.arguments) {
+                Object.assign(queueArgs, override.arguments);
             }
 
-            /** Track consumer tags for cancellation. */
-            const consumerTags: string[] = [];
+            const queueDurable = override?.durable ?? options.queueOptions?.durable ?? true;
+            const exclusive = options.consumerOptions?.exclusive ?? false;
 
-            // Start consuming
-            const consumeResult = await ch.consume(
+            try {
+                await ch.assertQueue(queueName, {
+                    durable: group ? queueDurable : false,
+                    autoDelete: isAutoGroup,
+                    exclusive: isAutoGroup ? exclusive : false,
+                    arguments: Object.keys(queueArgs).length > 0 ? queueArgs : undefined,
+                });
+
+                for (const amqpPattern of record.patterns.map(toAmqpPattern)) {
+                    await ch.bindQueue(queueName, exchange, amqpPattern);
+                }
+            } catch (err) {
+                await ch.close().catch(() => undefined);
+                throw topologyError(`Failed to declare queue '${queueName}'`, err);
+            }
+        } else if (topologyMode === AmqpTopologyMode.CHECK) {
+            try {
+                await ch.checkQueue(queueName);
+            } catch (err) {
+                await ch.close().catch(() => undefined);
+                throw topologyError(`Queue '${queueName}' does not exist (topologyMode: "check")`, err);
+            }
+        }
+        // skip mode: no checks — a missing queue fails on consume below.
+
+        const decode = options.serialization?.decode;
+
+        let consumeResult: amqp.Replies.Consume;
+        try {
+            consumeResult = await ch.consume(
                 queueName,
                 (msg: amqp.ConsumeMessage | null) => {
                     if (!msg) {
@@ -282,6 +368,17 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                     // Remove internal headers from metadata
                     msgHeaders.delete("x-event-id");
                     msgHeaders.delete("x-published-at");
+                    msgHeaders.delete(PUBLISH_ID_HEADER);
+
+                    let payload: Uint8Array;
+                    try {
+                        payload = decode ? decode(new Uint8Array(msg.content)) : new Uint8Array(msg.content);
+                    } catch {
+                        // Decode failure — reject without requeue (DLX or drop):
+                        // a payload that cannot be decoded will never succeed.
+                        ch.nack(msg, false, false);
+                        return;
+                    }
 
                     // Attempt: redelivered = at least 2nd delivery
                     const attempt = msg.fields.redelivered ? 2 : 1;
@@ -289,7 +386,7 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                     const rawEvent: RawEvent = {
                         eventId,
                         eventType: msg.fields.routingKey,
-                        payload: new Uint8Array(msg.content),
+                        payload,
                         publishedAt: Number.isFinite(publishedAt.getTime()) ? publishedAt : new Date(),
                         attempt,
                         metadata: msgHeaders,
@@ -308,44 +405,340 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                         }
                     };
 
-                    handler(rawEvent, ack, nack).catch(() => {
+                    record.handler(rawEvent, ack, nack).catch(() => {
                         // Handler error — nack for redelivery
                         ch.nack(msg, false, true);
                     });
                 },
                 { noAck: false },
             );
+        } catch (err) {
+            await ch.close().catch(() => undefined);
+            throw topologyError(`Failed to consume from queue '${queueName}'`, err);
+        }
 
-            consumerTags.push(consumeResult.consumerTag);
+        record.channel = ch;
+        record.consumerTag = consumeResult.consumerTag;
+        record.queueName = queueName;
+        record.isAutoGroup = isAutoGroup;
+    }
+
+    /**
+     * Recovery setup hook: runs on EVERY successful (re)connect before the
+     * wrapper reports the connection ready. Re-creates the publish channel,
+     * re-applies topology, and replays active subscriptions.
+     */
+    async function onSetup(model: amqp.ChannelModel): Promise<void> {
+        failPendingReturns();
+        await setupPublishChannel(model);
+        await applyTopology(publishChannel as amqp.ConfirmChannel);
+
+        for (const record of subscriptionRecords) {
+            if (record.active) {
+                await startConsumer(model, record);
+            }
+        }
+    }
+
+    return {
+        name: "amqp",
+
+        async connect(context?: AdapterContext): Promise<void> {
+            if (connection) {
+                throw new AmqpConnectionError("AmqpAdapter: already connected");
+            }
+            closing = false;
+
+            // Dynamic import to avoid top-level require issues with ESM
+            const amqplib = await import("amqplib");
+
+            const clientProperties: Record<string, string> = {};
+            if (context?.serviceName) {
+                clientProperties.connection_name = context.serviceName;
+            }
+
+            const recoveryEnabled = options.recovery !== false;
+            const recoveryOpts = typeof options.recovery === "object" ? options.recovery : {};
+
+            const connectOptions: Record<string, unknown> = {
+                ...options.socketOptions,
+            };
+            if (Object.keys(clientProperties).length > 0) {
+                connectOptions.clientProperties = clientProperties;
+            }
+            if (recoveryEnabled) {
+                // amqplib opt-in recovery: reconnect with backoff+jitter; our
+                // setup hook re-creates channels/topology/subscriptions.
+                connectOptions.recovery = {
+                    initialDelay: recoveryOpts.initialDelay,
+                    maxDelay: recoveryOpts.maxDelay,
+                    factor: recoveryOpts.factor,
+                    jitter: recoveryOpts.jitter,
+                    maxRetries: recoveryOpts.maxRetries,
+                    setup: onSetup,
+                };
+            }
+
+            const conn = (await amqplib.connect(options.url, connectOptions)) as amqp.ChannelModel;
+
+            // Surface connection lifecycle; never console-only.
+            conn.on("error", (err: Error) => {
+                lifecycle?.onDisconnected?.(err);
+            });
+
+            if (recoveryEnabled) {
+                conn.on("connect", () => {
+                    lifecycle?.onConnected?.();
+                });
+                conn.on("disconnect", (err: Error) => {
+                    failPendingReturns();
+                    lifecycle?.onDisconnected?.(err);
+                });
+                conn.on("reconnect-scheduled", (info: { attempt: number; delay: number; error: Error }) => {
+                    lifecycle?.onReconnecting?.(info);
+                });
+                conn.on("reconnect-failed", (err: Error) => {
+                    publishChannel = null;
+                    lifecycle?.onReconnectFailed?.(err);
+                });
+
+                // With recovery, the wrapper already ran onSetup before resolving.
+                connection = conn;
+                lifecycle?.onConnected?.();
+                return;
+            }
+
+            // recovery: false — legacy single-shot connection.
+            conn.on("close", () => {
+                connection = null;
+                publishChannel = null;
+                failPendingReturns();
+            });
+
+            try {
+                await onSetup(conn);
+                connection = conn;
+                lifecycle?.onConnected?.();
+            } catch (err) {
+                await conn.close().catch(() => undefined);
+                publishChannel = null;
+                throw err;
+            }
+        },
+
+        async disconnect(): Promise<void> {
+            closing = true;
+
+            // Unsubscribe all active subscriptions first (with error isolation).
+            for (const record of subscriptionRecords) {
+                if (record.active && record.channel) {
+                    if (record.consumerTag) {
+                        await record.channel.cancel(record.consumerTag).catch(() => undefined);
+                    }
+                    if (record.isAutoGroup) {
+                        await record.channel.deleteQueue(record.queueName).catch(() => undefined);
+                    }
+                    await record.channel.close().catch(() => undefined);
+                }
+                record.active = false;
+                record.channel = null;
+                record.consumerTag = null;
+            }
+            subscriptionRecords.length = 0;
+
+            if (publishChannel) {
+                await publishChannel.close().catch(() => undefined);
+                publishChannel = null;
+            }
+
+            if (connection) {
+                await connection.close().catch(() => undefined);
+                connection = null;
+            }
+            failPendingReturns();
+        },
+
+        async publish(eventType: string, payload: Uint8Array, publishOptions?: PublishOptions): Promise<void> {
+            const ch = publishChannel;
+            if (!ch || closing) {
+                throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
+            }
+
+            const routingKey = eventType;
+            const eventId = randomUUID();
+
+            // Build headers: user metadata first, then internal
+            const headers: Record<string, string> = {};
+
+            if (publishOptions?.metadata) {
+                for (const [key, value] of Object.entries(publishOptions.metadata)) {
+                    // Skip only internal EventBus headers to prevent spoofing
+                    if (key === "x-event-id" || key === "x-published-at" || key === PUBLISH_ID_HEADER) {
+                        continue;
+                    }
+                    headers[key] = String(value);
+                }
+            }
+
+            headers["x-event-id"] = eventId;
+            headers["x-published-at"] = new Date().toISOString();
+
+            const persistent = options.publisherOptions?.persistent ?? true;
+            const mandatory = options.publisherOptions?.mandatory ?? false;
+
+            let body: Buffer;
+            try {
+                const encode = options.serialization?.encode;
+                const encoded = encode ? encode(payload) : payload;
+                body = Buffer.from(encoded);
+            } catch (err) {
+                throw new AmqpSerializationError(`Payload encoding failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+            }
+
+            // basic.return correlation (mandatory only): header stamping by
+            // default; single-flight serialization when the header is disabled.
+            // Frame ordering alone is NOT reliable — returns carry no
+            // deliveryTag and confirms of other messages may interleave.
+            const publishId: string | null = mandatory ? eventId : null;
+            if (mandatory && correlationHeader) {
+                headers[PUBLISH_ID_HEADER] = eventId;
+            }
+
+            const doPublish = async (): Promise<void> => {
+                const pending: PendingReturn = { returned: false };
+                if (publishId !== null) {
+                    pendingReturns.set(publishId, pending);
+                }
+
+                try {
+                    await new Promise<void>((resolve, reject) => {
+                        let settled = false;
+                        const settle = (fn: () => void): void => {
+                            if (!settled) {
+                                settled = true;
+                                clearTimeout(timer);
+                                fn();
+                            }
+                        };
+
+                        const timer = setTimeout(() => {
+                            settle(() =>
+                                reject(new AmqpPublishTimeoutError(`No broker outcome within ${publishTimeoutMs}ms for routing key '${routingKey}' (message state UNKNOWN)`)),
+                            );
+                        }, publishTimeoutMs);
+
+                        let written: boolean;
+                        try {
+                            written = ch.publish(
+                                exchange,
+                                routingKey,
+                                body,
+                                {
+                                    persistent,
+                                    mandatory,
+                                    headers,
+                                    contentType,
+                                    messageId: eventId,
+                                    timestamp: Math.trunc(Date.now() / 1000),
+                                },
+                                (err) => {
+                                    // Per-message confirm callback (ack/nack). The broker
+                                    // guarantees basic.return arrives BEFORE the confirm of
+                                    // the same message — check the return flag first.
+                                    settle(() => {
+                                        if (err) {
+                                            reject(
+                                                closing || publishChannel !== ch
+                                                    ? new AmqpConnectionError("Connection lost while awaiting publish confirm", { cause: err })
+                                                    : new AmqpPublishNackError(`Broker nacked message for routing key '${routingKey}'`, { cause: err }),
+                                            );
+                                        } else if (pending.returned) {
+                                            reject(new AmqpUnroutableError(`Message unroutable (mandatory): no queue bound for routing key '${routingKey}'`, routingKey));
+                                        } else {
+                                            resolve();
+                                        }
+                                    });
+                                },
+                            );
+                        } catch (err) {
+                            settle(() => reject(new AmqpConnectionError(`Publish failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })));
+                            return;
+                        }
+
+                        // Back-pressure: the in-memory buffer is full. The confirm
+                        // callback still fires; nothing extra to await here.
+                        void written;
+                    });
+                } finally {
+                    if (publishId !== null) {
+                        pendingReturns.delete(publishId);
+                    }
+                }
+            };
+
+            // Confirms are always per-message: every publish resolves on its
+            // own broker ack (or rejects with a typed error).
+            if (mandatory && !correlationHeader) {
+                // Single-flight: serialize mandatory publishes so the headerless
+                // return frame is unambiguously the outstanding one.
+                const run = mandatoryChain.then(doPublish, doPublish);
+                mandatoryChain = run.catch(() => undefined);
+                return run;
+            }
+
+            return doPublish();
+        },
+
+        async subscribe(patterns: string[], handler: RawEventHandler, subOptions?: RawSubscribeOptions): Promise<EventSubscription> {
+            if (!connection) {
+                throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
+            }
+
+            const record: SubscriptionRecord = {
+                patterns,
+                handler,
+                subOptions,
+                channel: null,
+                consumerTag: null,
+                queueName: "",
+                isAutoGroup: !subOptions?.group,
+                active: true,
+            };
+
+            await startConsumer(connection, record);
+            subscriptionRecords.push(record);
 
             const subscription: EventSubscription = {
                 async unsubscribe(): Promise<void> {
-                    // Cancel consumers
-                    for (const tag of consumerTags) {
-                        await ch.cancel(tag).catch(() => undefined);
+                    record.active = false;
+
+                    const ch = record.channel;
+                    if (ch) {
+                        if (record.consumerTag) {
+                            await ch.cancel(record.consumerTag).catch(() => undefined);
+                        }
+
+                        // Delete auto-generated queues to prevent broker-side leak
+                        if (record.isAutoGroup) {
+                            await ch.deleteQueue(record.queueName).catch(() => undefined);
+                        }
+
+                        // Do not unbind patterns for named groups — the queue is durable
+                        // and shared across multiple consumers. Unbinding would break
+                        // delivery to other active consumers on the same group.
+
+                        await ch.close().catch(() => undefined);
                     }
-                    consumerTags.length = 0;
+                    record.channel = null;
+                    record.consumerTag = null;
 
-                    // Delete auto-generated queues to prevent broker-side leak
-                    if (isAutoGroup) {
-                        await ch.deleteQueue(queueName).catch(() => undefined);
-                    }
-
-                    // Do not unbind patterns for named groups — the queue is durable
-                    // and shared across multiple consumers. Unbinding would break
-                    // delivery to other active consumers on the same group.
-
-                    await ch.close().catch(() => undefined);
-
-                    // Remove from the active subscriptions list
-                    const idx = activeSubs.indexOf(subscription);
+                    const idx = subscriptionRecords.indexOf(record);
                     if (idx !== -1) {
-                        activeSubs.splice(idx, 1);
+                        subscriptionRecords.splice(idx, 1);
                     }
                 },
             };
 
-            activeSubs.push(subscription);
             return subscription;
         },
     };

--- a/packages/events-amqp/src/errors.ts
+++ b/packages/events-amqp/src/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Typed error taxonomy for the AMQP adapter.
+ *
+ * Every terminal publish/topology outcome is distinguishable by error class,
+ * which is what an at-least-once producer needs for an
+ * "advance cursor after confirm" pattern: a non-advanced message corresponds
+ * to exactly one typed error explaining why.
+ *
+ * @module errors
+ */
+
+/** Base class for all AMQP adapter errors. */
+export class AmqpAdapterError extends Error {
+    constructor(message: string, options?: { cause?: unknown }) {
+        super(message, options);
+        this.name = new.target.name;
+    }
+}
+
+/**
+ * Connection is absent, lost, or recovery is in progress / exhausted.
+ * Publishes during a disconnected window fail fast with this error;
+ * in-flight confirms are rejected with it on connection loss.
+ */
+export class AmqpConnectionError extends AmqpAdapterError {}
+
+/**
+ * The broker returned a `mandatory` message as unroutable
+ * (`basic.return`): no queue is bound for the routing key.
+ */
+export class AmqpUnroutableError extends AmqpAdapterError {
+    readonly routingKey: string;
+
+    constructor(message: string, routingKey: string) {
+        super(message);
+        this.routingKey = routingKey;
+    }
+}
+
+/** The broker negatively acknowledged (nacked) a published message. */
+export class AmqpPublishNackError extends AmqpAdapterError {}
+
+/**
+ * No broker outcome (ack/nack/return/connection loss) arrived within
+ * `publishTimeoutMs`. The message state is UNKNOWN — it may or may not
+ * have been routed; an at-least-once producer should republish.
+ */
+export class AmqpPublishTimeoutError extends AmqpAdapterError {}
+
+/**
+ * Topology declaration or verification failed: missing exchange/queue in
+ * `check`/`skip` mode, or a conflicting redeclare (PRECONDITION_FAILED) in
+ * `assert` mode.
+ */
+export class AmqpTopologyError extends AmqpAdapterError {}
+
+/** Payload encoding/decoding failed in a custom serialization hook. */
+export class AmqpSerializationError extends AmqpAdapterError {}

--- a/packages/events-amqp/src/index.ts
+++ b/packages/events-amqp/src/index.ts
@@ -25,10 +25,20 @@
  */
 
 export { AmqpAdapter, toAmqpPattern } from "./AmqpAdapter.ts";
+export { AmqpAdapterError, AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
 export type {
     AmqpAdapterOptions,
+    AmqpBindingDeclaration,
     AmqpConsumerOptions,
+    AmqpExchangeDeclaration,
     AmqpExchangeOptions,
+    AmqpLifecycleCallbacks,
     AmqpPublisherOptions,
+    AmqpQueueDeclaration,
     AmqpQueueOptions,
+    AmqpQueueOverride,
+    AmqpRecoveryOptions,
+    AmqpSerializationOptions,
+    AmqpTopology,
 } from "./types.ts";
+export { AmqpTopologyMode } from "./types.ts";

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -53,6 +53,178 @@ export interface AmqpAdapterOptions {
      * Publisher options.
      */
     readonly publisherOptions?: AmqpPublisherOptions;
+
+    /**
+     * Message serialization metadata and optional wire transcoding.
+     *
+     * The adapter receives payloads as bytes (the EventBus serializes
+     * protobuf upstream); this option controls the AMQP `contentType`
+     * property and lets an application transcode the wire body — e.g. when
+     * the application serializes JSON itself and publishes through the
+     * adapter directly against an external AsyncAPI contract.
+     */
+    readonly serialization?: AmqpSerializationOptions;
+
+    /**
+     * Explicit topology to declare on connect (and re-declare after
+     * recovery): exchanges, queues with arbitrary external names and raw
+     * arguments (e.g. `x-dead-letter-exchange`), and bindings — including
+     * exchange-to-exchange.
+     */
+    readonly topology?: AmqpTopology;
+
+    /**
+     * How topology is established:
+     * - `"assert"` (default) — declare idempotently (assertExchange/assertQueue/bind);
+     * - `"check"` — existence-only verification (checkExchange/checkQueue), fail
+     *   fast with AmqpTopologyError on missing objects. AMQP offers no passive
+     *   introspection: argument equivalence and binding presence are NOT
+     *   verifiable in this mode (a conflicting redeclare elsewhere is
+     *   PRECONDITION_FAILED 406);
+     * - `"skip"` — no topology operations at all; the application owns topology.
+     *
+     * @default "assert"
+     */
+    readonly topologyMode?: AmqpTopologyMode;
+
+    /**
+     * Map a consumer group name to an externally-named queue.
+     *
+     * By default a group consumes from `${exchange}.${group}`. An override
+     * lets a subscription attach to a queue from an external contract
+     * (with its own arguments) instead.
+     */
+    readonly queueOverrides?: Record<string, AmqpQueueOverride>;
+
+    /**
+     * Automatic connection recovery (delegated to amqplib's opt-in
+     * recovery). Enabled by default; pass `false` to restore
+     * no-reconnect behavior.
+     *
+     * On every (re)connect the adapter re-creates its channels, re-applies
+     * topology (per `topologyMode`), and replays active subscriptions.
+     * In-flight publishes at the moment of a connection loss reject with
+     * `AmqpConnectionError`.
+     *
+     * @default true (amqplib defaults: 100ms initial, ×2, 30s cap, jitter 0.2, infinite retries)
+     */
+    readonly recovery?: boolean | AmqpRecoveryOptions;
+
+    /**
+     * Connection lifecycle callbacks. Connection errors are surfaced here —
+     * not just logged.
+     */
+    readonly lifecycle?: AmqpLifecycleCallbacks;
+
+    /**
+     * Per-publish broker-outcome deadline in milliseconds. A publish whose
+     * ack/nack/return/connection-loss outcome does not arrive in time
+     * rejects with `AmqpPublishTimeoutError` (message state UNKNOWN — an
+     * at-least-once producer should republish).
+     *
+     * @default 30000
+     */
+    readonly publishTimeoutMs?: number;
+}
+
+/** Topology establishment mode. */
+export const AmqpTopologyMode = {
+    ASSERT: "assert",
+    CHECK: "check",
+    SKIP: "skip",
+} as const;
+
+export type AmqpTopologyMode = (typeof AmqpTopologyMode)[keyof typeof AmqpTopologyMode];
+
+/** Serialization metadata and optional wire transcoding. */
+export interface AmqpSerializationOptions {
+    /**
+     * AMQP `contentType` message property.
+     *
+     * @default "application/protobuf"
+     */
+    readonly contentType?: string;
+
+    /**
+     * Transform the outgoing wire body. Receives the payload bytes the
+     * EventBus (or the application) produced. Failures reject the publish
+     * with `AmqpSerializationError`.
+     */
+    readonly encode?: (payload: Uint8Array) => Uint8Array;
+
+    /**
+     * Transform the incoming wire body before it reaches the event handler.
+     * Failures nack the message (requeue per consumer policy).
+     */
+    readonly decode?: (content: Uint8Array) => Uint8Array;
+}
+
+/** Declarative topology. */
+export interface AmqpTopology {
+    readonly exchanges?: readonly AmqpExchangeDeclaration[];
+    readonly queues?: readonly AmqpQueueDeclaration[];
+    readonly bindings?: readonly AmqpBindingDeclaration[];
+}
+
+export interface AmqpExchangeDeclaration {
+    readonly name: string;
+    readonly type: "topic" | "direct" | "fanout" | "headers";
+    readonly durable?: boolean;
+    readonly autoDelete?: boolean;
+    /** Raw AMQP arguments passthrough. */
+    readonly arguments?: Record<string, unknown>;
+}
+
+export interface AmqpQueueDeclaration {
+    readonly name: string;
+    readonly durable?: boolean;
+    readonly autoDelete?: boolean;
+    readonly exclusive?: boolean;
+    /** Raw AMQP arguments passthrough (e.g. x-dead-letter-exchange). */
+    readonly arguments?: Record<string, unknown>;
+}
+
+export interface AmqpBindingDeclaration {
+    /** Destination queue name (queue binding) — mutually exclusive with `exchange`. */
+    readonly queue?: string;
+    /** Destination exchange name (exchange-to-exchange binding). */
+    readonly exchange?: string;
+    /** Source exchange. */
+    readonly source: string;
+    readonly routingKey: string;
+    readonly arguments?: Record<string, unknown>;
+}
+
+/** External queue override for a consumer group. */
+export interface AmqpQueueOverride {
+    /** Externally-defined queue name to consume from. */
+    readonly queue: string;
+    /** Raw AMQP arguments used when asserting the queue (assert mode only). */
+    readonly arguments?: Record<string, unknown>;
+    /** @default true */
+    readonly durable?: boolean;
+}
+
+/** Recovery knobs (passed through to amqplib's opt-in recovery). */
+export interface AmqpRecoveryOptions {
+    /** @default 100 */
+    readonly initialDelay?: number;
+    /** @default 30000 */
+    readonly maxDelay?: number;
+    /** @default 2 */
+    readonly factor?: number;
+    /** 0..1 @default 0.2 */
+    readonly jitter?: number;
+    /** @default Infinity */
+    readonly maxRetries?: number;
+}
+
+/** Connection lifecycle callbacks. */
+export interface AmqpLifecycleCallbacks {
+    readonly onConnected?: () => void;
+    readonly onDisconnected?: (cause: Error) => void;
+    readonly onReconnecting?: (info: { attempt: number; delay: number; error: Error }) => void;
+    readonly onReconnectFailed?: (cause: Error) => void;
 }
 
 /**
@@ -139,8 +311,24 @@ export interface AmqpPublisherOptions {
 
     /**
      * Whether the message should be returned if it cannot be routed.
+     * Unroutable messages reject the publish with `AmqpUnroutableError`.
      *
      * @default false
      */
     readonly mandatory?: boolean;
+
+    /**
+     * How `basic.return` frames are correlated to publishes when
+     * `mandatory: true`. The return frame carries no deliveryTag, so:
+     *
+     * - `true` (default): stamp a private `x-connectum-publish-id` header on
+     *   mandatory publishes and match returns by it. The header is visible
+     *   on the wire to external consumers — document it in contracts.
+     * - `false`: no header; mandatory publishes are serialized
+     *   (single-flight) so at most one is outstanding at a time —
+     *   correlation is unambiguous at the cost of throughput.
+     *
+     * @default true
+     */
+    readonly correlationHeader?: boolean;
 }

--- a/packages/events-amqp/tests/integration/amqp-broker.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-broker.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Happy-path integration tests against a real RabbitMQ broker.
+ *
+ * Skipped unless AMQP_TEST_URL is set, e.g.:
+ *   docker run -d --name connectum-amqp-test -p 15672:5672 rabbitmq:4-alpine
+ *   AMQP_TEST_URL=amqp://guest:guest@localhost:15672 pnpm test
+ *
+ * These require only a reachable broker (no container control), so they run in
+ * CI against a `services: rabbitmq` container. Connection-recovery scenarios
+ * (which must crash/restart the broker mid-test) live in amqp-recovery.test.ts
+ * and use testcontainers for programmatic lifecycle control.
+ *
+ * Covers: per-message confirms, mandatory/basic.return correlation (header +
+ * single-flight), external topology (assert/check/skip), exchange-to-exchange
+ * bindings, serialization contentType, custom transcoding, publish timeout.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { AmqpAdapter } from "../../src/AmqpAdapter.ts";
+import { AmqpTopologyError, AmqpUnroutableError } from "../../src/errors.ts";
+
+const AMQP_URL = process.env.AMQP_TEST_URL;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Wait until `cond` returns true or `timeoutMs` elapses. */
+async function waitFor(cond: () => boolean, timeoutMs = 10_000): Promise<void> {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error("waitFor: condition not met in time");
+        }
+        await sleep(100);
+    }
+}
+
+describe("AMQP broker integration", { skip: AMQP_URL === undefined ? "AMQP_TEST_URL not set" : false, concurrency: 1 }, () => {
+    const url = AMQP_URL as string;
+
+    it("per-message confirm: publish resolves on broker ack", async () => {
+        const adapter = AmqpAdapter({ url, exchange: "it.confirms", recovery: false });
+        await adapter.connect();
+        try {
+            await adapter.publish("it.confirms.ok", new Uint8Array([1, 2, 3]));
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("mandatory + header correlation: unroutable rejects, concurrent routable resolve", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.mandatory",
+            exchangeType: "topic",
+            recovery: false,
+            publisherOptions: { mandatory: true },
+        });
+        await adapter.connect();
+        try {
+            // Bind a queue for ONE routing key only
+            const sub = await adapter.subscribe(["it.mandatory.bound"], async (_e, ack) => ack(), { group: "g1" });
+
+            const results = await Promise.allSettled([
+                adapter.publish("it.mandatory.bound", new Uint8Array([1])),
+                adapter.publish("it.mandatory.UNBOUND", new Uint8Array([2])),
+                adapter.publish("it.mandatory.bound", new Uint8Array([3])),
+            ]);
+
+            assert.equal(results[0]?.status, "fulfilled", "routable #1 must resolve");
+            assert.equal(results[2]?.status, "fulfilled", "routable #3 must resolve");
+            assert.equal(results[1]?.status, "rejected", "unroutable must reject");
+            assert.ok(
+                (results[1] as PromiseRejectedResult).reason instanceof AmqpUnroutableError,
+                `expected AmqpUnroutableError, got: ${(results[1] as PromiseRejectedResult).reason}`,
+            );
+
+            await sub.unsubscribe();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("mandatory + single-flight (correlationHeader: false): correlation stays correct", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.singleflight",
+            exchangeType: "topic",
+            recovery: false,
+            publisherOptions: { mandatory: true, correlationHeader: false },
+        });
+        await adapter.connect();
+        try {
+            const sub = await adapter.subscribe(["it.singleflight.bound"], async (_e, ack) => ack(), { group: "g1" });
+
+            const results = await Promise.allSettled([
+                adapter.publish("it.singleflight.bound", new Uint8Array([1])),
+                adapter.publish("it.singleflight.UNBOUND", new Uint8Array([2])),
+                adapter.publish("it.singleflight.bound", new Uint8Array([3])),
+            ]);
+
+            assert.equal(results[0]?.status, "fulfilled");
+            assert.equal(results[1]?.status, "rejected");
+            assert.ok((results[1] as PromiseRejectedResult).reason instanceof AmqpUnroutableError);
+            assert.equal(results[2]?.status, "fulfilled");
+
+            await sub.unsubscribe();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("single-flight leaves the wire clean (no x-connectum-publish-id header)", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.cleanwire",
+            exchangeType: "topic",
+            recovery: false,
+            publisherOptions: { mandatory: true, correlationHeader: false },
+        });
+        await adapter.connect();
+        try {
+            const seen: Array<ReadonlyMap<string, string>> = [];
+            const sub = await adapter.subscribe(
+                ["it.cleanwire.evt"],
+                async (event, ack) => {
+                    seen.push(event.metadata);
+                    await ack();
+                },
+                { group: "g1" },
+            );
+
+            await adapter.publish("it.cleanwire.evt", new Uint8Array([7]));
+            await waitFor(() => seen.length === 1);
+
+            // metadata strips internal headers anyway — verify no stray id key
+            assert.equal(seen[0]?.has("x-connectum-publish-id"), false);
+
+            await sub.unsubscribe();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("external topology: DLQ-argument queue + queueOverrides consume + JSON contentType", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "partner.direct",
+            exchangeType: "direct",
+            recovery: false,
+            serialization: { contentType: "application/json" },
+            topology: {
+                exchanges: [{ name: "partner.dlx", type: "direct" }],
+                queues: [
+                    { name: "partner.dead.v1", durable: true },
+                    {
+                        name: "partner.inbound.v1",
+                        durable: true,
+                        arguments: {
+                            "x-dead-letter-exchange": "partner.dlx",
+                            "x-dead-letter-routing-key": "inbound.dead",
+                        },
+                    },
+                ],
+                bindings: [
+                    { queue: "partner.dead.v1", source: "partner.dlx", routingKey: "inbound.dead" },
+                    { queue: "partner.inbound.v1", source: "partner.direct", routingKey: "inbound" },
+                ],
+            },
+            queueOverrides: {
+                partner: { queue: "partner.inbound.v1" },
+            },
+        });
+        await adapter.connect();
+        try {
+            const received: Array<{ payload: Uint8Array }> = [];
+            const sub = await adapter.subscribe(
+                ["inbound"],
+                async (event, ack) => {
+                    received.push({ payload: event.payload });
+                    await ack();
+                },
+                { group: "partner" },
+            );
+
+            const body = new TextEncoder().encode(JSON.stringify({ code: "0104603..." }));
+            await adapter.publish("inbound", body);
+
+            await waitFor(() => received.length === 1);
+            assert.equal(new TextDecoder().decode(received[0]?.payload), '{"code":"0104603..."}');
+
+            await sub.unsubscribe();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("publishTimeoutMs: missing broker outcome rejects with AmqpPublishTimeoutError", async () => {
+        const { AmqpPublishTimeoutError } = await import("../../src/errors.ts");
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.timeout",
+            recovery: false,
+            // 0ms deadline fires on the next tick — always before the broker's
+            // network round-trip delivers the confirm.
+            publishTimeoutMs: 0,
+        });
+        await adapter.connect();
+        try {
+            await assert.rejects(
+                () => adapter.publish("it.timeout.evt", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpPublishTimeoutError,
+            );
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("custom encode/decode hooks: wire transcoding round-trip", async () => {
+        // XOR transform — distinguishable from identity on the wire
+        const xor = (bytes: Uint8Array): Uint8Array => bytes.map((b) => b ^ 0x5a);
+
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.transcode",
+            exchangeType: "topic",
+            recovery: false,
+            serialization: { contentType: "application/octet-stream", encode: xor, decode: xor },
+        });
+        await adapter.connect();
+        try {
+            const received: Uint8Array[] = [];
+            const sub = await adapter.subscribe(
+                ["it.transcode.evt"],
+                async (event, ack) => {
+                    received.push(event.payload);
+                    await ack();
+                },
+                { group: "g1" },
+            );
+
+            const original = new TextEncoder().encode("round-trip");
+            await adapter.publish("it.transcode.evt", original);
+
+            await waitFor(() => received.length === 1);
+            assert.equal(new TextDecoder().decode(received[0]), "round-trip");
+
+            await sub.unsubscribe();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("exchange-to-exchange binding routes through both exchanges", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.e2e.ingress",
+            exchangeType: "topic",
+            recovery: false,
+            topology: {
+                exchanges: [{ name: "it.e2e.audit", type: "topic" }],
+                bindings: [{ exchange: "it.e2e.audit", source: "it.e2e.ingress", routingKey: "#" }],
+            },
+            queueOverrides: { audit: { queue: "it.e2e.audit.q" } },
+        });
+        await adapter.connect();
+        try {
+            // Consume from a queue bound to the DOWNSTREAM exchange
+            const consumer = AmqpAdapter({
+                url,
+                exchange: "it.e2e.audit",
+                exchangeType: "topic",
+                recovery: false,
+            });
+            await consumer.connect();
+
+            const received: string[] = [];
+            const sub = await consumer.subscribe(
+                ["it.e2e.evt"],
+                async (event, ack) => {
+                    received.push(event.eventType);
+                    await ack();
+                },
+                { group: "audit" },
+            );
+
+            // Publish to the UPSTREAM exchange — must route through e2e binding
+            await adapter.publish("it.e2e.evt", new Uint8Array([1]));
+
+            await waitFor(() => received.length === 1);
+            assert.equal(received[0], "it.e2e.evt");
+
+            await sub.unsubscribe();
+            await consumer.disconnect();
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("topologyMode check: passes on existing objects, fails fast on missing queue", async () => {
+        // Objects exist from the previous test (durable)
+        const ok = AmqpAdapter({
+            url,
+            exchange: "partner.direct",
+            recovery: false,
+            topologyMode: "check",
+            topology: { queues: [{ name: "partner.inbound.v1" }] },
+        });
+        await ok.connect();
+        await ok.disconnect();
+
+        const missing = AmqpAdapter({
+            url,
+            exchange: "partner.direct",
+            recovery: false,
+            topologyMode: "check",
+            topology: { queues: [{ name: "it.does.not.exist" }] },
+        });
+        await assert.rejects(
+            () => missing.connect(),
+            (err: unknown) => err instanceof AmqpTopologyError,
+        );
+    });
+
+    // Connection-recovery scenarios (broker drop/restart mid-test) are in
+    // amqp-recovery.test.ts — they need programmatic container control.
+});

--- a/packages/events-amqp/tests/integration/amqp-recovery.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-recovery.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Connection-recovery integration tests using testcontainers.
+ *
+ * Unlike amqp-broker.test.ts (which only needs a reachable broker), these
+ * scenarios drop client connections at the broker mid-test, so they manage a
+ * RabbitMQ container programmatically (`container.exec` → rabbitmqctl). Gated
+ * behind RUN_RECOVERY_TESTS=1 (set in the non-blocking CI job) so a plain
+ * `pnpm test` without Docker stays green.
+ *
+ * Covers the recovery × ConfirmChannel gate from the
+ * events-amqp-external-contract change:
+ * 1. connection drop → reconnect restores publishing and consuming
+ * 2. publish-while-disconnected fails fast (recovery disabled)
+ * 3. reconnect-during-publish (mid-confirm) → the in-flight promise settles
+ *    (never hangs), rejecting with a typed connection/timeout error
+ * 4. topology mismatch on assert → AmqpTopologyError (PRECONDITION_FAILED 406)
+ * 5. reconnect-during-subscribe → consumer is replayed and resumes delivery
+ */
+
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { connect } from "amqplib";
+import { GenericContainer, type StartedTestContainer } from "testcontainers";
+import { AmqpAdapter } from "../../src/AmqpAdapter.ts";
+import { AmqpConnectionError, AmqpPublishTimeoutError, AmqpTopologyError } from "../../src/errors.ts";
+
+const RUN = process.env.RUN_RECOVERY_TESTS === "1";
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(cond: () => boolean, timeoutMs = 20_000): Promise<void> {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error("waitFor: condition not met in time");
+        }
+        await sleep(100);
+    }
+}
+
+describe("AMQP connection recovery (testcontainers)", { skip: RUN ? false : "RUN_RECOVERY_TESTS != 1", concurrency: 1 }, () => {
+    let container: StartedTestContainer;
+    let url: string;
+
+    /**
+     * Force-drop all client connections at the broker without restarting it.
+     * The broker stays up (port stable, no cold start), so recovery reconnects
+     * immediately — this exercises the reconnect + ConfirmChannel/consumer
+     * re-creation path deterministically. (A full broker restart would also
+     * test topology re-declaration but is slow and flaky on a cold RabbitMQ.)
+     */
+    async function dropConnections(): Promise<void> {
+        const res = await container.exec(["rabbitmqctl", "close_all_connections", "test-drop"]);
+        if (res.exitCode !== 0) {
+            throw new Error(`close_all_connections failed (${res.exitCode}): ${res.output}`);
+        }
+    }
+
+    before(async () => {
+        container = await new GenericContainer("rabbitmq:4-alpine").withExposedPorts(5672).start();
+        url = `amqp://guest:guest@${container.getHost()}:${container.getMappedPort(5672)}`;
+    });
+
+    after(async () => {
+        await container?.stop();
+    });
+
+    it("connection drop → reconnect restores publishing and consuming", async () => {
+        const lifecycle: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.restart",
+            exchangeType: "topic",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            lifecycle: {
+                onConnected: () => lifecycle.push("connected"),
+                onDisconnected: () => lifecycle.push("disconnected"),
+                onReconnecting: () => lifecycle.push("reconnecting"),
+                onReconnectFailed: () => lifecycle.push("reconnect-failed"),
+            },
+        });
+        await adapter.connect();
+        try {
+            const received: string[] = [];
+            await adapter.subscribe(
+                ["rec.restart.evt"],
+                async (event, ack) => {
+                    received.push(new TextDecoder().decode(event.payload));
+                    await ack();
+                },
+                { group: "g" },
+            );
+
+            await adapter.publish("rec.restart.evt", new TextEncoder().encode("before"));
+            await waitFor(() => received.length === 1);
+
+            await dropConnections();
+            await waitFor(() => lifecycle.includes("disconnected"));
+            await waitFor(() => lifecycle.filter((e) => e === "connected").length >= 2);
+
+            // Confirm channel and consumer must have been re-created by setup
+            await adapter.publish("rec.restart.evt", new TextEncoder().encode("after"));
+            await waitFor(() => received.length === 2);
+
+            assert.deepEqual(received, ["before", "after"]);
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("publish while disconnected fails fast with AmqpConnectionError (recovery disabled)", async () => {
+        const adapter = AmqpAdapter({ url, exchange: "rec.failfast", recovery: false });
+        await adapter.connect();
+        try {
+            await dropConnections();
+            await sleep(1000); // let the close event propagate
+
+            await assert.rejects(
+                () => adapter.publish("rec.failfast.evt", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpConnectionError,
+            );
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("reconnect during publish (mid-confirm): in-flight promise settles, never hangs", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.midconfirm",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            // Finite timeout proves "settles, never hangs" even in the worst case
+            publishTimeoutMs: 8000,
+        });
+        await adapter.connect();
+        try {
+            // Fire a batch of publishes, then drop connections underneath them.
+            // The key invariant: every in-flight publish promise SETTLES
+            // (resolve or typed reject) — none hangs forever.
+            const inflight = Array.from({ length: 20 }, (_, i) => adapter.publish("rec.midconfirm.evt", new TextEncoder().encode(`m${i}`)).then(
+                () => ({ ok: true as const }),
+                (err: unknown) => ({ ok: false as const, err }),
+            ));
+            await sleep(50);
+            await dropConnections();
+
+            const settled = await Promise.race([
+                Promise.all(inflight),
+                sleep(15_000).then(() => "TIMED_OUT" as const),
+            ]);
+
+            assert.notEqual(settled, "TIMED_OUT", "in-flight publishes must settle, not hang");
+            const results = settled as Array<{ ok: true } | { ok: false; err: unknown }>;
+            // Any rejection must be a typed connection/timeout error, never a raw hang or untyped throw
+            for (const r of results) {
+                if (!r.ok) {
+                    assert.ok(
+                        r.err instanceof AmqpConnectionError || r.err instanceof AmqpPublishTimeoutError,
+                        `unexpected rejection type: ${r.err}`,
+                    );
+                }
+            }
+
+            // After recovery the adapter must publish again (retry until the
+            // connection is back up)
+            let publishedAfter = false;
+            for (let attempt = 0; attempt < 100 && !publishedAfter; attempt++) {
+                try {
+                    await adapter.publish("rec.midconfirm.evt", new TextEncoder().encode("post"));
+                    publishedAfter = true;
+                } catch {
+                    await sleep(200);
+                }
+            }
+            assert.ok(publishedAfter, "adapter must publish again after recovery");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("topology mismatch on assert → AmqpTopologyError (PRECONDITION_FAILED 406)", async () => {
+        // Pre-declare a durable queue with one argument set via a throwaway connection.
+        const pre = await connect(url);
+        const ch = await pre.createChannel();
+        await ch.assertQueue("rec.contract.q", { durable: true, arguments: { "x-max-length": 100 } });
+        await ch.close();
+        await pre.close();
+
+        // Adapter asserts the SAME queue with a conflicting argument → 406.
+        // applyTopology is the same code path used by the recovery setup callback,
+        // so this also covers "mismatch on re-assert".
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.contract",
+            exchangeType: "direct",
+            recovery: false,
+            topology: {
+                queues: [{ name: "rec.contract.q", durable: true, arguments: { "x-max-length": 999 } }],
+            },
+        });
+
+        await assert.rejects(
+            () => adapter.connect(),
+            (err: unknown) => err instanceof AmqpTopologyError,
+        );
+        await adapter.disconnect().catch(() => undefined);
+    });
+
+    it("reconnect during subscribe: consumer is replayed and resumes delivery", async () => {
+        const lifecycle: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.resub",
+            exchangeType: "topic",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            lifecycle: {
+                onConnected: () => lifecycle.push("connected"),
+                onDisconnected: () => lifecycle.push("disconnected"),
+            },
+        });
+        await adapter.connect();
+        try {
+            const received: string[] = [];
+            await adapter.subscribe(
+                ["rec.resub.evt"],
+                async (event, ack) => {
+                    received.push(new TextDecoder().decode(event.payload));
+                    await ack();
+                },
+                { group: "g" },
+            );
+
+            // Restart BEFORE any message — exercises subscription replay on recovery
+            await dropConnections();
+            await waitFor(() => lifecycle.includes("disconnected"));
+            await waitFor(() => lifecycle.filter((e) => e === "connected").length >= 2);
+
+            await adapter.publish("rec.resub.evt", new TextEncoder().encode("after-resub"));
+            await waitFor(() => received.length === 1);
+
+            assert.deepEqual(received, ["after-resub"]);
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+});

--- a/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
@@ -95,7 +95,7 @@ describe("AmqpAdapter", () => {
         const adapter = AmqpAdapter({ url: "amqp://localhost:5672" });
         await assert.rejects(
             () => adapter.publish("test.event", new Uint8Array([1, 2, 3])),
-            { message: "AmqpAdapter: not connected" },
+            { message: "AmqpAdapter: not connected (or recovery in progress)" },
         );
     });
 
@@ -103,7 +103,7 @@ describe("AmqpAdapter", () => {
         const adapter = AmqpAdapter({ url: "amqp://localhost:5672" });
         await assert.rejects(
             () => adapter.subscribe(["test.>"], async () => {}),
-            { message: "AmqpAdapter: not connected" },
+            { message: "AmqpAdapter: not connected (or recovery in progress)" },
         );
     });
 
@@ -154,7 +154,9 @@ describe("AmqpAdapter AdapterContext", () => {
     });
 
     it("connect() accepts AdapterContext without TypeError", async () => {
-        const adapter = AmqpAdapter({ url: "amqp://invalid-host:5672" });
+        // recovery: false — with recovery enabled (default), connect() retries
+        // with backoff until the broker appears instead of rejecting.
+        const adapter = AmqpAdapter({ url: "amqp://invalid-host:5672", recovery: false });
 
         // connect() will fail (no broker), but should accept the context
         // without throwing TypeError. The serviceName is mapped to
@@ -172,7 +174,9 @@ describe("AmqpAdapter AdapterContext", () => {
     });
 
     it("connect() works with undefined context (backward compat)", async () => {
-        const adapter = AmqpAdapter({ url: "amqp://invalid-host:5672" });
+        // recovery: false — with recovery enabled (default), connect() retries
+        // with backoff until the broker appears instead of rejecting.
+        const adapter = AmqpAdapter({ url: "amqp://invalid-host:5672", recovery: false });
 
         // Calling connect() without context should still work (minus broker availability)
         await assert.rejects(

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -59,8 +59,6 @@ export interface RawSubscribeOptions {
 export interface PublishOptions {
     /** Override topic name (default: schema.typeName) */
     topic?: string;
-    /** Wait for broker confirmation (default: false = fire-and-forget) */
-    sync?: boolean;
     /** Named group tag for workflow grouping */
     group?: string;
     /** Additional metadata / headers */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,8 +297,8 @@ importers:
   packages/events-amqp:
     dependencies:
       amqplib:
-        specifier: ^1.0.3
-        version: 1.0.3
+        specifier: ^2.0.1
+        version: 2.0.1
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -315,6 +315,9 @@ importers:
       c8:
         specifier: 'catalog:'
         version: 10.1.3
+      testcontainers:
+        specifier: ^12.0.1
+        version: 12.0.1
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
@@ -700,6 +703,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1209,6 +1215,11 @@ packages:
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
     engines: {node: '>=12.10.0'}
 
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@grpc/proto-loader@0.8.0':
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
@@ -1276,6 +1287,9 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
   '@lambdalisue/connectrpc-grpcreflect@0.5.0':
     resolution: {integrity: sha512-OisIo84Kmv4sTIFSC8v6sFxlj7H22g8uvRScqFz8ZIWEhNdg7rJK60G05EdQo5juNSK0KzG+x31TieikgQotog==}
@@ -1687,6 +1701,12 @@ packages:
   '@types/amqplib@0.10.8':
     resolution: {integrity: sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1705,8 +1725,20 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1731,6 +1763,10 @@ packages:
   '@ungap/url-search-params@0.2.2':
     resolution: {integrity: sha512-qQsguKXZVKdCixOHX9jqnX/K/1HekPDpGKyEcXHT+zR6EjGA7S4boSuelL4uuPv6YfhN0n8c4UxW+v/Z3gM2iw==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -1743,8 +1779,8 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
-  amqplib@1.0.3:
-    resolution: {integrity: sha512-nsrXa59tvX4HPjPPW8JJGuBb/Db0MOq3DOhGdSbIY7bTsQDMV2fmF9c3i74g/8Gt9+QWyrxfEPppOOoV9lK1uQ==}
+  amqplib@2.0.1:
+    resolution: {integrity: sha512-a3P2MgfCf9nzVis12VxWEn0dS6hcqve7dlEAhXDtIWR27BlhtMkILOc+H9aeHjDi6i6r94dYKc2Kx2OFe3avvg==}
     engines: {node: '>=18'}
 
   ansi-colors@4.1.3:
@@ -1774,6 +1810,14 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1787,12 +1831,21 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1863,9 +1916,15 @@ packages:
     resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1886,17 +1945,29 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
-  buffer-more-ints@1.0.0:
-    resolution: {integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==}
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   c8@10.1.3:
     resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
@@ -1947,6 +2018,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   chromium-bidi@14.0.0:
     resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
     peerDependencies:
@@ -1985,6 +2059,10 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -2011,6 +2089,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
@@ -2027,6 +2108,19 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2074,6 +2168,18 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@5.0.0:
+    resolution: {integrity: sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==}
+    engines: {node: '>= 14.17'}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -2167,6 +2273,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -2242,6 +2352,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -2276,6 +2389,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2454,6 +2571,10 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -2465,6 +2586,9 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2553,6 +2677,10 @@ packages:
     resolution: {integrity: sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==}
     engines: {node: '>=14.0.0'}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -2586,6 +2714,9 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -2651,6 +2782,14 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -2663,6 +2802,9 @@ packages:
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nan@2.27.0:
+    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
@@ -2683,6 +2825,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2857,9 +3003,23 @@ packages:
     resolution: {integrity: sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
 
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
@@ -2911,9 +3071,19 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2946,6 +3116,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -2957,6 +3131,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3008,6 +3185,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3039,8 +3219,18 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -3062,6 +3252,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3087,8 +3280,15 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
@@ -3107,6 +3307,9 @@ packages:
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
+
+  testcontainers@12.0.1:
+    resolution: {integrity: sha512-EMjjfMNJf3HlL7V3elkxqKUO1r3CtqNBTdmKGwwma/lOtUGfoWvFJ0WQ/KQf1DHEMnRjLWzW4cXbv/Tndsbcbw==}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -3132,6 +3335,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3178,6 +3385,9 @@ packages:
     resolution: {integrity: sha512-lCPgus1NuTiBdaITWqzSH/Ff6HVL8HHGBtOXHg1dHRfcshN79XkygSdh0M6g8b0td91ILLG5MTkLOkp5UvyPJw==}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
@@ -3218,8 +3428,15 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3315,6 +3532,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3489,6 +3710,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
     optional: true
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@0.2.3':
     optional: true
@@ -4033,6 +4256,13 @@ snapshots:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
 
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
@@ -4114,6 +4344,12 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@lambdalisue/connectrpc-grpcreflect@0.5.0':
     dependencies:
@@ -4500,6 +4736,17 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 25.6.0
+      '@types/ssh2': 1.15.5
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
@@ -4520,9 +4767,26 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/stack-utils@2.0.3':
     optional: true
@@ -4552,6 +4816,10 @@ snapshots:
   '@ungap/url-search-params@0.2.2':
     optional: true
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4:
@@ -4564,9 +4832,7 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  amqplib@1.0.3:
-    dependencies:
-      buffer-more-ints: 1.0.0
+  amqplib@2.0.1: {}
 
   ansi-colors@4.1.3: {}
 
@@ -4585,6 +4851,30 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.2.0
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -4594,6 +4884,10 @@ snapshots:
   array-ify@1.0.0: {}
 
   array-union@2.1.0: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assert@2.1.0:
     dependencies:
@@ -4609,18 +4903,20 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  async-lock@1.4.1: {}
+
+  async@3.2.6: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
     optional: true
 
-  b4a@1.8.1:
-    optional: true
+  b4a@1.8.1: {}
 
   balanced-match@4.0.4: {}
 
-  bare-events@2.8.2:
-    optional: true
+  bare-events@2.8.2: {}
 
   bare-fs@4.7.1:
     dependencies:
@@ -4632,15 +4928,12 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
-  bare-os@3.9.1:
-    optional: true
+  bare-os@3.9.1: {}
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.9.1
-    optional: true
 
   bare-stream@2.13.1(bare-events@2.8.2):
     dependencies:
@@ -4650,15 +4943,12 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   bare-url@2.4.2:
     dependencies:
       bare-path: 3.0.0
-    optional: true
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.27:
     optional: true
@@ -4666,9 +4956,19 @@ snapshots:
   basic-ftp@5.2.2:
     optional: true
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -4695,18 +4995,27 @@ snapshots:
   buffer-crc32@0.2.13:
     optional: true
 
-  buffer-more-ints@1.0.0: {}
+  buffer-crc32@1.0.0: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
     optional: true
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
+
+  byline@5.0.0: {}
 
   c8@10.1.3:
     dependencies:
@@ -4776,6 +5085,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
   chromium-bidi@14.0.0(devtools-protocol@0.0.1595872):
     dependencies:
       devtools-protocol: 0.0.1595872
@@ -4811,6 +5122,14 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
@@ -4833,6 +5152,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  core-util-is@1.0.3: {}
+
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/node': 25.6.0
@@ -4848,6 +5169,19 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.27.0
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4896,6 +5230,30 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  docker-compose@1.4.2:
+    dependencies:
+      yaml: 2.8.4
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@5.0.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.5.5
+      tar-fs: 2.1.4
+    transitivePeerDependencies:
+      - supports-color
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -4921,7 +5279,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enquirer@2.4.1:
     dependencies:
@@ -5002,15 +5359,15 @@ snapshots:
   esutils@2.0.3:
     optional: true
 
+  event-target-shim@5.0.1: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
-    optional: true
 
-  events@3.3.0:
-    optional: true
+  events@3.3.0: {}
 
   expect@30.3.0:
     dependencies:
@@ -5037,8 +5394,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-fifo@1.3.2:
-    optional: true
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -5100,6 +5456,8 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -5142,6 +5500,8 @@ snapshots:
       hasown: 2.0.3
       math-intrinsics: 1.1.0
     optional: true
+
+  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -5271,8 +5631,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -5289,8 +5648,7 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@6.0.0: {}
 
@@ -5359,6 +5717,8 @@ snapshots:
       hasown: 2.0.3
     optional: true
 
+  is-stream@2.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -5369,6 +5729,8 @@ snapshots:
     optional: true
 
   is-windows@1.0.2: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -5473,6 +5835,10 @@ snapshots:
 
   kafkajs@2.2.4: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -5498,6 +5864,8 @@ snapshots:
   lodash.isarguments@3.1.0: {}
 
   lodash.startcase@4.4.0: {}
+
+  lodash@4.18.1: {}
 
   long@5.3.2: {}
 
@@ -5559,6 +5927,10 @@ snapshots:
   mitt@3.0.1:
     optional: true
 
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@3.0.1: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -5576,6 +5948,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nan@2.27.0:
+    optional: true
+
   netmask@2.1.1:
     optional: true
 
@@ -5588,6 +5963,8 @@ snapshots:
 
   node-releases@2.0.38:
     optional: true
+
+  normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
 
@@ -5616,7 +5993,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   os-browserify@0.3.0:
     optional: true
@@ -5753,8 +6129,25 @@ snapshots:
       react-is: 18.3.1
     optional: true
 
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
+
   progress@2.0.3:
     optional: true
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   protobufjs@7.5.5:
     dependencies:
@@ -5797,7 +6190,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -5844,12 +6236,33 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 10.2.3
 
   readdirp@4.1.2: {}
 
@@ -5869,6 +6282,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0:
     optional: true
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 
@@ -5907,8 +6322,9 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1:
-    optional: true
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -5975,6 +6391,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
     optional: true
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -6007,7 +6425,22 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split-ca@1.0.1: {}
+
   sprintf-js@1.0.3: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.27.0
 
   stack-utils@2.0.6:
     dependencies:
@@ -6030,7 +6463,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   string-width@4.2.3:
     dependencies:
@@ -6044,10 +6476,13 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -6073,6 +6508,13 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
   tar-fs@3.1.2:
     dependencies:
       pump: 3.0.4
@@ -6084,7 +6526,14 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-    optional: true
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tar-stream@3.2.0:
     dependencies:
@@ -6096,7 +6545,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-    optional: true
 
   teex@1.0.1:
     dependencies:
@@ -6104,7 +6552,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   term-size@2.2.1: {}
 
@@ -6121,12 +6568,34 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.3
 
+  testcontainers@12.0.1:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.4.2
+      dockerode: 5.0.0
+      get-port: 7.2.0
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.2
+      tmp: 0.2.7
+      undici: 7.27.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   thenify-all@1.6.0:
     dependencies:
@@ -6149,6 +6618,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6207,6 +6678,8 @@ snapshots:
       '@turbo/windows-64': 2.9.12
       '@turbo/windows-arm64': 2.9.12
 
+  tweetnacl@0.14.5: {}
+
   tweetnacl@1.0.3: {}
 
   typed-query-selector@2.12.2:
@@ -6237,7 +6710,11 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  undici-types@5.26.5: {}
+
   undici-types@7.19.2: {}
+
+  undici@7.27.2: {}
 
   universalify@0.1.2: {}
 
@@ -6254,8 +6731,7 @@ snapshots:
       qs: 6.15.1
     optional: true
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
 
   util@0.12.5:
     dependencies:
@@ -6312,8 +6788,7 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   ws@8.20.0:
     optional: true
@@ -6344,6 +6819,12 @@ snapshots:
     optional: true
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod@3.25.76:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,18 +1,26 @@
 packages:
   - packages/*
 
+allowBuilds:
+  '@biomejs/biome': true
+  '@bufbuild/buf': true
+  cpu-features: false
+  esbuild: true
+  protobufjs: true
+  ssh2: false
+
 catalog:
   '@biomejs/biome': ^2.3.15
   '@bufbuild/buf': ^1.65.0
   '@bufbuild/protobuf': ^2.11.0
   '@bufbuild/protoc-gen-es': ^2.11.0
   '@bufbuild/protovalidate': ^1.1.1
-  '@exodus/test': ^1.0.0-rc.116
   '@commitlint/cli': ^20.4.1
   '@commitlint/config-conventional': ^20.4.1
   '@connectrpc/connect': ^2.1.1
   '@connectrpc/connect-node': ^2.1.1
   '@connectrpc/validate': ^0.2.0
+  '@exodus/test': ^1.0.0-rc.116
   '@opentelemetry/api': ^1.9.0
   '@opentelemetry/api-logs': ^0.215.0
   '@opentelemetry/auto-instrumentations-node': ^0.69.0
@@ -38,19 +46,13 @@ catalog:
   tsup: ^8.5.0
   typescript: ^5.9.3
   zod: ^4.3.6
-
-allowBuilds:
-  '@biomejs/biome': true
-  '@bufbuild/buf': true
-  esbuild: true
-  protobufjs: true
 overrides:
   ajv@<8.18.0: 8.18.0
-  minimatch@<10.2.3: 10.2.3
   basic-ftp@<5.2.2: 5.2.2
-  rollup@>=4.0.0 <4.59.0: 4.59.0
+  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  minimatch@<10.2.3: 10.2.3
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
   protobufjs@<7.5.5: 7.5.5
   protobufjs@>=8.0.0 <8.0.1: 8.0.1
+  rollup@>=4.0.0 <4.59.0: 4.59.0


### PR DESCRIPTION
## Summary
Makes `@connectum/events-amqp` usable against an externally agreed AMQP contract and resilient to broker outages:

- **Serialization**: adapter-level `contentType` + `encode`/`decode` wire hooks
- **Topology**: explicit declaration (`topologyMode` assert/check/skip, external names, raw arguments, exchange-to-exchange bindings) + `queueOverrides`
- **Recovery**: amqplib v2 native opt-in recovery — lifecycle events, re-asserted topology, replayed subscriptions
- **Reliable publishing**: per-message confirms, `publishTimeoutMs`, mandatory/`basic.return` correlation (`x-connectum-publish-id` header or single-flight), typed error taxonomy

Also **removes the no-op `PublishOptions.sync`** from `@connectum/events` (ahead of first stable release; ADR-027) and adds a two-tier CI: required RabbitMQ happy-path job + non-blocking testcontainers recovery job. `amqplib` `^1.0.3` → `^2.0.1`.

Changesets included. From an external production feedback protocol.

> Stacked on #129 (`chore/require-node-22`); base will retarget to `main` after #129 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)