### PR TITLE
chore(deps): resolve Dependabot security alerts via pnpm overrides

### DIFF
--- a/.changeset/security-overrides.md
+++ b/.changeset/security-overrides.md
@@ -2,3 +2,17 @@
 ---
 
 Resolve critical and high security vulnerabilities (CVE-2026-27699, CVE-2026-27606, CVE-2026-26996, CVE-2026-27903) via pnpm overrides for basic-ftp, rollup, and minimatch.
+
+Additional Dependabot alert resolutions via pnpm overrides:
+
+- `protobufjs` floor raised `<7.5.5 → 7.5.8` (transitive via `@grpc/grpc-js → @grpc/proto-loader`).
+- `@grpc/grpc-js` floor `<1.14.4 → 1.14.4` (transitive via the OpenTelemetry OTLP/gRPC exporters).
+- `fast-uri` floor `<3.1.2 → 3.1.2` (dev-only, via `ajv → @commitlint`).
+- `qs` floor `<6.15.2 → 6.15.2` (dev-only, via `@exodus/test`).
+
+The duplicate `protobufjs@8.x` copy (via `@opentelemetry/otlp-transformer`) is
+resolved separately by upgrading OpenTelemetry to `0.219.0` (its transformer no
+longer depends on `protobufjs`), not by an override. The `esbuild` advisory is
+deferred: `esbuild@0.28.x` is incompatible with the current `tsup` (`esbuild
+^0.25`), and esbuild is a build-time tool that does not ship in the compiled
+`dist`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,15 +98,18 @@ catalogs:
       version: 4.4.2
 
 overrides:
+  '@grpc/grpc-js@<1.14.4': 1.14.4
   ajv@<8.18.0: 8.18.0
-  minimatch@<10.2.3: 10.2.3
   basic-ftp@<5.2.2: 5.2.2
-  rollup@>=4.0.0 <4.59.0: 4.59.0
+  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  fast-uri@<3.1.2: 3.1.2
+  minimatch@<10.2.3: 10.2.3
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
-  protobufjs@<7.5.5: 7.5.5
+  protobufjs@<7.5.8: 7.5.8
   protobufjs@>=8.0.0 <8.0.1: 8.0.1
+  qs@<6.15.2: 6.15.2
+  rollup@>=4.0.0 <4.59.0: 4.59.0
 
 importers:
 
@@ -1208,21 +1211,12 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
-    engines: {node: '>=12.10.0'}
-
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  '@grpc/proto-loader@0.8.0':
-    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -2308,8 +2302,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3014,8 +3008,8 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  protobufjs@7.5.5:
-    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   protobufjs@8.0.3:
@@ -3043,8 +3037,8 @@ packages:
     resolution: {integrity: sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==}
     engines: {node: '>=18'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -4253,11 +4247,6 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@grpc/grpc-js@1.14.3':
-    dependencies:
-      '@grpc/proto-loader': 0.8.0
-      '@js-sdsl/ordered-map': 4.4.2
-
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -4267,21 +4256,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
-      yargs: 17.7.2
-
-  '@grpc/proto-loader@0.8.0':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       yargs: 17.7.2
 
   '@inquirer/external-editor@1.0.3(@types/node@25.6.0)':
@@ -4441,7 +4423,7 @@ snapshots:
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
@@ -4460,7 +4442,7 @@ snapshots:
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.215.0(@opentelemetry/api@1.9.1)
@@ -4481,7 +4463,7 @@ snapshots:
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
@@ -4507,7 +4489,7 @@ snapshots:
 
   '@opentelemetry/otlp-grpc-exporter-base@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
@@ -4841,7 +4823,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5255,7 +5237,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 7.5.5
+      protobufjs: 7.5.8
       tar-fs: 2.1.4
     transitivePeerDependencies:
       - supports-color
@@ -5410,7 +5392,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6147,7 +6129,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  protobufjs@7.5.5:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -6212,7 +6194,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
     optional: true
@@ -6728,7 +6710,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.15.1
+      qs: 6.15.2
     optional: true
 
   util-deprecate@1.0.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,12 +47,15 @@ catalog:
   typescript: ^5.9.3
   zod: ^4.3.6
 overrides:
+  '@grpc/grpc-js@<1.14.4': 1.14.4
   ajv@<8.18.0: 8.18.0
   basic-ftp@<5.2.2: 5.2.2
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  fast-uri@<3.1.2: 3.1.2
   minimatch@<10.2.3: 10.2.3
   picomatch@<2.3.2: 2.3.2
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  protobufjs@<7.5.5: 7.5.5
+  protobufjs@<7.5.8: 7.5.8
   protobufjs@>=8.0.0 <8.0.1: 8.0.1
+  qs@<6.15.2: 6.15.2
   rollup@>=4.0.0 <4.59.0: 4.59.0


### PR DESCRIPTION
## What

Raise pnpm override floors to close open Dependabot security advisories. Supersedes #118 (which only raised protobufjs to 7.5.6 — below the required 7.5.8 — and had a stale lockfile).

| Package | Floor | Path | Severity |
|---------|-------|------|----------|
| `protobufjs` | `<7.5.5 → 7.5.8` | runtime (`@grpc/grpc-js → @grpc/proto-loader`) | — |
| `@grpc/grpc-js` | `<1.14.4 → 1.14.4` | runtime (OTLP/gRPC exporters) | high |
| `fast-uri` | `<3.1.2 → 3.1.2` | dev-only (`ajv → @commitlint`) | high |
| `qs` | `<6.15.2 → 6.15.2` | dev-only (`@exodus/test`) | medium |

## Not in this PR (by design)

- **`protobufjs@8.x`** (via `@opentelemetry/otlp-transformer`) — resolved separately by upgrading OpenTelemetry to `0.219.0` (its transformer dropped `protobufjs` in 0.218), not by an override.
- **`esbuild`** advisory — deferred. `esbuild@0.28.x` is incompatible with the current `tsup` (`esbuild ^0.25`, no tsup release supports 0.28.x), and esbuild is a build-time tool that does not ship in the compiled `dist`.

## Verification

Applied floors confirmed in the tree: `protobufjs@7.5.8`, `@grpc/grpc-js@1.14.4`, `fast-uri@3.1.2`, `qs@6.15.2`.

Local: `build` 16/16 ✅, `typecheck` ✅, `otel`/`core`/`interceptors` tests ✅, `lint` ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Resolved critical and high-severity vulnerabilities across multiple dependencies to enhance application stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->