### PR TITLE
feat(interceptors)!: opt-in resilience defaults + circuit breaker error classification

### DIFF
--- a/.changeset/circuit-breaker-failure-predicate.md
+++ b/.changeset/circuit-breaker-failure-predicate.md
@@ -1,0 +1,26 @@
+---
+"@connectum/interceptors": major
+---
+
+**BREAKING** (behavioral, ×2): explicit-over-hidden resilience defaults and infrastructure-only circuit breaker classification.
+
+1. **`createDefaultInterceptors()` no longer enables resilience interceptors implicitly.** `timeout`, `bulkhead`, `circuitBreaker`, and `retry` now default to disabled; only `errorHandler` and `validation` remain enabled by default. Hidden behavioral logic is unacceptable — enable each interceptor explicitly:
+
+   ```typescript
+   // Before (implicit): createDefaultInterceptors()
+   // After (explicit):
+   createDefaultInterceptors({
+     timeout: true,
+     bulkhead: true,
+     circuitBreaker: true,
+     retry: true,
+   });
+   ```
+
+2. **Circuit breaker now classifies errors.** Only infrastructure codes trip the breaker by default (`unknown`, `deadline_exceeded`, `internal`, `unavailable`, `data_loss`, `resource_exhausted`, plus non-`ConnectError` values). Business codes (`invalid_argument`, `not_found`, `failed_precondition`, `already_exists`, ...) no longer open the circuit, and in half-open state they close it. New `failurePredicate(error, defaultPredicate)` option composes with or replaces the default policy; `defaultFailurePredicate` is exported. Restore legacy all-errors counting with:
+
+   ```typescript
+   createCircuitBreakerInterceptor({ failurePredicate: () => true });
+   ```
+
+The circuit breaker is repositioned in the docs as an outbound/client-transport pattern; for inbound protection prefer explicit `timeout` + `bulkhead`. Guaranteed ordering: the breaker wraps retry, so one logical request increments the failure counter at most once.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -399,10 +399,10 @@ AuthzEffect.DENY   // 'deny'
 
 ## Interceptor Chain Order
 
-Auth interceptors should be placed **after** the default interceptor chain (error handler, timeout, bulkhead, etc.) and **before** business logic:
+Auth interceptors should be placed **after** the default interceptor chain (error handler and validation by default, plus any resilience interceptors you explicitly enable) and **before** business logic:
 
 ```text
-errorHandler -> timeout -> bulkhead -> circuitBreaker -> retry -> validation -> auth -> authz -> handler
+errorHandler -> [timeout -> bulkhead -> circuitBreaker -> retry, opt-in] -> validation -> auth -> authz -> handler
 ```
 
 ```typescript

--- a/packages/interceptors/README.md
+++ b/packages/interceptors/README.md
@@ -31,7 +31,7 @@ pnpm add @connectrpc/connect @bufbuild/protobuf
 
 ## Default interceptor chain
 
-The package provides a ready-made chain of 8 interceptors with a fixed order:
+The package provides a chain factory for 8 interceptors with a fixed order:
 
 ```
 errorHandler -> timeout -> bulkhead -> circuitBreaker -> retry -> fallback -> validation -> serializer
@@ -40,24 +40,79 @@ errorHandler -> timeout -> bulkhead -> circuitBreaker -> retry -> fallback -> va
 | # | Interceptor | Default | Purpose |
 |---|-------------|---------|---------|
 | 1 | errorHandler | enabled | Catch-all error normalization (must be first) |
-| 2 | timeout | enabled (30s) | Enforce deadline before processing starts |
-| 3 | bulkhead | enabled (10/10) | Concurrency limiting |
-| 4 | circuitBreaker | enabled (5 failures) | Cascading failure prevention |
-| 5 | retry | enabled (3 attempts) | Retry transient failures with exponential backoff |
-| 6 | fallback | **disabled** | Graceful degradation (requires a handler function) |
+| 2 | timeout | **opt-in** (30s when enabled) | Enforce deadline before processing starts |
+| 3 | bulkhead | **opt-in** (10/10 when enabled) | Concurrency limiting |
+| 4 | circuitBreaker | **opt-in** (5 failures when enabled) | Cascading failure prevention (outbound pattern, see below) |
+| 5 | retry | **opt-in** (3 attempts when enabled) | Retry transient failures with exponential backoff |
+| 6 | fallback | **opt-in** | Graceful degradation (requires a handler function) |
 | 7 | validation | enabled | `@connectrpc/validate` (`createValidateInterceptor()`) |
-| 8 | serializer | **disabled** | JSON serialization of protobuf responses |
+| 8 | serializer | **opt-in** | JSON serialization of protobuf responses |
 
-**Why this order:**
+**No hidden behavioral logic.** Only structural interceptors (errorHandler,
+validation) are enabled by default. Resilience interceptors (timeout,
+bulkhead, circuitBreaker, retry) alter request behavior and must be enabled
+explicitly — implicitly enabled resilience caused a confirmed production
+incident (a server-side circuit breaker tripped by expected business errors).
+
+**Why this order** (applies to whichever interceptors you enable; `interceptors[0]` is outermost in Connect-ES):
 
 1. **errorHandler** -- outer layer, catches all errors from the entire chain
 2. **timeout** -- fail fast for slow requests before processing starts
 3. **bulkhead** -- limit concurrent load to protect resources
-4. **circuitBreaker** -- fast rejection during cascading failures
+4. **circuitBreaker** -- fast rejection during cascading failures; **wraps retry**, so one logical request increments the failure counter at most once regardless of retry attempts (guaranteed)
 5. **retry** -- retry for transient failures
 6. **fallback** -- last chance for graceful degradation
 7. **validation** -- verify data correctness before business logic
 8. **serializer** -- serialize response (innermost)
+
+## Circuit breaker: placement and error classification
+
+The circuit breaker is an **outbound/client-side pattern**: it protects the
+caller from a sick upstream (fail fast instead of waiting on timeouts) and
+gives that upstream room to recover. On a server's inbound stack it
+degenerates into error-rate load shedding — for inbound protection prefer
+explicit `timeout` + `bulkhead`.
+
+```typescript
+// Recommended: circuit breaker on an outbound client transport
+import { createConnectTransport } from "@connectrpc/connect-node";
+import { createCircuitBreakerInterceptor } from "@connectum/interceptors";
+
+const transport = createConnectTransport({
+  baseUrl: "http://upstream:5000",
+  interceptors: [
+    createCircuitBreakerInterceptor({ threshold: 5, halfOpenAfter: 30_000 }),
+  ],
+});
+```
+
+**Error classification.** By default only infrastructure errors count as
+circuit failures: `Unknown`, `DeadlineExceeded`, `Internal`, `Unavailable`,
+`DataLoss`, `ResourceExhausted` (plus any non-`ConnectError` thrown value).
+Business codes (`invalid_argument`, `not_found`, `failed_precondition`,
+`already_exists`, ...) are expected responses of a healthy service: they
+never open the breaker, and in half-open state they close it (the upstream
+answered — it is alive).
+
+Customize with `failurePredicate(error, defaultPredicate)` — the default is
+passed in for composition:
+
+```typescript
+import { Code, ConnectError } from "@connectrpc/connect";
+import { createCircuitBreakerInterceptor, defaultFailurePredicate } from "@connectum/interceptors";
+
+// Exclude upstream per-client rate limits from tripping the breaker
+createCircuitBreakerInterceptor({
+  failurePredicate: (err, def) =>
+    def(err) && !(err instanceof ConnectError && err.code === Code.ResourceExhausted),
+});
+
+// Restore legacy behavior (every error trips the breaker)
+createCircuitBreakerInterceptor({ failurePredicate: () => true });
+```
+
+A predicate that throws is fail-closed: the error counts as a failure and the
+original upstream error is propagated to the caller.
 
 ## Quick Start
 
@@ -74,11 +129,10 @@ const server = createServer({
   services: [routes],
   port: 5000,
 
-  // Default chain with custom options
+  // errorHandler + validation by default; resilience is opt-in
   interceptors: createDefaultInterceptors({
-    timeout: { duration: 10000 },    // Custom timeout
-    retry: false,                    // Disable retry
-    // rest use defaults
+    timeout: { duration: 10000 },    // Explicitly enable timeout
+    bulkhead: true,                  // Explicitly enable bulkhead (10/10)
   }),
 });
 
@@ -108,8 +162,11 @@ const server = createServer({
 import { createDefaultInterceptors } from "@connectum/interceptors";
 import { createConnectTransport } from "@connectrpc/connect-node";
 
+// On an outbound transport the full resilience set makes sense —
+// enable each interceptor explicitly
 const interceptors = createDefaultInterceptors({
   timeout: { duration: 10000 },
+  circuitBreaker: { threshold: 5 },
   retry: { maxRetries: 5 },
   fallback: {
     handler: () => ({ data: [] }),
@@ -573,6 +630,10 @@ interface CircuitBreakerOptions {
   threshold?: number;       // default: 5
   halfOpenAfter?: number;   // default: 30000
   skipStreaming?: boolean;  // default: true
+  // Classify whether an error counts as a circuit failure. Receives the
+  // default predicate for composition. Default: defaultFailurePredicate
+  // (infrastructure codes only). See "Circuit breaker" above.
+  failurePredicate?: (error: unknown, defaultPredicate: (error: unknown) => boolean) => boolean;
 }
 ```
 
@@ -762,7 +823,18 @@ const interceptor = createValidateInterceptor();
 
 ### Changes in default chain
 
-Resilience interceptors (timeout, bulkhead, circuitBreaker, retry, fallback) are now **included** in the default chain (previously optional). Fallback remains disabled by default.
+Resilience interceptors (timeout, bulkhead, circuitBreaker, retry) are **opt-in**: a bare `createDefaultInterceptors()` enables only errorHandler and validation. Enable resilience explicitly:
+
+```typescript
+createDefaultInterceptors({
+  timeout: true,
+  bulkhead: true,
+  circuitBreaker: true,
+  retry: true,
+});
+```
+
+The circuit breaker additionally classifies errors (infrastructure codes only by default) — restore the legacy all-errors behavior with `failurePredicate: () => true`. See [Circuit breaker: placement and error classification](#circuit-breaker-placement-and-error-classification).
 
 ## Dependencies
 

--- a/packages/interceptors/src/circuit-breaker.ts
+++ b/packages/interceptors/src/circuit-breaker.ts
@@ -8,8 +8,38 @@
 
 import type { Interceptor } from "@connectrpc/connect";
 import { Code, ConnectError } from "@connectrpc/connect";
-import { BrokenCircuitError, ConsecutiveBreaker, circuitBreaker, handleAll } from "cockatiel";
+import { BrokenCircuitError, ConsecutiveBreaker, circuitBreaker, handleWhen } from "cockatiel";
 import type { CircuitBreakerOptions } from "./types.ts";
+
+/**
+ * Connect codes that count as circuit failures by default.
+ *
+ * Only infrastructure-level codes are listed: business codes
+ * (invalid_argument, not_found, failed_precondition, already_exists, ...)
+ * are expected responses of a healthy service and must never trip the
+ * breaker. ResourceExhausted is included because, on an outbound call, it is
+ * an honest "upstream degrading / stop sending" signal; exclude it via a
+ * custom failurePredicate when the upstream uses it for per-client quotas.
+ */
+const INFRASTRUCTURE_CODES: ReadonlySet<Code> = new Set([Code.Unknown, Code.DeadlineExceeded, Code.Internal, Code.Unavailable, Code.DataLoss, Code.ResourceExhausted]);
+
+/**
+ * Default circuit-failure classification.
+ *
+ * A ConnectError counts as a failure only when its code is an infrastructure
+ * code (Unknown, DeadlineExceeded, Internal, Unavailable, DataLoss,
+ * ResourceExhausted). Any non-ConnectError thrown value counts as a failure:
+ * unknown transport or runtime faults must still protect the upstream.
+ *
+ * Exported so custom predicates can compose with it — it is also passed as
+ * the second argument to {@link CircuitBreakerOptions.failurePredicate}.
+ */
+export function defaultFailurePredicate(error: unknown): boolean {
+    if (error instanceof ConnectError) {
+        return INFRASTRUCTURE_CODES.has(error.code);
+    }
+    return true;
+}
 
 /**
  * Create circuit breaker interceptor
@@ -22,30 +52,19 @@ import type { CircuitBreakerOptions } from "./types.ts";
  * - Open (failing): Requests rejected immediately
  * - Half-Open (testing): Single request allowed to test recovery
  *
+ * By default only infrastructure errors trip the breaker (see
+ * {@link defaultFailurePredicate}); business codes like invalid_argument or
+ * not_found never do. Customize via {@link CircuitBreakerOptions.failurePredicate}.
+ *
+ * The circuit breaker is an outbound/client-side pattern: it protects the
+ * caller from a sick upstream and gives that upstream room to recover. On a
+ * server's inbound stack it degenerates into error-rate load shedding —
+ * prefer timeout + bulkhead for inbound protection.
+ *
  * @param options - Circuit breaker options
  * @returns ConnectRPC interceptor
  *
- * @example Server-side usage with createServer
- * ```typescript
- * import { createServer } from '@connectum/core';
- * import { createCircuitBreakerInterceptor } from '@connectum/interceptors';
- * import { myRoutes } from './routes.js';
- *
- * const server = createServer({
- *   services: [myRoutes],
- *   interceptors: [
- *     createCircuitBreakerInterceptor({
- *       threshold: 5,           // Open after 5 consecutive failures
- *       halfOpenAfter: 30000,   // Try again after 30 seconds
- *       skipStreaming: true,    // Skip streaming calls
- *     }),
- *   ],
- * });
- *
- * await server.start();
- * ```
- *
- * @example Client-side usage with transport
+ * @example Client-side usage with transport (recommended placement)
  * ```typescript
  * import { createConnectTransport } from '@connectrpc/connect-node';
  * import { createCircuitBreakerInterceptor } from '@connectum/interceptors';
@@ -53,13 +72,27 @@ import type { CircuitBreakerOptions } from "./types.ts";
  * const transport = createConnectTransport({
  *   baseUrl: 'http://localhost:5000',
  *   interceptors: [
- *     createCircuitBreakerInterceptor({ threshold: 3 }),
+ *     createCircuitBreakerInterceptor({
+ *       threshold: 5,           // Open after 5 consecutive failures
+ *       halfOpenAfter: 30000,   // Try again after 30 seconds
+ *     }),
  *   ],
+ * });
+ * ```
+ *
+ * @example Custom failure classification (compose with the default)
+ * ```typescript
+ * import { Code, ConnectError } from '@connectrpc/connect';
+ *
+ * createCircuitBreakerInterceptor({
+ *   // Never trip on upstream per-client rate limits
+ *   failurePredicate: (err, def) =>
+ *     def(err) && !(err instanceof ConnectError && err.code === Code.ResourceExhausted),
  * });
  * ```
  */
 export function createCircuitBreakerInterceptor(options: CircuitBreakerOptions = {}): Interceptor {
-    const { threshold = 5, halfOpenAfter = 30000, skipStreaming = true } = options;
+    const { threshold = 5, halfOpenAfter = 30000, skipStreaming = true, failurePredicate } = options;
 
     // Validate options
     if (threshold < 1 || !Number.isFinite(threshold)) {
@@ -70,8 +103,26 @@ export function createCircuitBreakerInterceptor(options: CircuitBreakerOptions =
         throw new Error("halfOpenAfter must be a non-negative finite number");
     }
 
-    // Create circuit breaker policy using handleAll and ConsecutiveBreaker
-    const breaker = circuitBreaker(handleAll, {
+    // Classification wrapper. The try/catch is mandatory, not defensive:
+    // cockatiel calls the error filter without protection (Executor.invoke),
+    // so an exception thrown from it propagates as an UNHANDLED error — in
+    // half-open state that would close the circuit, inverting fail-closed.
+    const isFailure = (error: unknown): boolean => {
+        if (failurePredicate === undefined) {
+            return defaultFailurePredicate(error);
+        }
+        try {
+            return failurePredicate(error, defaultFailurePredicate);
+        } catch (predicateError) {
+            console.error("[circuit-breaker] failurePredicate threw — counting error as failure:", predicateError);
+            return true;
+        }
+    };
+
+    // Errors rejected by the predicate are "unhandled" for cockatiel: they do
+    // not increment the breaker and, in half-open, close the circuit
+    // ("Task failed successfully" path in CircuitBreakerPolicy.halfOpen).
+    const breaker = circuitBreaker(handleWhen(isFailure), {
         halfOpenAfter,
         breaker: new ConsecutiveBreaker(threshold),
     });

--- a/packages/interceptors/src/defaults.ts
+++ b/packages/interceptors/src/defaults.ts
@@ -1,9 +1,11 @@
 /**
  * Default interceptor chain factory
  *
- * Creates the production-ready interceptor chain with resilience patterns.
- * The interceptor order is fixed:
+ * Creates the interceptor chain in a fixed order:
  * errorHandler → timeout → bulkhead → circuitBreaker → retry → fallback → validation → serializer.
+ * Only errorHandler and validation are enabled by default; resilience
+ * interceptors (timeout, bulkhead, circuitBreaker, retry) are opt-in —
+ * no hidden behavioral logic.
  *
  * @module defaults
  */
@@ -27,8 +29,12 @@ import type { BulkheadOptions, CircuitBreakerOptions, ErrorHandlerOptions, Fallb
  * - `true` to enable with default options
  * - An options object to enable with custom configuration
  *
- * All interceptors are enabled by default except fallback and serializer
- * (which requires a handler function).
+ * Only structural interceptors (errorHandler, validation) are enabled by
+ * default. Behavioral resilience interceptors (timeout, bulkhead,
+ * circuitBreaker, retry) are opt-in: implicitly enabled behavior-altering
+ * logic is hidden logic, and hidden logic caused a confirmed production
+ * incident (a server-side circuit breaker tripping on expected business
+ * errors). Enable each one explicitly where you need it.
  */
 export interface DefaultInterceptorOptions {
     /**
@@ -41,28 +47,33 @@ export interface DefaultInterceptorOptions {
     /**
      * Timeout interceptor.
      * Enforces request deadline before any processing.
-     * @default true (30s)
+     * Opt-in: no hidden behavioral logic.
+     * @default false
      */
     timeout?: boolean | TimeoutOptions;
 
     /**
      * Bulkhead interceptor.
      * Limits concurrent requests to prevent resource exhaustion.
-     * @default true (10/10)
+     * Opt-in: no hidden behavioral logic.
+     * @default false
      */
     bulkhead?: boolean | BulkheadOptions;
 
     /**
      * Circuit breaker interceptor.
      * Prevents cascading failures by breaking circuit on consecutive errors.
-     * @default true (5 failures)
+     * Opt-in: no hidden behavioral logic. Intended primarily for outbound
+     * client transports — see the README before enabling it server-side.
+     * @default false
      */
     circuitBreaker?: boolean | CircuitBreakerOptions;
 
     /**
      * Retry interceptor.
      * Retries transient failures with exponential backoff.
-     * @default true (3 retries)
+     * Opt-in: no hidden behavioral logic.
+     * @default false
      */
     retry?: boolean | RetryOptions;
 
@@ -94,27 +105,32 @@ export interface DefaultInterceptorOptions {
  * Creates the default interceptor chain with the specified configuration.
  *
  * The interceptor order is fixed and intentional:
- * 1. **errorHandler** - Catch-all error normalization (outermost, must be first)
- * 2. **timeout** - Enforce deadline before any processing
- * 3. **bulkhead** - Limit concurrency
- * 4. **circuitBreaker** - Prevent cascading failures
- * 5. **retry** - Retry transient failures (exponential backoff)
- * 6. **fallback** - Graceful degradation (DISABLED by default)
- * 7. **validation** - @connectrpc/validate (createValidateInterceptor)
- * 8. **serializer** - JSON serialization (innermost, DISABLED by default)
+ * 1. **errorHandler** - Catch-all error normalization (outermost, must be first; enabled by default)
+ * 2. **timeout** - Enforce deadline before any processing (OPT-IN)
+ * 3. **bulkhead** - Limit concurrency (OPT-IN)
+ * 4. **circuitBreaker** - Prevent cascading failures (OPT-IN; wraps retry — one logical
+ *    request increments the failure counter once, regardless of retry attempts)
+ * 5. **retry** - Retry transient failures with exponential backoff (OPT-IN)
+ * 6. **fallback** - Graceful degradation (OPT-IN, requires handler)
+ * 7. **validation** - @connectrpc/validate (enabled by default)
+ * 8. **serializer** - JSON serialization (innermost, OPT-IN)
+ *
+ * Resilience interceptors (2-5) are opt-in by design: the recommended path
+ * must not silently alter request behavior.
  *
  * @param options - Configuration for each interceptor
  * @returns Array of configured interceptors in the correct order
  *
  * @example
  * ```typescript
- * // All defaults (fallback disabled)
+ * // Defaults: errorHandler + validation only
  * const interceptors = createDefaultInterceptors();
  *
- * // Disable retry, custom timeout
+ * // Explicitly enable resilience where needed
  * const interceptors = createDefaultInterceptors({
- *   retry: false,
  *   timeout: { duration: 10000 },
+ *   bulkhead: true,
+ *   retry: { maxRetries: 3 },
  * });
  *
  * // Enable fallback with handler
@@ -126,41 +142,52 @@ export interface DefaultInterceptorOptions {
  * // or pass `interceptors: []`
  * ```
  */
+/**
+ * Narrow an interceptor option to an options object.
+ *
+ * `typeof value === "object"` alone also matches `null`, so e.g. `{ timeout: null }`
+ * would forward `null` to a factory and crash during options destructuring.
+ * This guard excludes `null` (and `boolean`).
+ */
+function isOptionsObject<T>(value: boolean | T | undefined): value is T {
+    return typeof value === "object" && value !== null;
+}
+
 export function createDefaultInterceptors(options: DefaultInterceptorOptions = {}): Interceptor[] {
     const interceptors: Interceptor[] = [];
 
     // 1. Error handler (must be first!)
     if (options.errorHandler !== false) {
-        const opts = typeof options.errorHandler === "object" ? options.errorHandler : {};
+        const opts = isOptionsObject(options.errorHandler) ? options.errorHandler : {};
         interceptors.push(createErrorHandlerInterceptor(opts));
     }
 
-    // 2. Timeout
-    if (options.timeout !== false) {
-        const opts = typeof options.timeout === "object" ? options.timeout : {};
+    // 2. Timeout (opt-in: no hidden behavioral logic)
+    if (options.timeout === true || isOptionsObject(options.timeout)) {
+        const opts = isOptionsObject(options.timeout) ? options.timeout : {};
         interceptors.push(createTimeoutInterceptor(opts));
     }
 
-    // 3. Bulkhead
-    if (options.bulkhead !== false) {
-        const opts = typeof options.bulkhead === "object" ? options.bulkhead : {};
+    // 3. Bulkhead (opt-in: no hidden behavioral logic)
+    if (options.bulkhead === true || isOptionsObject(options.bulkhead)) {
+        const opts = isOptionsObject(options.bulkhead) ? options.bulkhead : {};
         interceptors.push(createBulkheadInterceptor(opts));
     }
 
-    // 4. Circuit breaker
-    if (options.circuitBreaker !== false) {
-        const opts = typeof options.circuitBreaker === "object" ? options.circuitBreaker : {};
+    // 4. Circuit breaker (opt-in: no hidden behavioral logic)
+    if (options.circuitBreaker === true || isOptionsObject(options.circuitBreaker)) {
+        const opts = isOptionsObject(options.circuitBreaker) ? options.circuitBreaker : {};
         interceptors.push(createCircuitBreakerInterceptor(opts));
     }
 
-    // 5. Retry
-    if (options.retry !== false) {
-        const opts = typeof options.retry === "object" ? options.retry : {};
+    // 5. Retry (opt-in: no hidden behavioral logic)
+    if (options.retry === true || isOptionsObject(options.retry)) {
+        const opts = isOptionsObject(options.retry) ? options.retry : {};
         interceptors.push(createRetryInterceptor(opts));
     }
 
     // 6. Fallback (opt-in, disabled by default — requires handler)
-    if (typeof options.fallback === "object") {
+    if (isOptionsObject(options.fallback)) {
         interceptors.push(createFallbackInterceptor(options.fallback));
     }
 
@@ -170,8 +197,8 @@ export function createDefaultInterceptors(options: DefaultInterceptorOptions = {
     }
 
     // 8. Serializer (opt-in, disabled by default)
-    if (options.serializer === true || typeof options.serializer === "object") {
-        const opts = typeof options.serializer === "object" ? options.serializer : {};
+    if (options.serializer === true || isOptionsObject(options.serializer)) {
+        const opts = isOptionsObject(options.serializer) ? options.serializer : {};
         interceptors.push(createSerializerInterceptor(opts));
     }
 

--- a/packages/interceptors/src/index.ts
+++ b/packages/interceptors/src/index.ts
@@ -3,15 +3,18 @@
  *
  * Production-ready ConnectRPC interceptors with resilience patterns.
  *
- * Default chain (8 interceptors):
+ * Fixed chain order (8 interceptors):
  * errorHandler → timeout → bulkhead → circuitBreaker → retry → fallback → validation → serializer
+ *
+ * Default-enabled: errorHandler, validation. Resilience interceptors
+ * (timeout, bulkhead, circuitBreaker, retry) are opt-in.
  *
  * @module @connectum/interceptors
  * @mergeModuleWith <project>
  */
 
 export { createBulkheadInterceptor } from "./bulkhead.ts";
-export { createCircuitBreakerInterceptor } from "./circuit-breaker.ts";
+export { createCircuitBreakerInterceptor, defaultFailurePredicate } from "./circuit-breaker.ts";
 export type { DefaultInterceptorOptions } from "./defaults.ts";
 // Default interceptor chain factory
 export { createDefaultInterceptors } from "./defaults.ts";

--- a/packages/interceptors/src/types.ts
+++ b/packages/interceptors/src/types.ts
@@ -141,6 +141,36 @@ export interface CircuitBreakerOptions {
      * @default true
      */
     skipStreaming?: boolean;
+
+    /**
+     * Decides whether an error counts as a circuit failure.
+     *
+     * Receives the default predicate as the second argument so the default
+     * policy can be composed (extended or restricted) instead of reimplemented:
+     *
+     * ```typescript
+     * // Extend: also trip on NotFound
+     * failurePredicate: (err, def) =>
+     *     def(err) || (err instanceof ConnectError && err.code === Code.NotFound)
+     *
+     * // Restrict: never trip on ResourceExhausted (e.g. upstream rate limits)
+     * failurePredicate: (err, def) =>
+     *     def(err) && !(err instanceof ConnectError && err.code === Code.ResourceExhausted)
+     *
+     * // Legacy behavior: every error trips the breaker
+     * failurePredicate: () => true
+     * ```
+     *
+     * Errors NOT classified as failures never open or re-arm the breaker and,
+     * in half-open state, close the circuit (treated as a successful probe).
+     * A predicate that throws is treated as if it returned `true` (fail-closed);
+     * the original upstream error is always the one propagated to the caller.
+     *
+     * @default defaultFailurePredicate (infrastructure codes only: Unknown,
+     * DeadlineExceeded, Internal, Unavailable, DataLoss, ResourceExhausted;
+     * non-ConnectError values count as failures)
+     */
+    failurePredicate?: (error: unknown, defaultPredicate: (error: unknown) => boolean) => boolean;
 }
 
 /**

--- a/packages/interceptors/tests/unit/circuit-breaker.test.ts
+++ b/packages/interceptors/tests/unit/circuit-breaker.test.ts
@@ -4,9 +4,23 @@
 
 import assert from "node:assert";
 import { describe, it, mock } from "node:test";
+import type { Interceptor } from "@connectrpc/connect";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { assertConnectError, createMockNext, createMockNextError, createMockRequest } from "@connectum/testing";
-import { createCircuitBreakerInterceptor } from "../../src/circuit-breaker.ts";
+import { createCircuitBreakerInterceptor, defaultFailurePredicate } from "../../src/circuit-breaker.ts";
+import { createRetryInterceptor } from "../../src/retry.ts";
+
+/**
+ * Compose interceptors with Connect-ES semantics: interceptors[0] is
+ * outermost (applyInterceptors iterates the reversed array and wraps).
+ */
+function composeInterceptors(interceptors: Interceptor[], next: any): any {
+    let wrapped = next;
+    for (const i of interceptors.concat().reverse()) {
+        wrapped = i(wrapped);
+    }
+    return wrapped;
+}
 
 describe("circuit breaker interceptor", () => {
     it("should pass request when circuit closed", async () => {
@@ -253,5 +267,295 @@ describe("circuit breaker interceptor", () => {
             () => createCircuitBreakerInterceptor({ halfOpenAfter: Number.POSITIVE_INFINITY }),
             /halfOpenAfter must be a non-negative finite number/,
         );
+    });
+
+    describe("failure classification", () => {
+        const mockReq = () => createMockRequest({ service: "test.Service", method: "Method", message: { field: "value" } });
+
+        it("should not open circuit on business errors (default predicate)", async () => {
+            const interceptor = createCircuitBreakerInterceptor({ threshold: 5, halfOpenAfter: 60_000 });
+            const next = createMockNextError(Code.InvalidArgument, "bad scan code");
+            const handler = interceptor(next as any);
+
+            // 5 consecutive business errors must NOT trip the breaker...
+            for (let i = 0; i < 5; i++) {
+                await assert.rejects(
+                    () => handler(mockReq()),
+                    (err: unknown) => {
+                        assertConnectError(err, Code.InvalidArgument);
+                        return true;
+                    },
+                );
+            }
+
+            // ...and the 6th call still reaches next (circuit closed)
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.InvalidArgument);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 6);
+        });
+
+        it("should open circuit on infrastructure errors (resource_exhausted)", async () => {
+            const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 60_000 });
+            const next = createMockNextError(Code.ResourceExhausted, "upstream overloaded");
+            const handler = interceptor(next as any);
+
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()));
+            }
+
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable, "Circuit breaker is open");
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 2);
+        });
+
+        it("should count non-ConnectError values as failures", async () => {
+            const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 60_000 });
+            const next = mock.fn(async () => {
+                throw new Error("plain runtime fault");
+            });
+            const handler = interceptor(next as any);
+
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()), /plain runtime fault/);
+            }
+
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+        });
+
+        it("should let custom predicate override the default (not_found opens)", async () => {
+            const interceptor = createCircuitBreakerInterceptor({
+                threshold: 2,
+                halfOpenAfter: 60_000,
+                failurePredicate: (err) => err instanceof ConnectError && err.code === Code.NotFound,
+            });
+            const next = createMockNextError(Code.NotFound, "missing");
+            const handler = interceptor(next as any);
+
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()));
+            }
+
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+        });
+
+        it("should compose with the default predicate (exclude resource_exhausted)", async () => {
+            const interceptor = createCircuitBreakerInterceptor({
+                threshold: 2,
+                halfOpenAfter: 60_000,
+                failurePredicate: (err, def) => def(err) && !(err instanceof ConnectError && err.code === Code.ResourceExhausted),
+            });
+            const next = createMockNextError(Code.ResourceExhausted, "rate limited");
+            const handler = interceptor(next as any);
+
+            // 5 rate-limit errors with threshold 2: circuit must stay closed
+            for (let i = 0; i < 5; i++) {
+                await assert.rejects(
+                    () => handler(mockReq()),
+                    (err: unknown) => {
+                        assertConnectError(err, Code.ResourceExhausted);
+                        return true;
+                    },
+                );
+            }
+            assert.strictEqual(next.mock.calls.length, 5);
+        });
+
+        it("should restore legacy all-errors behavior with () => true", async () => {
+            const interceptor = createCircuitBreakerInterceptor({
+                threshold: 2,
+                halfOpenAfter: 60_000,
+                failurePredicate: () => true,
+            });
+            const next = createMockNextError(Code.InvalidArgument, "bad input");
+            const handler = interceptor(next as any);
+
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()));
+            }
+
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+        });
+
+        it("should count error as failure when predicate throws (fail-closed)", async () => {
+            const interceptor = createCircuitBreakerInterceptor({
+                threshold: 2,
+                halfOpenAfter: 60_000,
+                failurePredicate: () => {
+                    throw new Error("buggy classifier");
+                },
+            });
+            const next = createMockNextError(Code.NotFound, "missing");
+            const handler = interceptor(next as any);
+
+            // Caller must receive the ORIGINAL upstream error, not the predicate's
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(
+                    () => handler(mockReq()),
+                    (err: unknown) => {
+                        assertConnectError(err, Code.NotFound);
+                        return true;
+                    },
+                );
+            }
+
+            // Despite NotFound being a non-failure by default, the throwing
+            // predicate fails closed: circuit is open
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+        });
+
+        it("should close circuit on business error in half-open", async () => {
+            const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 100 });
+
+            let callCount = 0;
+            const next = mock.fn(async () => {
+                callCount++;
+                if (callCount <= 2) {
+                    throw new ConnectError("infra down", Code.Internal);
+                }
+                throw new ConnectError("bad input", Code.InvalidArgument);
+            });
+            const handler = interceptor(next as any);
+
+            // Open circuit with infrastructure errors
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()));
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 150));
+
+            // Half-open probe rejects with a business error → treated as a
+            // successful probe (cockatiel "unhandled" path) → circuit closes
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.InvalidArgument);
+                    return true;
+                },
+            );
+
+            // Circuit closed: next call reaches next again
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.InvalidArgument);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 4);
+        });
+
+        it("should re-open circuit on infrastructure error in half-open", async () => {
+            const interceptor = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 100 });
+            const next = createMockNextError(Code.Internal, "still down");
+            const handler = interceptor(next as any);
+
+            for (let i = 0; i < 2; i++) {
+                await assert.rejects(() => handler(mockReq()));
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 150));
+
+            // Half-open probe fails with infra error → re-open
+            await assert.rejects(() => handler(mockReq()));
+
+            await assert.rejects(
+                () => handler(mockReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+        });
+
+        it("defaultFailurePredicate classifies codes as documented", () => {
+            const failureCodes = [Code.Unknown, Code.DeadlineExceeded, Code.Internal, Code.Unavailable, Code.DataLoss, Code.ResourceExhausted];
+            const nonFailureCodes = [
+                Code.Canceled,
+                Code.InvalidArgument,
+                Code.NotFound,
+                Code.AlreadyExists,
+                Code.PermissionDenied,
+                Code.FailedPrecondition,
+                Code.Aborted,
+                Code.OutOfRange,
+                Code.Unimplemented,
+                Code.Unauthenticated,
+            ];
+
+            for (const code of failureCodes) {
+                assert.strictEqual(defaultFailurePredicate(new ConnectError("x", code)), true, `Code ${code} must be a failure`);
+            }
+            for (const code of nonFailureCodes) {
+                assert.strictEqual(defaultFailurePredicate(new ConnectError("x", code)), false, `Code ${code} must not be a failure`);
+            }
+            assert.strictEqual(defaultFailurePredicate(new Error("plain")), true);
+            assert.strictEqual(defaultFailurePredicate("string throw"), true);
+        });
+    });
+
+    describe("ordering: breaker wraps retry (interceptors[0] outermost)", () => {
+        it("should increment failure counter once per logical call despite retries", async () => {
+            // Same relative order as createDefaultInterceptors: breaker before retry
+            const breaker = createCircuitBreakerInterceptor({ threshold: 2, halfOpenAfter: 60_000 });
+            const retry = createRetryInterceptor({ maxRetries: 3, initialDelay: 1, maxDelay: 5 });
+
+            const next = mock.fn(async () => {
+                throw new ConnectError("down", Code.Unavailable);
+            });
+            const mockReq = createMockRequest({ service: "test.Service", method: "Method", message: { field: "value" } });
+
+            const handler = composeInterceptors([breaker, retry], next as any);
+
+            // One logical call: retry exhausts attempts inside the breaker.
+            // Breaker counts ONE failure (threshold 2 → still closed).
+            await assert.rejects(
+                () => handler(mockReq),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unavailable);
+                    return true;
+                },
+            );
+            assert.ok(next.mock.calls.length > 1, "retry must have produced multiple attempts");
+
+            const attemptsAfterFirstCall = next.mock.calls.length;
+
+            // Circuit must still be CLOSED: second logical call reaches next again
+            await assert.rejects(() => handler(mockReq));
+            assert.ok(next.mock.calls.length > attemptsAfterFirstCall, "second logical call must reach next — circuit closed after one logical failure");
+        });
     });
 });

--- a/packages/interceptors/tests/unit/defaults.test.ts
+++ b/packages/interceptors/tests/unit/defaults.test.ts
@@ -1,6 +1,10 @@
 /**
  * Unit tests for default interceptor chain factory
  *
+ * Resilience interceptors (timeout, bulkhead, circuitBreaker, retry) are
+ * opt-in: a bare createDefaultInterceptors() returns only errorHandler and
+ * validation — no hidden behavioral logic.
+ *
  * @module defaults.test
  */
 
@@ -9,12 +13,45 @@ import { describe, it } from 'node:test';
 import { createDefaultInterceptors } from '../../src/defaults.ts';
 
 describe('createDefaultInterceptors', () => {
-    it('should create default chain with 6 interceptors', () => {
+    it('should create default chain with only errorHandler and validation', () => {
         const interceptors = createDefaultInterceptors();
 
-        // 6 enabled by default (fallback and serializer disabled)
-        // errorHandler, timeout, bulkhead, circuitBreaker, retry, validation
-        assert.strictEqual(interceptors.length, 6);
+        // Only structural interceptors enabled by default; resilience
+        // (timeout, bulkhead, circuitBreaker, retry) is opt-in
+        assert.strictEqual(interceptors.length, 2);
+    });
+
+    it('should not include resilience interceptors unless explicitly enabled', () => {
+        const bare = createDefaultInterceptors();
+        const explicit = createDefaultInterceptors({
+            timeout: true,
+            bulkhead: true,
+            circuitBreaker: true,
+            retry: true,
+        });
+
+        assert.strictEqual(bare.length, 2);
+        assert.strictEqual(explicit.length, 6);
+    });
+
+    it('should enable individual resilience interceptors with true', () => {
+        const resilienceKeys = ['timeout', 'bulkhead', 'circuitBreaker', 'retry'];
+
+        for (const key of resilienceKeys) {
+            const interceptors = createDefaultInterceptors({ [key]: true });
+            assert.strictEqual(
+                interceptors.length,
+                3,
+                `Enabling ${key} should increase count to 3`,
+            );
+        }
+    });
+
+    it('should enable individual resilience interceptors with options object', () => {
+        assert.strictEqual(createDefaultInterceptors({ timeout: { duration: 10000 } }).length, 3);
+        assert.strictEqual(createDefaultInterceptors({ bulkhead: { capacity: 5, queueSize: 5 } }).length, 3);
+        assert.strictEqual(createDefaultInterceptors({ circuitBreaker: { threshold: 3 } }).length, 3);
+        assert.strictEqual(createDefaultInterceptors({ retry: { maxRetries: 5 } }).length, 3);
     });
 
     it('should enable fallback when handler provided', () => {
@@ -22,8 +59,8 @@ describe('createDefaultInterceptors', () => {
             fallback: { handler: () => ({ data: [] }) },
         });
 
-        // 7 interceptors (all default + fallback)
-        assert.strictEqual(interceptors.length, 7);
+        // errorHandler + fallback + validation
+        assert.strictEqual(interceptors.length, 3);
     });
 
     it('should not enable fallback when set to true without handler', () => {
@@ -34,10 +71,24 @@ describe('createDefaultInterceptors', () => {
         });
 
         // fallback: true is not typeof "object", so it's skipped
-        assert.strictEqual(interceptors.length, 6);
+        assert.strictEqual(interceptors.length, 2);
     });
 
-    it('should disable individual interceptors', () => {
+    it('should treat null option as "use defaults", not crash (typeof null === object)', () => {
+        // { timeout: null } must not forward null to the factory and crash.
+        const interceptors = createDefaultInterceptors({
+            timeout: null as never,
+            bulkhead: null as never,
+            circuitBreaker: null as never,
+            retry: null as never,
+            fallback: null as never,
+            serializer: null as never,
+        });
+        // Opt-in resilience with null stays disabled; errorHandler + validation remain
+        assert.strictEqual(interceptors.length, 2);
+    });
+
+    it('should support explicit false for every interceptor', () => {
         const interceptors = createDefaultInterceptors({
             errorHandler: false,
             timeout: false,
@@ -61,63 +112,23 @@ describe('createDefaultInterceptors', () => {
             serializer: { skipGrpcServices: false },
         });
 
+        // errorHandler, timeout, bulkhead, circuitBreaker, retry, validation, serializer
         assert.strictEqual(interceptors.length, 7);
     });
 
-    it('should disable all interceptors except specific ones', () => {
-        const interceptors = createDefaultInterceptors({
-            errorHandler: true,
-            timeout: false,
-            bulkhead: false,
-            circuitBreaker: false,
-            retry: false,
-            validation: false,
-            serializer: true,
-        });
-
-        // Only errorHandler and serializer
-        assert.strictEqual(interceptors.length, 2);
-    });
-
-    it('should return empty array when all disabled', () => {
-        const interceptors = createDefaultInterceptors({
-            errorHandler: false,
-            timeout: false,
-            bulkhead: false,
-            circuitBreaker: false,
-            retry: false,
-            validation: false,
-            serializer: false,
-        });
-
-        assert.strictEqual(interceptors.length, 0);
-    });
-
     describe('interceptor chain ordering and disabling', () => {
-        it('should create 6 interceptors with all defaults', () => {
+        it('should create 2 interceptors with all defaults', () => {
             const interceptors = createDefaultInterceptors();
 
-            assert.strictEqual(interceptors.length, 6);
+            assert.strictEqual(interceptors.length, 2);
             for (const ic of interceptors) {
                 assert.strictEqual(typeof ic, 'function');
             }
         });
 
-        it('should create 7 interceptors when fallback has handler', () => {
-            const interceptors = createDefaultInterceptors({
-                fallback: { handler: () => null },
-            });
-
-            assert.strictEqual(interceptors.length, 7);
-        });
-
         it('should maintain correct order: errorHandler first, serializer last', () => {
             const onlyFirstLast = createDefaultInterceptors({
                 errorHandler: true,
-                timeout: false,
-                bulkhead: false,
-                circuitBreaker: false,
-                retry: false,
                 validation: false,
                 serializer: true,
             });
@@ -128,45 +139,37 @@ describe('createDefaultInterceptors', () => {
         });
 
         it('should allow disabling each default-enabled interceptor individually with false', () => {
-            const enabledByDefault = [
-                'errorHandler', 'timeout', 'bulkhead',
-                'circuitBreaker', 'retry', 'validation',
-            ];
+            const enabledByDefault = ['errorHandler', 'validation'];
 
             for (const key of enabledByDefault) {
                 const interceptors = createDefaultInterceptors({ [key]: false });
                 assert.strictEqual(
                     interceptors.length,
-                    5,
-                    `Disabling ${key} should reduce count to 5`,
+                    1,
+                    `Disabling ${key} should reduce count to 1`,
                 );
             }
         });
 
         it('should not change count when disabling already-disabled serializer', () => {
             const interceptors = createDefaultInterceptors({ serializer: false });
-            assert.strictEqual(interceptors.length, 6);
+            assert.strictEqual(interceptors.length, 2);
         });
 
         it('should enable serializer when set to true', () => {
             const interceptors = createDefaultInterceptors({ serializer: true });
-            assert.strictEqual(interceptors.length, 7);
+            assert.strictEqual(interceptors.length, 3);
         });
 
         it('should enable serializer when given options object', () => {
             const interceptors = createDefaultInterceptors({ serializer: { skipGrpcServices: false } });
-            assert.strictEqual(interceptors.length, 7);
+            assert.strictEqual(interceptors.length, 3);
         });
 
         it('should return empty array when all interceptors are disabled', () => {
             const interceptors = createDefaultInterceptors({
                 errorHandler: false,
-                timeout: false,
-                bulkhead: false,
-                circuitBreaker: false,
-                retry: false,
                 validation: false,
-                serializer: false,
             });
 
             assert.strictEqual(interceptors.length, 0);


### PR DESCRIPTION
## Summary
`createDefaultInterceptors()` no longer enables `timeout`, `bulkhead`, `circuitBreaker`, `retry` implicitly — only `errorHandler` and `validation` stay on by default. Hidden resilience logic caused a confirmed production incident (a server-side circuit breaker tripped by expected business errors).

The circuit breaker now **classifies errors**: by default only infrastructure Connect codes trip it (`unknown`, `deadline_exceeded`, `internal`, `unavailable`, `data_loss`, `resource_exhausted`, plus non-`ConnectError` values); business codes never open it and close it in half-open. New composable `failurePredicate(error, defaultPredicate)`; `defaultFailurePredicate` exported. The breaker is repositioned as an outbound/client-transport pattern.

## Breaking
- Resilience interceptors are opt-in — re-enable explicitly (`timeout: true`, …).
- Breaker default classification changed — restore legacy counting with `failurePredicate: () => true`.

Changeset included. From an external production feedback protocol. (Supersedes #133, auto-closed when the Node-22 base branch merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Resilience interceptors (timeout, bulkhead, circuit breaker, retry) are now opt-in; only error handling and validation are enabled by default.

* **New Features**
  * Circuit breaker now classifies failures intelligently—only infrastructure errors trigger it by default; business errors no longer open the circuit.
  * Added customizable failure detection for circuit breaker via new `failurePredicate` option.

* **Documentation**
  * Updated guides to reflect new opt-in resilience model and clarified interceptor chain ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->