### PR TITLE
chore: exit changeset pre-release mode for stable 1.0.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@connectum/cli": "1.0.0-beta.2",


### PR DESCRIPTION
Flip `.changeset/pre.json` from `pre` to `exit` so the next `changeset version` run produces stable `1.0.0` versions instead of `rc` pre-releases.

After this merges, the Changesets Release workflow regenerates the **Version Packages** PR with the final `1.0.0` bumps (consuming the accumulated changesets) instead of an `rc.N` bump.

Single-line change to `.changeset/pre.json`; no package or source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->