### PR TITLE
feat(otel): support service.instance.id and custom resource attributes

### DIFF
--- a/.changeset/otel-resource-attributes.md
+++ b/.changeset/otel-resource-attributes.md
@@ -1,0 +1,19 @@
+---
+"@connectum/otel": minor
+---
+
+Support `service.instance.id` and custom resource attributes in `initProvider`.
+
+`ProviderOptions` gains two optional, backwards-compatible fields:
+
+- `instanceId` — sets `service.instance.id` on the resource (OTel semconv), so a
+  fleet of same-role processes can be told apart in telemetry.
+- `resourceAttributes` — extra resource attributes (e.g. `device.id`,
+  `facility`) merged into the resource.
+
+The standard `OTEL_SERVICE_INSTANCE_ID` and `OTEL_RESOURCE_ATTRIBUTES` env vars
+are now honored, with explicit options taking precedence. The resource is built
+once and shared across traces, metrics, and logs so instance id and custom
+attributes apply consistently to every signal (previously the resource was
+built three times from service name/version only). Existing callers are
+unaffected — all new fields are optional.

--- a/packages/otel/src/provider.ts
+++ b/packages/otel/src/provider.ts
@@ -17,6 +17,7 @@ import { OTLPMetricExporter as OTLPMetricExporterGRPC } from "@opentelemetry/exp
 import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exporter-metrics-otlp-http";
 import { OTLPTraceExporter as OTLPTraceExporterGRPC } from "@opentelemetry/exporter-trace-otlp-grpc";
 import { OTLPTraceExporter as OTLPTraceExporterHTTP } from "@opentelemetry/exporter-trace-otlp-http";
+import type { Resource } from "@opentelemetry/resources";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ConsoleLogRecordExporter, LoggerProvider, SimpleLogRecordProcessor } from "@opentelemetry/sdk-logs";
 import { ConsoleMetricExporter, MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
@@ -24,6 +25,9 @@ import { BatchSpanProcessor, ConsoleSpanExporter, NodeTracerProvider } from "@op
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import type { CollectorOptions, OTLPSettings } from "./config.ts";
 import { ExporterType, getBatchSpanProcessorOptions, getCollectorOptions, getOTLPSettings, getServiceMetadata } from "./config.ts";
+
+/** OpenTelemetry semconv key for the service instance id. */
+const ATTR_SERVICE_INSTANCE_ID = "service.instance.id";
 
 /**
  * Options for initializing the OpenTelemetry provider
@@ -33,8 +37,88 @@ export interface ProviderOptions {
     serviceName?: string;
     /** Override service version (defaults to npm_package_version) */
     serviceVersion?: string;
+    /**
+     * Sets `service.instance.id` on the resource (OTel semconv). Lets a fleet of
+     * same-role processes be told apart in telemetry. Takes precedence over the
+     * `OTEL_SERVICE_INSTANCE_ID` env var.
+     */
+    instanceId?: string;
+    /**
+     * Extra resource attributes merged into the resource (e.g. `device.id`,
+     * `facility`). Applied to traces, metrics, and logs alike. Takes precedence
+     * over attributes parsed from the `OTEL_RESOURCE_ATTRIBUTES` env var.
+     */
+    resourceAttributes?: Record<string, string | number | boolean>;
     /** Override OTLP exporter settings (defaults to env-based config) */
     settings?: Partial<OTLPSettings>;
+}
+
+/**
+ * Parse the standard `OTEL_RESOURCE_ATTRIBUTES` env var
+ * (`key1=value1,key2=value2`) into an attribute record. Malformed pairs (no
+ * `=`, empty key) are skipped. Values are kept as strings; whitespace around
+ * keys and values is trimmed.
+ */
+export function parseOtelResourceAttributesEnv(raw: string | undefined): Record<string, string> {
+    if (raw === undefined || raw === "") {
+        return {};
+    }
+    const result: Record<string, string> = {};
+    for (const pair of raw.split(",")) {
+        const eq = pair.indexOf("=");
+        if (eq <= 0) {
+            continue;
+        }
+        const key = pair.slice(0, eq).trim();
+        const value = pair.slice(eq + 1).trim();
+        if (key !== "") {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+/** Inputs for {@link buildResourceAttributes}. */
+export interface ResourceAttributeInputs {
+    serviceName: string;
+    serviceVersion: string;
+    instanceId?: string | undefined;
+    resourceAttributes?: Record<string, string | number | boolean> | undefined;
+    /** Environment source (defaults to `process.env`). */
+    env?: { OTEL_RESOURCE_ATTRIBUTES?: string; OTEL_SERVICE_INSTANCE_ID?: string } | undefined;
+}
+
+/**
+ * Build the flat resource-attribute record shared by traces, metrics, and logs.
+ *
+ * Precedence (lowest to highest): `service.name`/`service.version` → env
+ * (`OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_INSTANCE_ID`) → explicit
+ * `resourceAttributes` → explicit `instanceId`.
+ */
+export function buildResourceAttributes(inputs: ResourceAttributeInputs): Record<string, string | number | boolean> {
+    const env = inputs.env ?? process.env;
+
+    const attributes: Record<string, string | number | boolean> = {
+        [ATTR_SERVICE_NAME]: inputs.serviceName,
+        [ATTR_SERVICE_VERSION]: inputs.serviceVersion,
+        // Env-provided attributes (lower precedence than explicit options).
+        ...parseOtelResourceAttributesEnv(env.OTEL_RESOURCE_ATTRIBUTES),
+    };
+
+    const envInstanceId = env.OTEL_SERVICE_INSTANCE_ID;
+    if (envInstanceId !== undefined && envInstanceId !== "") {
+        attributes[ATTR_SERVICE_INSTANCE_ID] = envInstanceId;
+    }
+
+    // Explicit options take precedence over env.
+    if (inputs.resourceAttributes !== undefined) {
+        Object.assign(attributes, inputs.resourceAttributes);
+    }
+    if (inputs.instanceId !== undefined && inputs.instanceId !== "") {
+        attributes[ATTR_SERVICE_INSTANCE_ID] = inputs.instanceId;
+    }
+
+    return attributes;
 }
 
 /**
@@ -57,6 +141,7 @@ class OtelProvider {
     private readonly collectorOptions: CollectorOptions;
     private readonly serviceName: string;
     private readonly serviceVersion: string;
+    private readonly resource: Resource;
 
     constructor(options?: ProviderOptions) {
         // Set diagnostic logger to ERROR level
@@ -76,10 +161,30 @@ class OtelProvider {
         this.serviceName = options?.serviceName ?? metadata.name;
         this.serviceVersion = options?.serviceVersion ?? metadata.version;
 
+        // Build the resource once and share it across traces, metrics, and logs
+        // so service.instance.id and custom attributes apply to every signal.
+        this.resource = this.buildResource(options);
+
         // Initialize providers
         this.tracer = this.createTracer();
         this.meter = this.createMeter();
         this.logger = this.createLogger();
+    }
+
+    /**
+     * Build the OpenTelemetry resource from service metadata, environment
+     * variables, and explicit options. See {@link buildResourceAttributes} for
+     * the precedence rules.
+     */
+    private buildResource(options?: ProviderOptions): Resource {
+        return resourceFromAttributes(
+            buildResourceAttributes({
+                serviceName: this.serviceName,
+                serviceVersion: this.serviceVersion,
+                instanceId: options?.instanceId,
+                resourceAttributes: options?.resourceAttributes,
+            }),
+        );
     }
 
     /**
@@ -93,11 +198,8 @@ class OtelProvider {
             return trace.getTracer(this.serviceName, this.serviceVersion);
         }
 
-        // Create resource with service metadata
-        const resource = resourceFromAttributes({
-            [ATTR_SERVICE_NAME]: this.serviceName,
-            [ATTR_SERVICE_VERSION]: this.serviceVersion,
-        });
+        // Shared resource (service metadata + instance id + custom attributes)
+        const resource = this.resource;
 
         // Create exporter based on protocol
         let traceExporter: OTLPTraceExporterHTTP | OTLPTraceExporterGRPC | ConsoleSpanExporter;
@@ -165,10 +267,7 @@ class OtelProvider {
 
         // Create meter provider with periodic exporter
         this.meterProvider = new MeterProvider({
-            resource: resourceFromAttributes({
-                [ATTR_SERVICE_NAME]: this.serviceName,
-                [ATTR_SERVICE_VERSION]: this.serviceVersion,
-            }),
+            resource: this.resource,
             readers: [
                 new PeriodicExportingMetricReader({
                     exporter: metricExporter,
@@ -212,10 +311,7 @@ class OtelProvider {
 
         // Create logger provider with processors
         this.loggerProvider = new LoggerProvider({
-            resource: resourceFromAttributes({
-                [ATTR_SERVICE_NAME]: this.serviceName,
-                [ATTR_SERVICE_VERSION]: this.serviceVersion,
-            }),
+            resource: this.resource,
             processors: [new SimpleLogRecordProcessor(logExporter)],
         });
 

--- a/packages/otel/tests/unit/provider.test.ts
+++ b/packages/otel/tests/unit/provider.test.ts
@@ -4,7 +4,11 @@
 
 import assert from "node:assert";
 import { afterEach, describe, it } from "node:test";
-import { getProvider, initProvider, shutdownProvider } from "../../src/provider.ts";
+import { buildResourceAttributes, getProvider, initProvider, parseOtelResourceAttributesEnv, shutdownProvider } from "../../src/provider.ts";
+
+const ATTR_SERVICE_NAME = "service.name";
+const ATTR_SERVICE_VERSION = "service.version";
+const ATTR_SERVICE_INSTANCE_ID = "service.instance.id";
 
 // Disable real exporters for tests
 process.env.OTEL_TRACES_EXPORTER = "none";
@@ -56,5 +60,72 @@ describe("provider", () => {
 			// Should not throw
 			await shutdownProvider();
 		});
+	});
+
+	it("should accept instanceId and resourceAttributes without throwing", () => {
+		assert.doesNotThrow(() => initProvider({ instanceId: "pod-7", resourceAttributes: { "device.id": "abc" } }));
+	});
+});
+
+describe("parseOtelResourceAttributesEnv", () => {
+	it("returns empty for undefined or empty input", () => {
+		assert.deepStrictEqual(parseOtelResourceAttributesEnv(undefined), {});
+		assert.deepStrictEqual(parseOtelResourceAttributesEnv(""), {});
+	});
+
+	it("parses comma-separated key=value pairs and trims whitespace", () => {
+		assert.deepStrictEqual(parseOtelResourceAttributesEnv("a=1, b = two ,c=3"), { a: "1", b: "two", c: "3" });
+	});
+
+	it("keeps '=' inside values and skips malformed pairs", () => {
+		assert.deepStrictEqual(parseOtelResourceAttributesEnv("url=http://x?a=b,=noKey,bad,k=v"), { url: "http://x?a=b", k: "v" });
+	});
+});
+
+describe("buildResourceAttributes", () => {
+	const base = { serviceName: "svc", serviceVersion: "1.2.3" };
+
+	it("includes service name and version by default", () => {
+		const attrs = buildResourceAttributes({ ...base, env: {} });
+		assert.strictEqual(attrs[ATTR_SERVICE_NAME], "svc");
+		assert.strictEqual(attrs[ATTR_SERVICE_VERSION], "1.2.3");
+		assert.strictEqual(attrs[ATTR_SERVICE_INSTANCE_ID], undefined);
+	});
+
+	it("sets service.instance.id from explicit instanceId", () => {
+		const attrs = buildResourceAttributes({ ...base, instanceId: "pod-7", env: {} });
+		assert.strictEqual(attrs[ATTR_SERVICE_INSTANCE_ID], "pod-7");
+	});
+
+	it("sets service.instance.id from OTEL_SERVICE_INSTANCE_ID env", () => {
+		const attrs = buildResourceAttributes({ ...base, env: { OTEL_SERVICE_INSTANCE_ID: "env-pod" } });
+		assert.strictEqual(attrs[ATTR_SERVICE_INSTANCE_ID], "env-pod");
+	});
+
+	it("explicit instanceId takes precedence over env", () => {
+		const attrs = buildResourceAttributes({ ...base, instanceId: "explicit", env: { OTEL_SERVICE_INSTANCE_ID: "env-pod" } });
+		assert.strictEqual(attrs[ATTR_SERVICE_INSTANCE_ID], "explicit");
+	});
+
+	it("merges OTEL_RESOURCE_ATTRIBUTES env attributes", () => {
+		const attrs = buildResourceAttributes({ ...base, env: { OTEL_RESOURCE_ATTRIBUTES: "device.id=d1,facility=f1" } });
+		assert.strictEqual(attrs["device.id"], "d1");
+		assert.strictEqual(attrs.facility, "f1");
+	});
+
+	it("explicit resourceAttributes take precedence over env attributes", () => {
+		const attrs = buildResourceAttributes({
+			...base,
+			resourceAttributes: { "device.id": "explicit" },
+			env: { OTEL_RESOURCE_ATTRIBUTES: "device.id=env,facility=f1" },
+		});
+		assert.strictEqual(attrs["device.id"], "explicit");
+		assert.strictEqual(attrs.facility, "f1");
+	});
+
+	it("supports non-string attribute values", () => {
+		const attrs = buildResourceAttributes({ ...base, resourceAttributes: { replica: 3, primary: true }, env: {} });
+		assert.strictEqual(attrs.replica, 3);
+		assert.strictEqual(attrs.primary, true);
 	});
 });


### PR DESCRIPTION
Closes #132.

## What

`ProviderOptions` gains two optional, backwards-compatible fields so a fleet of same-role processes can be told apart in telemetry:

- **`instanceId`** — sets `service.instance.id` on the resource (OTel semconv).
- **`resourceAttributes`** — extra resource attributes (e.g. `device.id`, `facility`) merged into the resource.

The standard **`OTEL_SERVICE_INSTANCE_ID`** and **`OTEL_RESOURCE_ATTRIBUTES`** env vars are now honored, with explicit options taking precedence.

## Why

Previously the resource was built **three times** (traces / metrics / logs) from `service.name` + `service.version` only. A fleet of same-role processes carried identical resource attributes, so their series collapsed onto one identity in the backend. Now the resource is built **once** and shared across all three signals, so instance id and custom attributes apply consistently.

## Precedence

`service.name`/`service.version` → env (`OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_INSTANCE_ID`) → explicit `resourceAttributes` → explicit `instanceId`.

## Verification

Pure-function `buildResourceAttributes` extracted for contract testing — 8 unit tests cover precedence (explicit > env), env parsing (malformed pairs skipped, `=` preserved in values), and non-string values. All `@connectum/otel` tests pass (13 suites). `build` / `typecheck` / `lint` clean. Backwards compatible — all new fields optional. Changeset: `minor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for custom OpenTelemetry resource attributes and service instance ID configuration
* New optional `instanceId` and `resourceAttributes` configuration options
* Support for `OTEL_SERVICE_INSTANCE_ID` and `OTEL_RESOURCE_ATTRIBUTES` environment variables
* Improved resource consistency across traces, metrics, and logs

## Tests
* Extended test coverage for provider configuration and attribute parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->