### PR TITLE
fix: publish-boundary defects in @connectum/core and @connectum/testing

### DIFF
--- a/.changeset/fix-core-const-enum-exports.md
+++ b/.changeset/fix-core-const-enum-exports.md
@@ -1,0 +1,7 @@
+---
+"@connectum/core": patch
+---
+
+fix: re-export `EffectiveTransport` and `TransportValidationMode` as values from the package root
+
+These are ADR-001 const-object enums — they carry both a runtime value and a type. They were re-exported from the barrel with `export type { … }`, which erased the runtime const: consumers got `undefined` (e.g. `TransportValidationMode.ERROR`, `EffectiveTransport.TLS_H2_ONLY`) while the generated `.d.ts` still advertised them as usable values, so calls type-checked and then crashed (or compared always-false against `resolveEffectiveTransport()`). They are now re-exported as values, carrying both the const and the type.

--- a/.changeset/fix-testing-parity-node-protocol.md
+++ b/.changeset/fix-testing-parity-node-protocol.md
@@ -1,0 +1,7 @@
+---
+"@connectum/testing": patch
+---
+
+fix: make `@connectum/testing/parity` importable by preserving the `node:` protocol prefix
+
+tsup strips the `node:` prefix from builtin imports by default (`removeNodeProtocol: true`). For `node:test` that is fatal — the unprefixed `test` has no bare builtin equivalent, so the published `dist/parity.js` shipped `import { test } from "test"` and threw `Cannot find package 'test'` in every consumer of the `./parity` subpath. Setting `removeNodeProtocol: false` keeps `node:test` (and other builtins) intact; the consumer floor is Node >=22.13 where the prefix is required for `node:test` and supported for every builtin.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,8 +53,18 @@ export { isSanitizableError } from "./errors.ts";
 // TLS utilities
 export { getTLSPath, readTLSCertificates, tlsPath } from "./TLSConfig.ts";
 // Transport validation (streaming kinds vs transport)
-export type { EffectiveTransport, StreamingMethodInfo, TransportValidationMode } from "./TransportValidation.ts";
-export { collectStreamingMethods, resolveEffectiveTransport, TRANSPORT_VALIDATION_ERROR_CODE, TransportValidationError } from "./TransportValidation.ts";
+// EffectiveTransport / TransportValidationMode are const-object enums (ADR-001):
+// they carry a runtime value AND a type, so they must be re-exported as values
+// (a type-only re-export erases the const → undefined at runtime).
+export type { StreamingMethodInfo } from "./TransportValidation.ts";
+export {
+    collectStreamingMethods,
+    EffectiveTransport,
+    resolveEffectiveTransport,
+    TRANSPORT_VALIDATION_ERROR_CODE,
+    TransportValidationError,
+    TransportValidationMode,
+} from "./TransportValidation.ts";
 
 // =============================================================================
 // TYPES

--- a/packages/core/tests/unit/publicExports.test.ts
+++ b/packages/core/tests/unit/publicExports.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Public-API surface regression tests.
+ *
+ * Const-object enums (ADR-001) carry BOTH a runtime value and a type. They must
+ * be re-exported from the package barrel (`src/index.ts`) as VALUES — a
+ * type-only re-export (`export type { X }`) erases the runtime const, leaving
+ * the symbol `undefined` for every consumer while the `.d.ts` still advertises
+ * it as a value. (Regression: `EffectiveTransport` / `TransportValidationMode`
+ * were re-exported as types and shipped `undefined` in 1.0.0-rc.) These imports
+ * come from the BARREL on purpose — importing the source module directly would
+ * not reproduce the erasure.
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { EffectiveTransport, ServerState, TransportValidationMode } from "../../src/index.ts";
+
+describe("public exports — const-object enums are runtime values from the barrel", () => {
+    it("TransportValidationMode is a runtime object with its documented members", () => {
+        assert.strictEqual(typeof TransportValidationMode, "object");
+        assert.deepStrictEqual({ ...TransportValidationMode }, { ERROR: "error", WARN: "warn", OFF: "off" });
+    });
+
+    it("EffectiveTransport is a runtime object with its documented members", () => {
+        assert.strictEqual(typeof EffectiveTransport, "object");
+        assert.deepStrictEqual({ ...EffectiveTransport }, {
+            PLAINTEXT_H1: "plaintext-h1",
+            H2C: "h2c",
+            TLS_H1_NEGOTIABLE: "tls-h1-negotiable",
+            TLS_H2_ONLY: "tls-h2-only",
+        });
+    });
+
+    it("ServerState (existing const-enum) stays a runtime value too", () => {
+        assert.strictEqual(typeof ServerState, "object");
+    });
+});

--- a/packages/testing/tests/integration/parityBuildOutput.test.ts
+++ b/packages/testing/tests/integration/parityBuildOutput.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Build-output regression for the `./parity` subpath.
+ *
+ * tsup strips the `node:` prefix from builtin imports by default
+ * (`removeNodeProtocol: true`). For `node:test` that is fatal — the unprefixed
+ * `test` has no bare builtin equivalent, so the published `dist/parity.js`
+ * shipped `import { test } from "test"` and threw `Cannot find package 'test'`
+ * in every consumer. The fix is `removeNodeProtocol: false` in tsup.config.ts;
+ * this guards the built artifact against the regression. (build → test in the
+ * turbo graph guarantees dist exists when this runs.)
+ */
+
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const parityJs = fileURLToPath(new URL("../../dist/parity.js", import.meta.url));
+
+describe("parity build output — node: protocol preserved", () => {
+    const src = readFileSync(parityJs, "utf8");
+
+    it("imports node:test with its prefix (never bare 'test')", () => {
+        assert.match(src, /from\s*"node:test"/, "expected `from \"node:test\"` in dist/parity.js");
+        assert.doesNotMatch(src, /from\s*"test"/, "bare `from \"test\"` would be unresolvable for consumers");
+    });
+
+    it("keeps the node: prefix on other builtins (e.g. node:assert)", () => {
+        assert.doesNotMatch(src, /from\s*"assert"/, "bare `from \"assert\"` indicates node: stripping is back on");
+    });
+});

--- a/packages/testing/tsup.config.ts
+++ b/packages/testing/tsup.config.ts
@@ -8,4 +8,11 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // tsup strips the `node:` prefix from builtin imports by default
+    // (removeNodeProtocol: true). For `node:test` that is fatal: the unprefixed
+    // `test` has no bare builtin equivalent, so `dist/parity.js` shipped
+    // `import { test } from "test"` and threw `Cannot find package 'test'` in
+    // every consumer. The consumer floor is Node >=22.13 where the `node:`
+    // prefix is required for node:test and supported for every builtin, so keep it.
+    removeNodeProtocol: false,
 });


### PR DESCRIPTION
## Summary

Two consumer-facing publish-boundary defects found while validating the 1.0.0 preview packages as a third-party consumer (installed from packed artifacts, every `exports` subpath, `.d.ts` vs runtime, full public surface). Both are invisible to the framework's own build, to `tsc`, and to the type-stripped examples — they only manifest in the published, packed artifacts.

## Fixes

### `@connectum/core` — const-enum values erased at runtime (`6ba1276`)
`EffectiveTransport` and `TransportValidationMode` are ADR-001 const-object enums (each is both a runtime value and a type). The package barrel re-exported them with `export type { … }`, which erased the runtime const: consumers got `undefined` (`TransportValidationMode.ERROR`, `EffectiveTransport.TLS_H2_ONLY`, or comparisons against `resolveEffectiveTransport()`) while the generated `.d.ts` still advertised them as usable values — so the code type-checked and then crashed at runtime. Now re-exported as values (carrying both const and type).

### `@connectum/testing/parity` — unimportable subpath (`754c999`)
tsup strips the `node:` prefix from builtin imports by default (`removeNodeProtocol: true`). For `node:test` that is fatal — the unprefixed `test` has no bare builtin equivalent, so `dist/parity.js` shipped `import { test } from "test"` and threw `Cannot find package 'test'` in every consumer of the `@connectum/testing/parity` subpath. Set `removeNodeProtocol: false` (the consumer floor is Node >=22.13, where the `node:` prefix is required for `node:test` and supported for every builtin).

## Tests
- `packages/core/tests/unit/publicExports.test.ts` — asserts the const-object enums are runtime values when imported from the barrel.
- `packages/testing/tests/integration/parityBuildOutput.test.ts` — asserts the built `dist/parity.js` keeps the `node:test` prefix.

## Verification
Repo-wide `typecheck` + `test:unit` + `lint` green. Re-validated the fixed packages as a consumer (every export subpath resolves, `.d.ts` graph type-checks under `skipLibCheck:false`, declared value-exports present at runtime, `./parity` importable). Both changesets are `patch`, absorbed into the 1.0.0 release bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@connectum/core` to properly export transport validation enums as runtime values, enabling correct access by consumers
  * Fixed `@connectum/testing/parity` to preserve Node.js built-in import protocol prefixes for correct module resolution

* **Tests**
  * Added regression tests for public API exports and parity build output validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->