### PR TITLE
feat(core)!: startup diagnostics for bidi streaming vs transport

### DIFF
--- a/.changeset/core-bidi-transport-diagnostics.md
+++ b/.changeset/core-bidi-transport-diagnostics.md
@@ -1,0 +1,22 @@
+---
+"@connectum/core": major
+---
+
+**BREAKING** (behavioral): startup validation of bidi-streaming methods vs the effective transport.
+
+Per the Connect protocol, bidirectional streaming requires HTTP/2 — but the default `createServer()` transport without TLS is plaintext HTTP/1.1 (`allowHTTP1: true`). Previously a bidi service registered cleanly on that transport and failed silently at runtime: the first client send hung forever (or yielded HTTP 505). Now `server.start()` rejects with a `TransportValidationError` carrying the stable code `CONNECTUM_UNSUPPORTED_STREAMING_TRANSPORT`, the affected `service.method` list with streaming kinds, and both fixes (`allowHTTP1: false` for h2c, or TLS with ALPN). The rejected promise and the `error` event carry the same error object.
+
+New option:
+
+```typescript
+createServer({
+  // "error" (default) — fail fast at start()
+  // "warn"  — log the diagnostic once and start anyway
+  // "off"   — skip the check
+  transportValidation: "error" | "warn" | "off",
+});
+```
+
+Unary, server-streaming, and client-streaming methods are unaffected on any transport (the Connect protocol supports them over HTTP/1.1). A TLS server that also allows HTTP/1.1 (`allowHTTP1: true`) emits a one-time **warning** for bidi methods — never a hard error — because a client negotiating HTTP/1.1 over TLS hits the same hang; set `allowHTTP1: false` to refuse HTTP/1.1 at ALPN and remove the risk. A TLS or h2c server restricted to HTTP/2 never triggers the check.
+
+Deployments that knowingly ran bidi services on an HTTP/1.1-permitting config (they were broken at runtime) can downgrade with `transportValidation: "warn"` or `"off"`. Exported: `TransportValidationError`, `TRANSPORT_VALIDATION_ERROR_CODE`, `collectStreamingMethods`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -437,14 +437,15 @@ interface TLSOptions {
 
 ### Interceptors
 
-`@connectum/core` does not include built-in interceptors. Use `@connectum/interceptors` for a production-ready chain:
+`@connectum/core` does not include built-in interceptors. Use `@connectum/interceptors` for a production-ready chain (errorHandler + validation by default; resilience interceptors such as timeout, bulkhead, circuitBreaker, retry are opt-in):
 
 ```typescript
 import { createDefaultInterceptors } from '@connectum/interceptors';
 
 const server = createServer({
   services: [routes],
-  interceptors: createDefaultInterceptors(),
+  // Defaults to errorHandler + validation only. Enable resilience explicitly:
+  interceptors: createDefaultInterceptors({ timeout: true, retry: true }),
 });
 ```
 

--- a/packages/core/src/Server.ts
+++ b/packages/core/src/Server.ts
@@ -14,6 +14,7 @@ import { buildRoutes } from "./buildRoutes.ts";
 import { performGracefulShutdown } from "./gracefulShutdown.ts";
 import { ShutdownManager } from "./ShutdownManager.ts";
 import { TransportManager } from "./TransportManager.ts";
+import { resolveEffectiveTransport, validateTransport } from "./TransportValidation.ts";
 import type { CreateServerOptions, EventBusLike, ProtocolRegistration, Server, ServiceRoute, ShutdownHook, TransportServer } from "./types.ts";
 import { ServerState } from "./types.ts";
 
@@ -128,13 +129,34 @@ class ServerImpl extends EventEmitter implements Server {
         this.emit("start");
 
         try {
-            const { handler, registry } = buildRoutes({
+            const { handler, registry, userRegistry } = buildRoutes({
                 services: this._routes,
                 protocols: this._protocols,
                 interceptors: this._interceptors,
                 shutdownSignal: this._abortController.signal,
             });
             this._registry.push(...registry);
+
+            // Streaming kinds vs transport: USER bidi methods on a plaintext
+            // HTTP/1.1 server hang silently at runtime — fail fast instead;
+            // on a TLS server that also allows HTTP/1.1 the same hang is a
+            // residual risk for HTTP/1.1-negotiating clients → one-time warn.
+            // Protocol-contributed services (gRPC Reflection's
+            // ServerReflectionInfo is bidi) are excluded: their transport
+            // limitations are documented, not a user misconfiguration.
+            // The thrown error and the 'error' event below carry the SAME
+            // object; the framework itself prints nothing (no double reporting).
+            const validationError = validateTransport({
+                registry: userRegistry,
+                // Boolean() mirrors TransportManager's truthy TLS check, so a
+                // falsy-but-defined tls (e.g. null from untyped JS) is treated
+                // as plaintext consistently with the actual transport selection.
+                transport: resolveEffectiveTransport({ hasTls: Boolean(this._options.tls), allowHTTP1: this._options.allowHTTP1 }),
+                mode: this._options.transportValidation ?? "error",
+            });
+            if (validationError) {
+                throw validationError;
+            }
 
             if (this._eventBus) {
                 await this._eventBus.start({ signal: this._abortController.signal });

--- a/packages/core/src/TransportValidation.ts
+++ b/packages/core/src/TransportValidation.ts
@@ -1,0 +1,199 @@
+/**
+ * Transport / streaming-kind validation
+ *
+ * The Connect protocol requires HTTP/2 for bidi-streaming RPCs ("Bidirectional
+ * streaming requires HTTP/2, but the other RPC types also support HTTP/1.1" —
+ * connectrpc.com/docs/protocol). HTTP/1.1 is half-duplex at the wire level, so
+ * a bidi method registers cleanly and then fails silently at runtime: the
+ * first client send hangs forever (or yields HTTP 505). This module turns that
+ * misconfiguration into a startup-time diagnostic.
+ *
+ * Two transport situations are diagnosed:
+ * - **plaintext HTTP/1.1** (no TLS, `allowHTTP1: true` — the default): bidi can
+ *   only ever fail → `error` by default (configurable).
+ * - **TLS with `allowHTTP1: true`**: the server negotiates HTTP/2 via ALPN, so
+ *   bidi works for HTTP/2 clients — but a client (or proxy) that negotiates
+ *   HTTP/1.1 over TLS hits the same hang. This is a residual risk, not a
+ *   certain failure, so it is always a one-time `warn` (never a hard error):
+ *   a mixed port serving HTTP/1.1 unary clients alongside HTTP/2 bidi clients
+ *   is a legitimate, if discouraged, configuration. Setting `allowHTTP1: false`
+ *   makes the server refuse HTTP/1.1 at ALPN and removes the risk entirely.
+ *
+ * Unary, server-streaming, and client-streaming are excluded: the Connect
+ * protocol supports them over HTTP/1.1.
+ *
+ * @module TransportValidation
+ */
+
+import type { DescFile } from "@bufbuild/protobuf";
+
+/**
+ * Stable error code for the streaming-vs-transport startup diagnostic.
+ * Searchable in logs and docs.
+ */
+export const TRANSPORT_VALIDATION_ERROR_CODE = "CONNECTUM_UNSUPPORTED_STREAMING_TRANSPORT";
+
+/** Validation severity. */
+export const TransportValidationMode = {
+    ERROR: "error",
+    WARN: "warn",
+    OFF: "off",
+} as const;
+
+export type TransportValidationMode = (typeof TransportValidationMode)[keyof typeof TransportValidationMode];
+
+/**
+ * Effective transport resolved from `tls` + `allowHTTP1`.
+ *
+ * - `plaintext-h1` — no TLS, `allowHTTP1: true` (default): HTTP/1.1 only.
+ * - `h2c` — no TLS, `allowHTTP1: false`: plaintext HTTP/2.
+ * - `tls-h1-negotiable` — TLS, `allowHTTP1: true`: ALPN offers both; a client
+ *   may negotiate HTTP/1.1 (residual bidi risk).
+ * - `tls-h2-only` — TLS, `allowHTTP1: false`: ALPN refuses HTTP/1.1.
+ */
+export const EffectiveTransport = {
+    PLAINTEXT_H1: "plaintext-h1",
+    H2C: "h2c",
+    TLS_H1_NEGOTIABLE: "tls-h1-negotiable",
+    TLS_H2_ONLY: "tls-h2-only",
+} as const;
+
+export type EffectiveTransport = (typeof EffectiveTransport)[keyof typeof EffectiveTransport];
+
+/**
+ * Resolve the effective transport from the server's TLS and `allowHTTP1`
+ * configuration. `allowHTTP1` defaults to `true` (matching TransportManager).
+ */
+export function resolveEffectiveTransport(options: { hasTls: boolean; allowHTTP1?: boolean | undefined }): EffectiveTransport {
+    const allowHTTP1 = options.allowHTTP1 ?? true;
+    if (options.hasTls) {
+        return allowHTTP1 ? EffectiveTransport.TLS_H1_NEGOTIABLE : EffectiveTransport.TLS_H2_ONLY;
+    }
+    return allowHTTP1 ? EffectiveTransport.PLAINTEXT_H1 : EffectiveTransport.H2C;
+}
+
+/** A streaming method that requires HTTP/2. */
+export interface StreamingMethodInfo {
+    /** Fully qualified service typeName (e.g. `acme.v1.ScannerService`). */
+    readonly service: string;
+    /** Method name (e.g. `StreamCodes`). */
+    readonly method: string;
+    /** Streaming kind: `bidi_streaming`. */
+    readonly kind: string;
+}
+
+/**
+ * Startup validation error: bidi-streaming methods registered on a
+ * transport that cannot carry them. Carries the stable
+ * {@link TRANSPORT_VALIDATION_ERROR_CODE} code and the affected methods.
+ */
+export class TransportValidationError extends Error {
+    readonly code = TRANSPORT_VALIDATION_ERROR_CODE;
+    readonly methods: readonly StreamingMethodInfo[];
+
+    constructor(message: string, methods: readonly StreamingMethodInfo[]) {
+        super(message);
+        this.name = "TransportValidationError";
+        this.methods = methods;
+    }
+}
+
+/**
+ * Collect bidi-streaming methods from a DescFile registry (built during
+ * route registration). Client-streaming is NOT collected — the Connect
+ * protocol supports it over HTTP/1.1.
+ */
+export function collectStreamingMethods(registry: readonly DescFile[]): StreamingMethodInfo[] {
+    const result: StreamingMethodInfo[] = [];
+    for (const file of registry) {
+        for (const service of file.services) {
+            for (const method of service.methods) {
+                if (method.methodKind === "bidi_streaming") {
+                    result.push({ service: service.typeName, method: method.name, kind: method.methodKind });
+                }
+            }
+        }
+    }
+    return result;
+}
+
+/** Format the affected-methods list. */
+function formatMethodList(methods: readonly StreamingMethodInfo[]): string {
+    return methods.map((m) => `  - ${m.service}.${m.method} (${m.kind})`).join("\n");
+}
+
+/**
+ * Diagnostic for the **plaintext HTTP/1.1** case: bidi can never work here.
+ * Names the methods, the effective transport, both remediations, and the
+ * runtime symptoms («first send hangs», «HTTP 505») for log searchability.
+ */
+export function formatTransportValidationMessage(methods: readonly StreamingMethodInfo[]): string {
+    return (
+        `[${TRANSPORT_VALIDATION_ERROR_CODE}] The following bidi-streaming methods require HTTP/2, ` +
+        `but the effective transport is plaintext HTTP/1.1 (no TLS, allowHTTP1: true — the default):\n` +
+        `${formatMethodList(methods)}\n` +
+        `Without HTTP/2 these calls fail silently at runtime: the first send hangs forever ` +
+        `(or the client receives HTTP 505).\n` +
+        `Fix one of:\n` +
+        `  1. allowHTTP1: false — plaintext h2c (recommended for internal services);\n` +
+        `  2. configure TLS — HTTP/2 via ALPN.\n` +
+        `Or downgrade this check: transportValidation: "warn" | "off".`
+    );
+}
+
+/**
+ * Diagnostic for the **TLS + allowHTTP1** case: bidi works for HTTP/2 clients,
+ * but a client that negotiates HTTP/1.1 over TLS hits the same hang. Residual
+ * risk → warning only.
+ */
+export function formatTlsHttp1WarningMessage(methods: readonly StreamingMethodInfo[]): string {
+    return (
+        `[${TRANSPORT_VALIDATION_ERROR_CODE}] The TLS server allows HTTP/1.1 (allowHTTP1: true), so ALPN may ` +
+        `negotiate HTTP/1.1 with some clients or proxies. The following bidi-streaming methods require HTTP/2 ` +
+        `and will hang for any client that negotiates HTTP/1.1:\n` +
+        `${formatMethodList(methods)}\n` +
+        `If you do not need to serve HTTP/1.1 clients, set allowHTTP1: false so the server refuses HTTP/1.1 at ` +
+        `ALPN (HTTP/1.1 clients then fail the TLS handshake explicitly instead of hanging on bidi).\n` +
+        `Silence this warning with transportValidation: "off".`
+    );
+}
+
+/**
+ * Validate bidi-streaming methods against the effective transport.
+ *
+ * @returns A {@link TransportValidationError} to throw (plaintext HTTP/1.1 +
+ * `mode: "error"`), or `null` after optionally logging a one-time warning
+ * (plaintext HTTP/1.1 + `mode: "warn"`, or TLS-with-HTTP/1.1 in any non-`off`
+ * mode) / doing nothing (`mode: "off"`, an HTTP/2-only transport, or no bidi
+ * methods).
+ */
+export function validateTransport(options: { registry: readonly DescFile[]; transport: EffectiveTransport; mode: TransportValidationMode }): TransportValidationError | null {
+    if (options.mode === TransportValidationMode.OFF) {
+        return null;
+    }
+    // HTTP/2-only transports (h2c, TLS without HTTP/1.1) carry bidi fine.
+    if (options.transport === EffectiveTransport.H2C || options.transport === EffectiveTransport.TLS_H2_ONLY) {
+        return null;
+    }
+
+    const methods = collectStreamingMethods(options.registry);
+    if (methods.length === 0) {
+        return null;
+    }
+
+    // TLS that also negotiates HTTP/1.1: residual risk only — always a
+    // one-time warning, never a hard error (mixed h1-unary + h2-bidi on one
+    // port is a legitimate, if discouraged, configuration).
+    if (options.transport === EffectiveTransport.TLS_H1_NEGOTIABLE) {
+        console.warn(formatTlsHttp1WarningMessage(methods));
+        return null;
+    }
+
+    // Plaintext HTTP/1.1: bidi can never work.
+    const message = formatTransportValidationMessage(methods);
+    if (options.mode === TransportValidationMode.WARN) {
+        console.warn(message);
+        return null;
+    }
+    return new TransportValidationError(message, methods);
+}

--- a/packages/core/src/buildRoutes.ts
+++ b/packages/core/src/buildRoutes.ts
@@ -28,6 +28,14 @@ export interface BuildRoutesOptions {
 export interface BuildRoutesResult {
     handler: (req: NodeRequest, res: NodeResponse) => void;
     registry: DescFile[];
+    /**
+     * The prefix of `registry` contributed by user services (before protocol
+     * registration). Transport validation runs against this slice only:
+     * protocol-contributed services (e.g. gRPC Reflection, whose
+     * ServerReflectionInfo is bidi) own their documented transport
+     * limitations and must not fail the user's startup.
+     */
+    userRegistry: DescFile[];
 }
 
 /**
@@ -44,6 +52,7 @@ export function buildRoutes(options: BuildRoutesOptions): BuildRoutesResult {
     const { services, protocols, interceptors, shutdownSignal } = options;
 
     const registry: DescFile[] = [];
+    let userFileCount = 0;
 
     // Setup routes with registry interceptor
     const routes = (router: ConnectRouter) => {
@@ -59,6 +68,9 @@ export function buildRoutes(options: BuildRoutesOptions): BuildRoutesResult {
         for (const serviceRoute of services) {
             serviceRoute(router);
         }
+        // Everything registered up to here came from user services;
+        // descriptors added below belong to protocols.
+        userFileCount = registry.length;
 
         // Register protocols
         const context: ProtocolContext = { registry };
@@ -89,5 +101,7 @@ export function buildRoutes(options: BuildRoutesOptions): BuildRoutesResult {
         },
     });
 
-    return { handler: handler as (req: NodeRequest, res: NodeResponse) => void, registry };
+    // connectNodeAdapter invokes routes() synchronously, so both the full
+    // registry and the user-service prefix are populated at this point.
+    return { handler: handler as (req: NodeRequest, res: NodeResponse) => void, registry, userRegistry: registry.slice(0, userFileCount) };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,9 @@ export type { SanitizableError } from "./errors.ts";
 export { isSanitizableError } from "./errors.ts";
 // TLS utilities
 export { getTLSPath, readTLSCertificates, tlsPath } from "./TLSConfig.ts";
+// Transport validation (streaming kinds vs transport)
+export type { EffectiveTransport, StreamingMethodInfo, TransportValidationMode } from "./TransportValidation.ts";
+export { collectStreamingMethods, resolveEffectiveTransport, TRANSPORT_VALIDATION_ERROR_CODE, TransportValidationError } from "./TransportValidation.ts";
 
 // =============================================================================
 // TYPES

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -298,6 +298,28 @@ export interface CreateServerOptions {
     allowHTTP1?: boolean;
 
     /**
+     * Startup validation of streaming method kinds vs the effective transport.
+     *
+     * Bidi-streaming methods require HTTP/2 (Connect protocol: "Bidirectional
+     * streaming requires HTTP/2, but the other RPC types also support
+     * HTTP/1.1"). On a plaintext HTTP/1.1 server (no TLS + `allowHTTP1: true`,
+     * the default) they fail silently at runtime — the first send hangs
+     * forever. With `"error"` (default) `start()` rejects with a
+     * `TransportValidationError` (code `CONNECTUM_UNSUPPORTED_STREAMING_TRANSPORT`)
+     * naming the affected methods and both fixes; `"warn"` logs once and
+     * starts anyway; `"off"` skips the check.
+     *
+     * On a TLS server that also allows HTTP/1.1 (`allowHTTP1: true`), bidi
+     * works for HTTP/2 clients but a client negotiating HTTP/1.1 over TLS
+     * hits the same hang — this residual risk is always a one-time warning
+     * (never a hard error), silenced only by `"off"`. Set `allowHTTP1: false`
+     * to remove the risk (the server refuses HTTP/1.1 at ALPN).
+     *
+     * @default "error"
+     */
+    transportValidation?: "error" | "warn" | "off";
+
+    /**
      * Handshake timeout in milliseconds
      * @default 30000
      */

--- a/packages/core/tests/integration/transport-validation.test.ts
+++ b/packages/core/tests/integration/transport-validation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Server.start() transport-validation integration tests
+ *
+ * A USER-registered bidi-streaming method on the default plaintext HTTP/1.1
+ * server must fail startup (TransportValidationError, stable code); the same
+ * registry on an h2c server must start cleanly. Protocol-contributed bidi
+ * descriptors (the gRPC Reflection case — ServerReflectionInfo is bidi) must
+ * NOT fail the user's startup: their transport limitations are documented.
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { DescFile } from "@bufbuild/protobuf";
+import { createServer } from "../../src/Server.ts";
+import { TRANSPORT_VALIDATION_ERROR_CODE, TransportValidationError } from "../../src/TransportValidation.ts";
+import type { ProtocolRegistration, ServiceRoute } from "../../src/types.ts";
+
+const BIDI_FILE = {
+    services: [
+        {
+            typeName: "acme.v1.ScannerService",
+            methods: [{ name: "StreamCodes", methodKind: "bidi_streaming" }],
+        },
+    ],
+} as unknown as DescFile;
+
+/**
+ * User service route contributing a bidi descriptor. buildRoutes intercepts
+ * router.service() and records service.file BEFORE delegating to the real
+ * Connect router — which rejects the structural mock, so the route swallows
+ * that error: the registry entry is what the test needs.
+ */
+function bidiUserService(): ServiceRoute {
+    return (router) => {
+        try {
+            router.service({ file: BIDI_FILE } as never, {} as never);
+        } catch {
+            // Connect router rejects the structural mock — irrelevant here:
+            // the descriptor has already been recorded in the registry.
+        }
+    };
+}
+
+/** Protocol contributing the same bidi descriptor (the Reflection scenario). */
+function bidiDescriptorProtocol(): ProtocolRegistration {
+    return {
+        name: "bidi-fixture",
+        register(_router, context): void {
+            (context.registry as DescFile[]).push(BIDI_FILE);
+        },
+    };
+}
+
+describe("Server.start() transport validation", () => {
+    it("rejects startup for a user bidi service on default plaintext HTTP/1.1", async () => {
+        const server = createServer({
+            services: [bidiUserService()],
+            port: 0,
+            interceptors: [],
+            // defaults: no TLS, allowHTTP1: true → plaintext HTTP/1.1
+        });
+
+        // The rejected promise and the 'error' event must carry the SAME object
+        let emitted: unknown;
+        server.on("error", (err) => {
+            emitted = err;
+        });
+
+        await assert.rejects(
+            () => server.start(),
+            (err: unknown) => {
+                assert.ok(err instanceof TransportValidationError, `expected TransportValidationError, got ${err}`);
+                assert.strictEqual(err.code, TRANSPORT_VALIDATION_ERROR_CODE);
+                assert.ok(err.message.includes("acme.v1.ScannerService.StreamCodes"));
+                assert.strictEqual(emitted, err, "error event must deliver the identical error instance");
+                return true;
+            },
+        );
+    });
+
+    it("starts cleanly for the same user service on h2c (allowHTTP1: false)", async () => {
+        const server = createServer({
+            services: [bidiUserService()],
+            port: 0,
+            interceptors: [],
+            allowHTTP1: false,
+        });
+
+        await server.start();
+        assert.ok(server.isRunning);
+        await server.stop();
+    });
+
+    it("starts on plaintext HTTP/1.1 with transportValidation: warn", async () => {
+        const server = createServer({
+            services: [bidiUserService()],
+            port: 0,
+            interceptors: [],
+            transportValidation: "warn",
+        });
+
+        await server.start();
+        assert.ok(server.isRunning);
+        await server.stop();
+    });
+
+    it("protocol-contributed bidi (Reflection scenario) does NOT fail startup on plaintext HTTP/1.1", async () => {
+        const server = createServer({
+            services: [],
+            port: 0,
+            protocols: [bidiDescriptorProtocol()],
+            interceptors: [],
+            // defaults: plaintext HTTP/1.1 — protocol bidi must not trip validation
+        });
+
+        await server.start();
+        assert.ok(server.isRunning);
+        await server.stop();
+    });
+});

--- a/packages/core/tests/unit/TransportValidation.test.ts
+++ b/packages/core/tests/unit/TransportValidation.test.ts
@@ -1,0 +1,154 @@
+/**
+ * TransportValidation unit tests
+ *
+ * Validation matrix: mode (error/warn/off) × transport (plaintext-h1 vs
+ * streaming-capable) × method kinds. DescFile registry entries are mocked
+ * structurally (services[].methods[].methodKind — the protobuf-es
+ * descriptor shape).
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { DescFile } from "@bufbuild/protobuf";
+import { collectStreamingMethods, EffectiveTransport, formatTransportValidationMessage, resolveEffectiveTransport, TRANSPORT_VALIDATION_ERROR_CODE, TransportValidationError, validateTransport } from "../../src/TransportValidation.ts";
+
+/**
+ * Capture `console.warn` calls during `fn`, returning each call's arguments.
+ * Portable across Node and Bun — avoids `node:test` `mock.method`, which is
+ * absent under Bun's test engine.
+ */
+function captureWarnings(fn: () => void): unknown[][] {
+    const original = console.warn;
+    const calls: unknown[][] = [];
+    console.warn = (...args: unknown[]): void => {
+        calls.push(args);
+    };
+    try {
+        fn();
+    } finally {
+        console.warn = original;
+    }
+    return calls;
+}
+
+/** Structural mock of a DescFile with the given service methods. */
+function mockDescFile(service: string, methods: Array<{ name: string; methodKind: string }>): DescFile {
+    return {
+        services: [{ typeName: service, methods }],
+    } as unknown as DescFile;
+}
+
+const UNARY_ONLY = mockDescFile("acme.v1.UnaryService", [
+    { name: "Get", methodKind: "unary" },
+    { name: "Watch", methodKind: "server_streaming" },
+]);
+
+const WITH_BIDI = mockDescFile("acme.v1.ScannerService", [
+    { name: "Get", methodKind: "unary" },
+    { name: "StreamCodes", methodKind: "bidi_streaming" },
+]);
+
+const WITH_CLIENT_STREAM = mockDescFile("acme.v1.UploadService", [{ name: "Upload", methodKind: "client_streaming" }]);
+
+describe("collectStreamingMethods", () => {
+    it("collects only bidi — unary, server-streaming, and client-streaming work over HTTP/1.1 per the Connect protocol", () => {
+        const methods = collectStreamingMethods([UNARY_ONLY, WITH_BIDI, WITH_CLIENT_STREAM]);
+
+        assert.deepStrictEqual(methods, [{ service: "acme.v1.ScannerService", method: "StreamCodes", kind: "bidi_streaming" }]);
+    });
+
+    it("returns empty for unary/server-streaming-only registry", () => {
+        assert.deepStrictEqual(collectStreamingMethods([UNARY_ONLY]), []);
+    });
+});
+
+describe("resolveEffectiveTransport", () => {
+    it("maps tls × allowHTTP1 to the four transports", () => {
+        assert.strictEqual(resolveEffectiveTransport({ hasTls: false, allowHTTP1: true }), EffectiveTransport.PLAINTEXT_H1);
+        assert.strictEqual(resolveEffectiveTransport({ hasTls: false }), EffectiveTransport.PLAINTEXT_H1); // allowHTTP1 defaults true
+        assert.strictEqual(resolveEffectiveTransport({ hasTls: false, allowHTTP1: false }), EffectiveTransport.H2C);
+        assert.strictEqual(resolveEffectiveTransport({ hasTls: true, allowHTTP1: true }), EffectiveTransport.TLS_H1_NEGOTIABLE);
+        assert.strictEqual(resolveEffectiveTransport({ hasTls: true, allowHTTP1: false }), EffectiveTransport.TLS_H2_ONLY);
+    });
+});
+
+describe("validateTransport", () => {
+    it("mode error + plaintext-h1 + bidi → returns TransportValidationError", () => {
+        const err = validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.PLAINTEXT_H1, mode: "error" });
+
+        assert.ok(err instanceof TransportValidationError);
+        assert.strictEqual(err.code, TRANSPORT_VALIDATION_ERROR_CODE);
+        assert.strictEqual(err.methods.length, 1);
+    });
+
+    it("never fires on HTTP/2-only transports (h2c, TLS without HTTP/1.1)", () => {
+        assert.strictEqual(validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.H2C, mode: "error" }), null);
+        assert.strictEqual(validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.TLS_H2_ONLY, mode: "error" }), null);
+    });
+
+    it("TLS with HTTP/1.1 + bidi → one-time warn, never an error", () => {
+        let result: TransportValidationError | null = null;
+        // Even with mode "error" the TLS-h1 case is only a warning
+        const warnings = captureWarnings(() => {
+            result = validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.TLS_H1_NEGOTIABLE, mode: "error" });
+        });
+
+        assert.strictEqual(result, null);
+        assert.strictEqual(warnings.length, 1);
+        assert.ok(String(warnings[0]?.[0]).includes("allowHTTP1: false"));
+        assert.ok(String(warnings[0]?.[0]).includes("negotiate HTTP/1.1"));
+    });
+
+    it("TLS with HTTP/1.1 + mode off → no warning", () => {
+        let result: TransportValidationError | null = null;
+        const warnings = captureWarnings(() => {
+            result = validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.TLS_H1_NEGOTIABLE, mode: "off" });
+        });
+        assert.strictEqual(result, null);
+        assert.strictEqual(warnings.length, 0);
+    });
+
+    it("never fires for unary/server-streaming-only services on any transport", () => {
+        assert.strictEqual(validateTransport({ registry: [UNARY_ONLY], transport: EffectiveTransport.PLAINTEXT_H1, mode: "error" }), null);
+    });
+
+    it("mode off skips the check entirely", () => {
+        assert.strictEqual(validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.PLAINTEXT_H1, mode: "off" }), null);
+    });
+
+    it("mode warn logs exactly once and returns null", () => {
+        let result: TransportValidationError | null = null;
+        const warnings = captureWarnings(() => {
+            result = validateTransport({ registry: [WITH_BIDI], transport: EffectiveTransport.PLAINTEXT_H1, mode: "warn" });
+        });
+
+        assert.strictEqual(result, null);
+        assert.strictEqual(warnings.length, 1);
+    });
+
+    it("client-streaming alone does NOT trigger validation (works over HTTP/1.1)", () => {
+        assert.strictEqual(validateTransport({ registry: [WITH_CLIENT_STREAM], transport: EffectiveTransport.PLAINTEXT_H1, mode: "error" }), null);
+    });
+});
+
+describe("formatTransportValidationMessage", () => {
+    it("contains methods with kinds, transport mode, remediations, and symptoms", () => {
+        const message = formatTransportValidationMessage([{ service: "acme.v1.ScannerService", method: "StreamCodes", kind: "bidi_streaming" }]);
+
+        // Stable code for log searchability
+        assert.ok(message.includes(TRANSPORT_VALIDATION_ERROR_CODE));
+        // Offending method with kind
+        assert.ok(message.includes("acme.v1.ScannerService.StreamCodes"));
+        assert.ok(message.includes("bidi_streaming"));
+        // Effective transport mode
+        assert.ok(message.includes("plaintext HTTP/1.1"));
+        // Both remediations
+        assert.ok(message.includes("allowHTTP1: false"));
+        assert.ok(message.includes("TLS"));
+        // Runtime symptoms (searchable)
+        assert.ok(message.includes("hangs"));
+        assert.ok(message.includes("505"));
+        // Escape hatch
+        assert.ok(message.includes('transportValidation: "warn" | "off"'));
+    });
+});


### PR DESCRIPTION
## Summary
Bidi-streaming methods require HTTP/2 (Connect protocol), but the default plaintext HTTP/1.1 transport made them hang silently at runtime. `server.start()` now rejects with `TransportValidationError` (code `CONNECTUM_UNSUPPORTED_STREAMING_TRANSPORT`) naming offending user methods and both fixes (`allowHTTP1: false`, or TLS). TLS+HTTP/1.1 emits a one-time warning (residual risk). New `transportValidation: "error" | "warn" | "off"` (default `"error"`). Protocol services (gRPC Reflection) excluded.

## Breaking
Startup now fails for bidi services on plaintext HTTP/1.1 — downgrade with `transportValidation: "warn" | "off"`.

Changeset. From an external production feedback protocol. (Supersedes #136.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Server startup now validates bidi-streaming method compatibility with the effective transport; plaintext HTTP/1.1 rejects by default with `TransportValidationError`.

* **New Features**
  * Added `transportValidation` option to `createServer()` to control validation behavior ("error", "warn", "off").
  * Exported new error type `TransportValidationError` and helper `collectStreamingMethods()` for diagnostics.

* **Documentation**
  * Clarified that interceptors and resilience features (timeout, retry, etc.) are opt-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->