### PR TITLE
fix(release-notes): strip HTML comments from highlights

### DIFF
--- a/scripts/build-release-notes.mjs
+++ b/scripts/build-release-notes.mjs
@@ -126,9 +126,13 @@ const sharedKeys = new Set([...groups.entries()].filter(([, g]) => g.pkgs.size >
 
 const out = [];
 
-// 1. Highlights (curated).
+// 1. Highlights (curated). HTML comments hold maintainer guidance that must not
+// leak into the published notes, so they are stripped out.
 if (existsSync(highlightsFile)) {
-    const hl = readFileSync(highlightsFile, "utf8").trim();
+    const hl = readFileSync(highlightsFile, "utf8")
+        .replace(/<!--[\s\S]*?-->/g, "")
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
     if (hl) {
         out.push("## Highlights", "", hl, "");
     }

--- a/scripts/build-release-notes.mjs
+++ b/scripts/build-release-notes.mjs
@@ -46,6 +46,28 @@ const highlightsFile = getOpt("--highlights", ".github/RELEASE_HIGHLIGHTS.md");
 
 const CATEGORIES = ["Major Changes", "Minor Changes", "Patch Changes"];
 
+/**
+ * Remove HTML comments (maintainer guidance in the highlights file) without a
+ * regex, scanning for `<!--`/`-->` pairs. An unterminated `<!--` drops the
+ * remainder so no dangling comment marker survives into the published notes.
+ */
+function stripHtmlComments(input) {
+    let result = "";
+    let i = 0;
+    while (i < input.length) {
+        const open = input.indexOf("<!--", i);
+        if (open === -1) {
+            result += input.slice(i);
+            break;
+        }
+        result += input.slice(i, open);
+        const close = input.indexOf("-->", open + 4);
+        if (close === -1) break; // unterminated: drop the rest, leaving no `<!--`
+        i = close + 3;
+    }
+    return result;
+}
+
 /** Extract the body of the `## <version>` section from a CHANGELOG. */
 function extractVersionSection(changelog, ver) {
     const lines = changelog.split("\n");
@@ -129,8 +151,7 @@ const out = [];
 // 1. Highlights (curated). HTML comments hold maintainer guidance that must not
 // leak into the published notes, so they are stripped out.
 if (existsSync(highlightsFile)) {
-    const hl = readFileSync(highlightsFile, "utf8")
-        .replace(/<!--[\s\S]*?-->/g, "")
+    const hl = stripHtmlComments(readFileSync(highlightsFile, "utf8"))
         .replace(/\n{3,}/g, "\n\n")
         .trim();
     if (hl) {


### PR DESCRIPTION
## Type of change
- [x] CI / release tooling fix (no package source or runtime changes)

## What & why
`.github/RELEASE_HIGHLIGHTS.md` includes an HTML maintainer-guidance comment. The release-notes generator copied the highlights verbatim, so that comment leaked (invisibly, but present in the raw markdown) into both the draft GitHub Release and the Version Packages PR body. This strips all HTML comments from the highlights before emitting.

## Test plan
- [x] Highlights output no longer contains `<!-- -->`; first line is a bullet.
- [x] End-to-end generation still emits `## Highlights → ## Repo-wide changes → ## Package changes`.
- [x] `biome check` clean.

## Parity coverage
- [x] N/A — release tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)