### PR TITLE
feat(healthcheck): health components for RPC-less workers

### DIFF
--- a/.changeset/healthcheck-process-components.md
+++ b/.changeset/healthcheck-process-components.md
@@ -1,0 +1,17 @@
+---
+"@connectum/healthcheck": minor
+---
+
+Health components for RPC-less workers: `register()` / `set()` / `unregister()` on `HealthcheckManager`.
+
+A worker with `services: []` could never become SERVING — the registry stayed empty, `/healthz` answered 503 permanently, breaking docker-compose `service_healthy` gating. Now the application can register arbitrary health components that participate in `areAllHealthy()`, gRPC `Check`/`Watch`, and `/healthz` exactly like RPC services:
+
+```typescript
+healthcheckManager.register('process');
+server.on('ready', () => healthcheckManager.set('process', ServingStatus.SERVING));
+server.on('stopping', () => healthcheckManager.set('process', ServingStatus.NOT_SERVING));
+```
+
+Component names are validated (non-empty, dot-free — conventionally packaged proto typeNames are dotted, so namespaces do not collide; a kind check guards the rare package-less case).
+
+Behavioral note: registry entries are now kind-tagged. `initialize()` (called by the Healthcheck protocol on server start) replaces only the **service slice**: components always survive, services absent from the new registration are removed (watchers observe `SERVICE_UNKNOWN`). Components may be registered before or after `server.start()`.

--- a/packages/healthcheck/README.md
+++ b/packages/healthcheck/README.md
@@ -115,20 +115,72 @@ Class for managing service health statuses.
 
 | Method | Description |
 |--------|-------------|
-| `update(status, service?)` | Update status. Without `service` -- updates all registered services. |
-| `getStatus(service)` | Get the status of a specific service |
+| `update(status, service?)` | Update status. Without `service` -- updates **all** registered entries, **including components** (see note below). Throws on unknown names. |
+| `register(component, initialStatus?)` | Register an application health component (default `UNKNOWN`). Re-registering preserves the current status. |
+| `set(component, status)` | Set a component's status (upsert: registers the component if absent). |
+| `unregister(component)` | Remove a registered component. |
+| `getStatus(service)` | Get the status of a specific service or component |
 | `getAllStatuses()` | Get a Map of all statuses |
-| `areAllHealthy()` | Check if all services are in SERVING status |
-| `initialize(serviceNames)` | Initialize service tracking |
-| `clear()` | Clear all services |
+| `areAllHealthy()` | Check if all services and components are in SERVING status |
+| `initialize(serviceNames)` | Initialize RPC service tracking (called by the protocol) |
+| `clear()` | Clear all services and components |
+
+#### Services vs components
+
+The registry tracks two kinds of entries:
+
+- **Services** -- Connect RPC services, owned by the Healthcheck protocol.
+  `initialize()` adds, preserves, and removes these on server start.
+- **Components** -- application-defined readiness gates (`process`, `amqp`,
+  a database connection, ...), owned by the application via
+  `register()`/`set()`/`unregister()`. `initialize()` never touches them.
+
+Component names must be non-empty and dot-free: conventionally packaged proto
+service typeNames are dotted, so the two namespaces do not collide (a kind
+check guards the rare package-less service). A registered component is
+a readiness gate -- it participates in `areAllHealthy()`, gRPC `Check`/`Watch`
+(queryable by name), and `/healthz` exactly like a service.
+
+> **Note on `update(status)` without a service name:** it overwrites **every**
+> registered entry, components included. In a mixed app (RPC services plus an
+> independently managed component such as `amqp`), a blanket
+> `healthcheckManager.update(SERVING)` on `ready` would mask a real component
+> failure. Update independently managed components addressably via
+> `set(component, status)` instead.
 
 #### initialize() Behavior
 
-The `initialize()` method performs a **merge** with existing state:
-- Services that were already registered retain their current status
+`initialize()` replaces only the **service slice** of the registry:
+- Services already registered retain their current status
 - New services are added with `UNKNOWN` status
+- Services absent from the new list are removed (active `Watch` streams on
+  them observe `SERVICE_UNKNOWN`)
+- Components are never touched
 
-This allows updating the service list without losing previously set statuses (e.g., during hot reload).
+#### Workers without RPC
+
+A worker with no public RPCs (`services: []`) can never become SERVING through
+the service registry -- the registry is empty and `/healthz` answers 503
+permanently. Register a process component instead; registration works before
+or after `server.start()`:
+
+```typescript
+import { createServer } from '@connectum/core';
+import { Healthcheck, healthcheckManager, ServingStatus } from '@connectum/healthcheck';
+
+const server = createServer({
+  services: [],            // poller / publisher / exporter — no public RPCs
+  protocols: [Healthcheck({ httpEnabled: true })],
+});
+
+healthcheckManager.register('process');  // UNKNOWN until ready
+
+server.on('ready', () => healthcheckManager.set('process', ServingStatus.SERVING));
+server.on('stopping', () => healthcheckManager.set('process', ServingStatus.NOT_SERVING));
+
+await server.start();
+// docker-compose `service_healthy` gating now works: /healthz → 200 when ready
+```
 
 ### ServingStatus
 

--- a/packages/healthcheck/src/HealthcheckManager.ts
+++ b/packages/healthcheck/src/HealthcheckManager.ts
@@ -1,7 +1,7 @@
 /**
  * Healthcheck state manager
  *
- * Manages health status for all registered services.
+ * Manages health status for all registered services and components.
  * Module-level singleton accessed via `healthcheckManager` export.
  *
  * @module @connectum/healthcheck/HealthcheckManager
@@ -10,103 +10,249 @@
 import { type ServiceStatus, ServingStatus } from "./types.ts";
 
 /**
+ * Registry entry kind.
+ *
+ * - `service` — a Connect RPC service, owned by the Healthcheck protocol:
+ *   `initialize()` adds, preserves, and removes these.
+ * - `component` — an application-defined health component (process, broker
+ *   connection, ...), owned by the application: `initialize()` never touches
+ *   these.
+ */
+const EntryKind = {
+    SERVICE: "service",
+    COMPONENT: "component",
+} as const;
+
+type EntryKind = (typeof EntryKind)[keyof typeof EntryKind];
+
+/**
+ * Internal registry entry. The `kind` tag is deliberately NOT exposed through
+ * `getStatus()`/`getAllStatuses()`: their `ServiceStatus` shape feeds directly
+ * into the gRPC `HealthListResponse`, and an extra field must not leak into
+ * the wire contract.
+ */
+interface HealthEntry {
+    status: ServingStatus;
+    kind: EntryKind;
+}
+
+/**
+ * Validate a component name: non-empty and dot-free.
+ *
+ * Conventionally packaged proto services have dotted typeNames
+ * (`package.Service`), so dot-free component names do not collide with them.
+ * A package-less service (dot-free typeName) is the rare exception; the kind
+ * check in `register`/`set`/`unregister` and `initialize` covers it
+ * defensively. The dot syntax is reserved for service typeNames.
+ */
+function assertValidComponentName(component: string): void {
+    if (component === "") {
+        throw new Error("Component name must not be empty");
+    }
+    if (component.includes(".")) {
+        throw new Error(`Component name '${component}' must not contain dots: dotted names are reserved for RPC service typeNames`);
+    }
+}
+
+/**
  * Healthcheck manager
  *
- * Manages health status for all registered services.
+ * Manages health status for all registered services and components.
  * Module-level singleton. Import `healthcheckManager` from the package.
  *
- * @example
+ * @example RPC service status (after server.start())
  * ```typescript
  * import { healthcheckManager, ServingStatus } from '@connectum/healthcheck';
  *
- * // After server.start():
  * healthcheckManager.update(ServingStatus.SERVING);
+ * ```
+ *
+ * @example RPC-less worker (poller, publisher, exporter)
+ * ```typescript
+ * import { healthcheckManager, ServingStatus } from '@connectum/healthcheck';
+ *
+ * healthcheckManager.register('process');           // before or after start
+ * server.on('ready', () => healthcheckManager.set('process', ServingStatus.SERVING));
+ * server.on('stopping', () => healthcheckManager.set('process', ServingStatus.NOT_SERVING));
  * ```
  */
 export class HealthcheckManager {
-    private services: Map<string, ServiceStatus> = new Map();
+    private entries: Map<string, HealthEntry> = new Map();
 
     /**
      * Update service health status
      *
-     * When called without a service name, updates ALL registered services.
+     * When called without a service name, updates ALL registered entries
+     * (services and components alike).
      * When called with an unknown service name, throws an error.
      *
      * @param status - New serving status
-     * @param service - Service name (if not provided, updates all services)
+     * @param service - Service name (if not provided, updates all entries)
      * @throws Error if service name is provided but not registered
      */
     update(status: ServingStatus, service?: string): void {
-        // No service specified: update ALL registered services
+        // No service specified: update ALL registered entries
         if (service === undefined) {
-            for (const key of this.services.keys()) {
-                this.services.set(key, { status });
+            for (const [key, entry] of this.entries) {
+                this.entries.set(key, { status, kind: entry.kind });
             }
             return;
         }
 
         // Specific service: validate it exists
-        if (!this.services.has(service)) {
-            throw new Error(`Unknown service '${service}'. Registered services: ${[...this.services.keys()].join(", ")}`);
+        const existing = this.entries.get(service);
+        if (existing === undefined) {
+            throw new Error(`Unknown service '${service}'. Registered services: ${[...this.entries.keys()].join(", ")}`);
         }
 
-        this.services.set(service, { status });
+        this.entries.set(service, { status, kind: existing.kind });
+    }
+
+    /**
+     * Register an application health component.
+     *
+     * A registered component is a readiness gate: it participates in
+     * `areAllHealthy()`, gRPC `Check`/`Watch`, and `/healthz` exactly like an
+     * RPC service. Registering an already-registered component does NOT reset
+     * its status. Component names must be non-empty and dot-free.
+     *
+     * @param component - Component name (e.g. "process", "amqp")
+     * @param initialStatus - Initial status (default UNKNOWN)
+     * @throws Error on invalid name or when the name belongs to an RPC service
+     */
+    register(component: string, initialStatus: ServingStatus = ServingStatus.UNKNOWN): void {
+        assertValidComponentName(component);
+
+        const existing = this.entries.get(component);
+        if (existing !== undefined) {
+            if (existing.kind === EntryKind.SERVICE) {
+                throw new Error(`Name '${component}' is a registered RPC service, not a component`);
+            }
+            // Re-register: keep current status
+            return;
+        }
+
+        this.entries.set(component, { status: initialStatus, kind: EntryKind.COMPONENT });
+    }
+
+    /**
+     * Set a component's status (upsert).
+     *
+     * Unlike `update()`, does not throw for unknown names: the component is
+     * registered first if absent. Component names must be non-empty and
+     * dot-free.
+     *
+     * @param component - Component name
+     * @param status - New serving status
+     * @throws Error on invalid name or when the name belongs to an RPC service
+     */
+    set(component: string, status: ServingStatus): void {
+        assertValidComponentName(component);
+
+        const existing = this.entries.get(component);
+        if (existing !== undefined && existing.kind === EntryKind.SERVICE) {
+            throw new Error(`Name '${component}' is a registered RPC service, not a component`);
+        }
+
+        this.entries.set(component, { status, kind: EntryKind.COMPONENT });
+    }
+
+    /**
+     * Remove a registered component.
+     *
+     * @param component - Component name
+     * @throws Error when the name belongs to an RPC service
+     */
+    unregister(component: string): void {
+        const existing = this.entries.get(component);
+        if (existing === undefined) {
+            return;
+        }
+        if (existing.kind === EntryKind.SERVICE) {
+            throw new Error(`Name '${component}' is a registered RPC service, not a component`);
+        }
+        this.entries.delete(component);
     }
 
     /**
      * Get service health status
      *
-     * @param service - Service name
+     * @param service - Service or component name
      * @returns Service status or undefined if not found
      */
     getStatus(service: string): ServiceStatus | undefined {
-        return this.services.get(service);
+        const entry = this.entries.get(service);
+        return entry === undefined ? undefined : { status: entry.status };
     }
 
     /**
      * Get all services health status
      *
-     * @returns Map of service name to health status
+     * @returns Map of service/component name to health status
      */
     getAllStatuses(): Map<string, ServiceStatus> {
-        return new Map(this.services);
+        const result = new Map<string, ServiceStatus>();
+        for (const [key, entry] of this.entries) {
+            result.set(key, { status: entry.status });
+        }
+        return result;
     }
 
     /**
-     * Check if all services are healthy (SERVING)
+     * Check if all services and components are healthy (SERVING)
      *
-     * @returns True if all services are SERVING
+     * @returns True if all entries are SERVING; false for an empty registry
      */
     areAllHealthy(): boolean {
-        if (this.services.size === 0) {
+        if (this.entries.size === 0) {
             return false;
         }
-        return Array.from(this.services.values()).every((s) => s.status === ServingStatus.SERVING);
+        return Array.from(this.entries.values()).every((e) => e.status === ServingStatus.SERVING);
     }
 
     /**
-     * Initialize services map
+     * Initialize the RPC service slice of the registry.
      *
-     * Merges new service names with existing state. Services that were
-     * already registered retain their current status. New services start
-     * with UNKNOWN status.
+     * Affects only `service`-kind entries:
+     * - names in `serviceNames` are added (UNKNOWN) or preserved with their
+     *   current status;
+     * - `service` entries absent from `serviceNames` are removed — pollers on
+     *   `watch` observe SERVICE_UNKNOWN for them afterwards;
+     * - `component` entries are never touched, so components registered
+     *   before `server.start()` survive protocol initialization.
      *
-     * @param serviceNames - Array of service names to track
+     * Called by the Healthcheck protocol on server start; not intended for
+     * application code.
+     *
+     * @param serviceNames - Array of RPC service typeNames to track
      */
     initialize(serviceNames: string[]): void {
-        const merged = new Map<string, ServiceStatus>();
-        for (const name of serviceNames) {
-            const existing = this.services.get(name);
-            merged.set(name, existing ?? { status: ServingStatus.UNKNOWN });
+        const incoming = new Set(serviceNames);
+
+        // Remove stale services (never components): a service absent from the
+        // registry must not stay SERVING forever — that would be fail-open.
+        for (const [key, entry] of this.entries) {
+            if (entry.kind === EntryKind.SERVICE && !incoming.has(key)) {
+                this.entries.delete(key);
+            }
         }
-        this.services = merged;
+
+        for (const name of serviceNames) {
+            const existing = this.entries.get(name);
+            if (existing === undefined) {
+                this.entries.set(name, { status: ServingStatus.UNKNOWN, kind: EntryKind.SERVICE });
+            }
+            // Existing service: keep status. Existing component with the same
+            // name: unreachable in practice (typeNames are dotted, component
+            // names are dot-free) — left untouched rather than failing start.
+        }
     }
 
     /**
-     * Clear all services
+     * Clear all services and components
      */
     clear(): void {
-        this.services.clear();
+        this.entries.clear();
     }
 }
 

--- a/packages/healthcheck/tests/integration/worker-components.test.ts
+++ b/packages/healthcheck/tests/integration/worker-components.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for RPC-less worker health components
+ *
+ * The adopter scenario this capability exists for: a worker service with no
+ * public RPCs (`services: []`) must be able to become SERVING for
+ * docker-compose `service_healthy` gating.
+ *
+ * Flow under test:
+ * 1. register("process") BEFORE server start
+ * 2. Healthcheck protocol initialize() must NOT clobber the component
+ * 3. set("process", SERVING) on ready
+ * 4. /healthz returns 200; gRPC Check("process") returns SERVING
+ * 5. Watch("process") observes status transitions
+ *
+ * Transport: createGrpcTransport (HTTP/2, required for streaming).
+ */
+
+import assert from "node:assert";
+import http2 from "node:http2";
+import { after, before, describe, it } from "node:test";
+import { createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import type { Server } from "@connectum/core";
+import { createServer } from "@connectum/core";
+import { Health } from "../../gen/grpc/health/v1/health_pb.js";
+import { Healthcheck } from "../../src/Healthcheck.ts";
+import { createHealthcheckManager } from "../../src/HealthcheckManager.ts";
+import { ServingStatus } from "../../src/types.ts";
+
+/** Fetch an HTTP health endpoint over h2c and return the status code. */
+function httpStatus(baseUrl: string, path: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const session = http2.connect(baseUrl);
+        session.on("error", reject);
+        const req = session.request({ ":path": path });
+        req.on("response", (headers) => {
+            const status = Number(headers[":status"] ?? 0);
+            req.close();
+            session.close();
+            resolve(status);
+        });
+        req.on("error", reject);
+        req.end();
+    });
+}
+
+describe("RPC-less worker health components", () => {
+    let server: Server;
+    let serverUrl: string;
+    let manager: ReturnType<typeof createHealthcheckManager>;
+
+    before(async () => {
+        manager = createHealthcheckManager();
+
+        // Register the process component BEFORE server start: protocol
+        // initialization must preserve it (service-slice replacement).
+        manager.register("process");
+
+        server = createServer({
+            services: [],
+            port: 0,
+            protocols: [Healthcheck({ httpEnabled: true, manager, watchInterval: 50 })],
+            interceptors: [],
+            allowHTTP1: false,
+        });
+
+        await server.start();
+        const port = server.address?.port;
+        assert.ok(port, "Server should have an assigned port");
+        serverUrl = `http://localhost:${port}`;
+    });
+
+    after(async () => {
+        if (server?.isRunning) {
+            await server.stop();
+        }
+    });
+
+    it("component registered before start survives protocol initialization", () => {
+        assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.UNKNOWN);
+    });
+
+    it("/healthz is 503 while the process component is UNKNOWN", async () => {
+        assert.strictEqual(await httpStatus(serverUrl, "/healthz"), 503);
+    });
+
+    it("worker becomes healthy after set(process, SERVING)", async () => {
+        manager.set("process", ServingStatus.SERVING);
+
+        // HTTP readiness
+        assert.strictEqual(await httpStatus(serverUrl, "/healthz"), 200);
+
+        // gRPC Check by component name
+        const transport = createGrpcTransport({ baseUrl: serverUrl });
+        const client = createClient(Health, transport);
+
+        const byName = await client.check({ service: "process" });
+        assert.strictEqual(byName.status, ServingStatus.SERVING);
+
+        // Overall health (empty service name)
+        const overall = await client.check({ service: "" });
+        assert.strictEqual(overall.status, ServingStatus.SERVING);
+    });
+
+    it("watch stream observes component transitions", async () => {
+        manager.set("process", ServingStatus.SERVING);
+
+        const transport = createGrpcTransport({ baseUrl: serverUrl });
+        const client = createClient(Health, transport);
+
+        const controller = new AbortController();
+        const received: ServingStatus[] = [];
+
+        const watching = (async () => {
+            try {
+                for await (const update of client.watch({ service: "process" }, { signal: controller.signal })) {
+                    received.push(update.status);
+                    if (received.length >= 2) {
+                        controller.abort();
+                    }
+                }
+            } catch {
+                // AbortError on cancel is expected
+            }
+        })();
+
+        // Give the stream time to deliver the initial status, then flip
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        manager.set("process", ServingStatus.NOT_SERVING);
+
+        await watching;
+
+        assert.strictEqual(received[0], ServingStatus.SERVING, "initial status");
+        assert.strictEqual(received[1], ServingStatus.NOT_SERVING, "transition observed");
+    });
+
+    it("NOT_SERVING component turns /healthz back to 503 (shutdown semantics)", async () => {
+        manager.set("process", ServingStatus.NOT_SERVING);
+
+        assert.strictEqual(await httpStatus(serverUrl, "/healthz"), 503);
+    });
+});

--- a/packages/healthcheck/tests/unit/HealthcheckManager.test.ts
+++ b/packages/healthcheck/tests/unit/HealthcheckManager.test.ts
@@ -221,3 +221,164 @@ describe("HealthcheckManager — additional scenarios", () => {
         });
     });
 });
+
+describe("HealthcheckManager components", () => {
+    let manager: HealthcheckManager;
+
+    beforeEach(() => {
+        manager = new HealthcheckManager();
+    });
+
+    describe("register", () => {
+        it("should register a component with UNKNOWN status by default", () => {
+            manager.register("process");
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.UNKNOWN);
+            assert.ok(manager.getAllStatuses().has("process"));
+        });
+
+        it("should register a component with explicit initial status", () => {
+            manager.register("amqp", ServingStatus.NOT_SERVING);
+
+            assert.strictEqual(manager.getStatus("amqp")?.status, ServingStatus.NOT_SERVING);
+        });
+
+        it("should not reset status on re-register", () => {
+            manager.register("process");
+            manager.set("process", ServingStatus.SERVING);
+            manager.register("process");
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.SERVING);
+        });
+
+        it("should reject empty component name", () => {
+            assert.throws(() => manager.register(""), /must not be empty/);
+        });
+
+        it("should reject dotted component name", () => {
+            assert.throws(() => manager.register("acme.process"), /must not contain dots/);
+        });
+
+        it("should reject register() of a name already held by an RPC service", () => {
+            // A dot-free (package-less) service name reaches the kind check.
+            manager.initialize(["Health"]);
+            assert.throws(() => manager.register("Health"), /registered RPC service/);
+        });
+    });
+
+    describe("set (upsert)", () => {
+        it("should reject set() of a name already held by an RPC service", () => {
+            manager.initialize(["Health"]);
+            assert.throws(() => manager.set("Health", ServingStatus.SERVING), /registered RPC service/);
+        });
+
+        it("should register an unknown component on set", () => {
+            manager.set("process", ServingStatus.SERVING);
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.SERVING);
+        });
+
+        it("should update an existing component", () => {
+            manager.register("process");
+            manager.set("process", ServingStatus.SERVING);
+            manager.set("process", ServingStatus.NOT_SERVING);
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.NOT_SERVING);
+        });
+
+        it("should reject empty and dotted names", () => {
+            assert.throws(() => manager.set("", ServingStatus.SERVING), /must not be empty/);
+            assert.throws(() => manager.set("a.b", ServingStatus.SERVING), /must not contain dots/);
+        });
+    });
+
+    describe("unregister", () => {
+        it("should remove a component", () => {
+            manager.register("process");
+            manager.unregister("process");
+
+            assert.strictEqual(manager.getStatus("process"), undefined);
+        });
+
+        it("should be a no-op for unknown names", () => {
+            manager.unregister("ghost");
+        });
+
+        it("should reject unregistering an RPC service", () => {
+            manager.initialize(["svc.v1.Foo"]);
+
+            assert.throws(() => manager.unregister("svc.v1.Foo"), /registered RPC service/);
+        });
+    });
+
+    describe("kind collision", () => {
+        it("update() works for components by name", () => {
+            manager.register("process");
+            manager.update(ServingStatus.SERVING, "process");
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.SERVING);
+        });
+
+        it("update() without name updates components too", () => {
+            manager.initialize(["svc.v1.Foo"]);
+            manager.register("process");
+            manager.update(ServingStatus.SERVING);
+
+            assert.strictEqual(manager.getStatus("svc.v1.Foo")?.status, ServingStatus.SERVING);
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.SERVING);
+        });
+    });
+
+    describe("initialize with components", () => {
+        it("should preserve components registered before initialization", () => {
+            manager.register("process");
+            manager.initialize(["svc.v1.Foo"]);
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.UNKNOWN);
+            assert.strictEqual(manager.getStatus("svc.v1.Foo")?.status, ServingStatus.UNKNOWN);
+            assert.strictEqual(manager.getAllStatuses().size, 2);
+        });
+
+        it("should preserve component status across re-initialization", () => {
+            manager.register("process");
+            manager.set("process", ServingStatus.SERVING);
+            manager.initialize(["svc.v1.Foo"]);
+            manager.initialize(["svc.v1.Bar"]);
+
+            assert.strictEqual(manager.getStatus("process")?.status, ServingStatus.SERVING);
+            assert.strictEqual(manager.getStatus("svc.v1.Foo"), undefined);
+            assert.strictEqual(manager.getStatus("svc.v1.Bar")?.status, ServingStatus.UNKNOWN);
+        });
+
+        it("should remove stale services but never components", () => {
+            manager.initialize(["svc.v1.Foo", "svc.v1.Bar"]);
+            manager.register("process");
+            manager.initialize(["svc.v1.Foo"]);
+
+            assert.strictEqual(manager.getStatus("svc.v1.Bar"), undefined);
+            assert.ok(manager.getAllStatuses().has("process"));
+            assert.ok(manager.getAllStatuses().has("svc.v1.Foo"));
+        });
+    });
+
+    describe("aggregate health with components", () => {
+        it("NOT_SERVING component fails aggregate health", () => {
+            manager.set("process", ServingStatus.SERVING);
+            manager.set("amqp", ServingStatus.NOT_SERVING);
+
+            assert.strictEqual(manager.areAllHealthy(), false);
+        });
+
+        it("all SERVING components and services are healthy", () => {
+            manager.initialize(["svc.v1.Foo"]);
+            manager.update(ServingStatus.SERVING, "svc.v1.Foo");
+            manager.set("process", ServingStatus.SERVING);
+
+            assert.strictEqual(manager.areAllHealthy(), true);
+        });
+
+        it("empty registry stays unhealthy", () => {
+            assert.strictEqual(manager.areAllHealthy(), false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
A service with no public RPCs (`services: []`) could never become SERVING — the registry stayed empty, `/healthz` answered 503 permanently, docker-compose `service_healthy` gating never passed.

Adds `register()` / `set()` / `unregister()` on `HealthcheckManager`. Components participate in `areAllHealthy()`, gRPC `Check`/`Watch`, and `/healthz` like RPC services; names validated (non-empty, dot-free). Kind-tagged entries: `initialize()` replaces only the service slice (components survive, removed services notify watchers `SERVICE_UNKNOWN`).

Changeset (`minor`). From an external production feedback protocol. (Supersedes #134.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for registering health components in RPC-less workers via `register()`, `set()`, and `unregister()` methods
  * Health components now participate in `/healthz` endpoint and gRPC health checks

* **Bug Fixes**
  * Fixed `/healthz` returning 503 for workers without RPC services

* **Documentation**
  * Enhanced health check documentation with component management guidance and examples for RPC-less worker scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->