### PR TITLE
ci(auto-label): self-heal labels on synchronize/reopened/edited

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: Auto Label
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened, edited]
   issues:
     types: [opened]
 


### PR DESCRIPTION
## Problem

The Auto Label workflow triggers only on `pull_request: types: [opened]`. If the
`opened` event's run does not materialize for a PR, the PR stays **permanently
unlabeled** — subsequent pushes emit `synchronize`, which the workflow ignores,
so there is no second chance to apply labels. This was observed on a real
feature PR that ended up with no `type:` or `pkg:` labels.

## Fix

Add `synchronize, reopened, edited` to the `pull_request` trigger types so a
later push (or a title edit) re-applies labels.

Both steps are safe to re-run:

- the title-detection `addLabels` call is additive and swallows the `422` when a
  label already exists;
- `actions/labeler` runs with `sync-labels: false`, so it only **adds** package
  labels for matching paths and never removes them.

`edited` additionally catches the case where a `!` is added to the title (or
`BREAKING CHANGE` to the body) after opening, so the `breaking change` label is
applied without reopening the PR.

The `issues` trigger is intentionally left as `[opened]` — issue triage labels
should not be re-applied on every edit.