### PR TITLE
chore(interceptors): version-agnostic cockatiel v4 comments + changeset

### DIFF
--- a/.changeset/bump-cockatiel-4.md
+++ b/.changeset/bump-cockatiel-4.md
@@ -1,0 +1,14 @@
+---
+"@connectum/interceptors": patch
+---
+
+Bump `cockatiel` to `4.0.0`.
+
+`cockatiel` 4.0.0 is ESM-only and raises its minimum Node.js to 22 (aligned with
+the framework's `>=22.13.0` floor). The circuit-breaker interceptor remains
+behaviorally identical: the policy executor still invokes the error filter
+without guarding it (so the mandatory fail-closed `try/catch` around the failure
+predicate is retained), and predicate-rejected errors are still rethrown as
+unhandled — they do not increment the breaker and, in half-open, close the
+circuit. Verified against the 4.0.0 sources; the full interceptors test suite
+(158 tests) passes unchanged.

--- a/packages/interceptors/src/circuit-breaker.ts
+++ b/packages/interceptors/src/circuit-breaker.ts
@@ -104,9 +104,10 @@ export function createCircuitBreakerInterceptor(options: CircuitBreakerOptions =
     }
 
     // Classification wrapper. The try/catch is mandatory, not defensive:
-    // cockatiel calls the error filter without protection (Executor.invoke),
-    // so an exception thrown from it propagates as an UNHANDLED error — in
-    // half-open state that would close the circuit, inverting fail-closed.
+    // cockatiel invokes the error filter without guarding it (verified in the
+    // policy executor through cockatiel v4), so an exception thrown from the
+    // predicate propagates as an UNHANDLED error — in half-open state that
+    // would close the circuit, inverting fail-closed.
     const isFailure = (error: unknown): boolean => {
         if (failurePredicate === undefined) {
             return defaultFailurePredicate(error);
@@ -119,9 +120,9 @@ export function createCircuitBreakerInterceptor(options: CircuitBreakerOptions =
         }
     };
 
-    // Errors rejected by the predicate are "unhandled" for cockatiel: they do
-    // not increment the breaker and, in half-open, close the circuit
-    // ("Task failed successfully" path in CircuitBreakerPolicy.halfOpen).
+    // Errors rejected by the predicate are "unhandled" for cockatiel: the
+    // executor rethrows them, so they do not increment the breaker and, in
+    // half-open, they take the success path and close the circuit.
     const breaker = circuitBreaker(handleWhen(isFailure), {
         halfOpenAfter,
         breaker: new ConsecutiveBreaker(threshold),


### PR DESCRIPTION
## What

Follow-up to #143 (cockatiel `3.2.1` → `4.0.0`, merged via dependabot without a changeset).

- Updates `circuit-breaker.ts` comments to be version-agnostic — drops brittle references to internal cockatiel symbols (`Executor.invoke`, `"Task failed successfully"`) while preserving the verified rationale.
- Adds the missing `patch` changeset for `@connectum/interceptors` documenting the cockatiel 4.0.0 bump.

## Why

cockatiel 4.0.0 is ESM-only and raises its Node floor to 22 (aligned with the framework's `>=22.13.0`). The bump is a major version of a runtime dependency of a published package, so it must appear in the changelog.

## Verification

Verified against the cockatiel 4.0.0 sources that circuit-breaker behavior is unchanged:
- The policy executor still invokes the error filter **without** guarding it → the mandatory fail-closed `try/catch` around the failure predicate is retained.
- Predicate-rejected errors are still rethrown as unhandled → they do not increment the breaker and, in half-open, close the circuit.

Local: `build` ✅, `typecheck` ✅, interceptors tests **158/158** ✅, `lint` ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js requirement to 22.13.0+
  * Upgraded interceptors package dependency to the latest version with ESM-only module format

* **Documentation**
  * Clarified circuit-breaker error handling behavior in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->