### PR TITLE
feat(release-gate): publish-boundary gate + pre-release behavioral smoke

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,3 +32,23 @@ jobs:
         run: pnpm build
 
       - run: pnpx pkg-pr-new publish --pnpm './packages/*'
+
+  release-gate:
+    name: Release Gate (pre-release smoke + publish boundary)
+    needs: snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "25.2.0"
+          cache: pnpm
+
+      # Validate the just-published pre-release as a third-party consumer:
+      # install every @connectum/* from this PR's pkg-pr-new snapshot (pinned to
+      # the head SHA), then run the publish-boundary oracle + behavioral smoke.
+      - name: Run release gate against the PR snapshot
+        run: node scripts/release-gate/run.mjs --mode preview --ref "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,7 +38,11 @@ jobs:
     needs: snapshot
     runs-on: ubuntu-latest
     steps:
+      # This job runs the PR's code (the gate executes the PR's scripts), so do
+      # not persist the checkout token in local git config.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
+.tmp/
+.gate-work/
 .idea/
 .vscode/
 .husky/_/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "lint": "turbo run lint",
     "format": "turbo run format",
     "biome": "biome check --write .",
+    "release:gate": "node scripts/release-gate/run.mjs --mode pack",
+    "release:gate:preview": "node scripts/release-gate/run.mjs --mode preview",
     "dev": "turbo run dev --parallel",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "changeset": "changeset",

--- a/scripts/release-gate/README.md
+++ b/scripts/release-gate/README.md
@@ -10,25 +10,30 @@ unimportable subpaths, and catalog-codegen breakage.
 
 `run.mjs` builds a throwaway consumer from [`fixture/`](./fixture), installs every
 published `@connectum/*` package from the chosen source, generates the service
-catalog, then runs four publish-boundary checks plus the behavioral smoke:
+catalog, then runs six publish-boundary checks plus the behavioral smoke:
 
-1. **export-map** — every `exports` subpath resolves to a real file on disk.
+1. **export-map** ([`checks/oracle.mjs`](./fixture/checks/oracle.mjs)) — every `exports` subpath resolves to a real file on disk.
 2. **`.d.ts` graph** ([`checks/oracle.mjs`](./fixture/checks/oracle.mjs)) —
    namespace-imports every subpath and type-checks the full declaration graph
    with `skipLibCheck: false` under a realistic consumer tsconfig (DOM/fetch lib
    via `target esnext`, so `@connectrpc`-inherited globals like `HeadersInit`
    resolve). Enumerates each subpath's value/type exports into `gen-cov/report.json`.
 3. **value-export completeness** ([`checks/completeness.mjs`](./fixture/checks/completeness.mjs)) —
-   every value export declared in the `.d.ts` must be present in the runtime
-   `Object.keys` (build-drop detection).
+   `.d.ts` value exports must be present in the runtime `Object.keys` (build-drop),
+   and no runtime value may be declared type-only (the inverse).
 4. **runtime importability** ([`checks/runtime-import.mjs`](./fixture/checks/runtime-import.mjs)) —
    every subpath `import()`s under Node ESM. Type-only subpaths (0 declared value
    exports) are expected to be empty; executable / buf-plugin entries are skipped
    with a documented reason ([`checks/allowlist.mjs`](./fixture/checks/allowlist.mjs)).
-5. **behavioral smoke** ([`fixture/src/smoke.ts`](./fixture/src/smoke.ts)) — calls
+5. **node: builtin prefixes** ([`checks/builtins.mjs`](./fixture/checks/builtins.mjs)) —
+   no prefix-only builtin (`node:test`/`sqlite`/`sea`) ships with its `node:` prefix stripped.
+6. **consumer usage type-check** ([`checks/usage-typecheck.mjs`](./fixture/checks/usage-typecheck.mjs)) —
+   a cast-free fixture ([`src/usage.ts`](./fixture/src/usage.ts)) compiles documented
+   signatures against the packed `.d.ts`, catching signature regressions.
+7. **behavioral smoke** ([`fixture/src/smoke.ts`](./fixture/src/smoke.ts)) — calls
    public functions not covered by the example e2e (catalog key-validation,
    resolvers, `defaultFailurePredicate` classification, opt-in interceptors, otel
-   getters, auth helpers, healthcheck, events helpers, testing mocks).
+   getters, auth helpers, healthcheck, events helpers, testing mocks, real `ctx.call`).
 
 The gate exits non-zero if any check fails.
 

--- a/scripts/release-gate/README.md
+++ b/scripts/release-gate/README.md
@@ -1,0 +1,52 @@
+# Release publish-boundary gate
+
+Validates the framework **as a third-party consumer experiences it**, against the
+**packed** artifacts — not against `src/` or in-workspace `dist/`. This catches
+publish-boundary defects that the framework build, `tsc`, and the (type-stripped)
+examples cannot see: broken `exports` maps, `.d.ts` ↔ `.js` drift (build-drop),
+unimportable subpaths, and catalog-codegen breakage.
+
+## What it does
+
+`run.mjs` builds a throwaway consumer from [`fixture/`](./fixture), installs every
+published `@connectum/*` package from the chosen source, generates the service
+catalog, then runs four publish-boundary checks plus the behavioral smoke:
+
+1. **export-map** — every `exports` subpath resolves to a real file on disk.
+2. **`.d.ts` graph** ([`checks/oracle.mjs`](./fixture/checks/oracle.mjs)) —
+   namespace-imports every subpath and type-checks the full declaration graph
+   with `skipLibCheck: false` under a realistic consumer tsconfig (DOM/fetch lib
+   via `target esnext`, so `@connectrpc`-inherited globals like `HeadersInit`
+   resolve). Enumerates each subpath's value/type exports into `gen-cov/report.json`.
+3. **value-export completeness** ([`checks/completeness.mjs`](./fixture/checks/completeness.mjs)) —
+   every value export declared in the `.d.ts` must be present in the runtime
+   `Object.keys` (build-drop detection).
+4. **runtime importability** ([`checks/runtime-import.mjs`](./fixture/checks/runtime-import.mjs)) —
+   every subpath `import()`s under Node ESM. Type-only subpaths (0 declared value
+   exports) are expected to be empty; executable / buf-plugin entries are skipped
+   with a documented reason ([`checks/allowlist.mjs`](./fixture/checks/allowlist.mjs)).
+5. **behavioral smoke** ([`fixture/src/smoke.ts`](./fixture/src/smoke.ts)) — calls
+   public functions not covered by the example e2e (catalog key-validation,
+   resolvers, `defaultFailurePredicate` classification, opt-in interceptors, otel
+   getters, auth helpers, healthcheck, events helpers, testing mocks).
+
+The gate exits non-zero if any check fails.
+
+## Running
+
+```bash
+# Local: build + pnpm-pack the workspace, then validate the tarballs
+pnpm release:gate
+
+# Pre-release: validate a pkg-pr-new snapshot (pinned to a commit SHA)
+pnpm release:gate:preview --ref <commit-sha>
+```
+
+In CI the gate runs automatically on every PR to `main` (in `snapshot.yml`,
+after the pkg-pr-new snapshot publishes) against that PR's pre-release build.
+
+## Scope
+
+Verifies the publish boundary and pure/in-process behavior directly. RPC-path
+runtime (streaming/bidi), broker-backed adapters, and the auth interceptors are
+covered by the example e2e, not by this gate.

--- a/scripts/release-gate/fixture/buf.gen.yaml
+++ b/scripts/release-gate/fixture/buf.gen.yaml
@@ -1,0 +1,18 @@
+version: v2
+clean: true
+inputs:
+  - directory: proto
+plugins:
+  - local: protoc-gen-es
+    out: gen
+    opt:
+      - target=ts
+      - import_extension=.ts
+  # Published @connectum/protoc-gen-catalog buf plugin (bin: protoc-gen-connectum-catalog).
+  # strategy: all → single catalog.gen.ts aggregating every service.
+  - local: protoc-gen-connectum-catalog
+    strategy: all
+    out: gen
+    opt:
+      - target=ts
+      - import_extension=.ts

--- a/scripts/release-gate/fixture/buf.yaml
+++ b/scripts/release-gate/fixture/buf.yaml
@@ -1,0 +1,9 @@
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/scripts/release-gate/fixture/checks/allowlist.mjs
+++ b/scripts/release-gate/fixture/checks/allowlist.mjs
@@ -1,0 +1,15 @@
+// Documented exceptions for the publish-boundary gate. Every exemption from a
+// check MUST have a recorded reason here — an unexplained exception is a
+// coverage gap, not a pass.
+
+// Subpaths that cannot be runtime-imported / completeness-diffed because the
+// `.` entry is not a library module:
+export const IMPORT_EXCEPTIONS = {
+    "@connectum/cli": "executable entry — dist/index.js calls runMain() + process.exit() on import; the programmatic API is on ./commands/* and ./utils/*",
+    "@connectum/protoc-gen-catalog": "buf-plugin entry — reads stdin when run; validated by the catalog codegen check, not by import",
+};
+
+/** Reason this spec is exempt from import-based checks, or null if it is not. */
+export function importExceptionReason(spec) {
+    return IMPORT_EXCEPTIONS[spec] ?? null;
+}

--- a/scripts/release-gate/fixture/checks/builtins.mjs
+++ b/scripts/release-gate/fixture/checks/builtins.mjs
@@ -1,0 +1,49 @@
+// Gate check 5 — node: protocol on prefix-only builtins.
+//
+// tsup's `removeNodeProtocol: true` default strips the `node:` prefix from
+// builtin imports. For most builtins (fs, crypto, os, http2, assert, …) the
+// bare form is a valid Node alias, so stripping is only a style issue. But a
+// handful of builtins are exposed ONLY under the `node:` prefix and have NO bare
+// alias — `node:test`, `node:test/reporters`, `node:sqlite`, `node:sea`. If the
+// build strips the prefix from one of these, the published artifact ships an
+// unresolvable bare specifier (`import { test } from "test"` → Cannot find
+// package 'test') for every consumer. This is the @connectum/testing/parity bug
+// class; this static scan guards every package's shipped .js against it.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const NM = resolve("node_modules", "@connectum");
+// Builtins with NO bare alias — they MUST keep the node: prefix.
+const PREFIX_ONLY = ["test", "test/reporters", "sqlite", "sea"];
+const bareRe = new RegExp(`(?:from\\s*|import\\s*\\(\\s*|require\\s*\\(\\s*)["'](${PREFIX_ONLY.map((b) => b.replace("/", "\\/")).join("|")})["']`, "g");
+
+function jsFiles(dir, acc) {
+    for (const e of readdirSync(dir)) {
+        const p = join(dir, e);
+        const st = statSync(p);
+        if (st.isDirectory()) {
+            if (e !== "node_modules") jsFiles(p, acc);
+        } else if (e.endsWith(".js") || e.endsWith(".mjs") || e.endsWith(".cjs")) acc.push(p);
+    }
+    return acc;
+}
+
+const hits = [];
+for (const pkg of readdirSync(NM).sort()) {
+    const dist = join(NM, pkg, "dist");
+    if (!existsSync(dist)) continue;
+    for (const file of jsFiles(dist, [])) {
+        const src = readFileSync(file, "utf8");
+        for (const m of src.matchAll(bareRe)) {
+            hits.push({ pkg: `@connectum/${pkg}`, file: file.slice(NM.length + 1), bare: m[1] });
+        }
+    }
+}
+
+if (hits.length === 0) {
+    console.log(`builtins: OK — no prefix-only Node builtin (${PREFIX_ONLY.join(", ")}) shipped without its node: prefix`);
+    process.exit(0);
+}
+console.log(`builtins: FAIL — ${hits.length} stripped node: prefix on a prefix-only builtin:`);
+for (const h of hits) console.log(`  ${h.pkg} ${h.file}: bare "${h.bare}" (must be "node:${h.bare}")`);
+process.exit(1);

--- a/scripts/release-gate/fixture/checks/completeness.mjs
+++ b/scripts/release-gate/fixture/checks/completeness.mjs
@@ -14,6 +14,12 @@ import { importExceptionReason } from "./allowlist.mjs";
 
 const report = JSON.parse(readFileSync("./gen-cov/report.json", "utf8"));
 
+// A subpath that hangs during module evaluation must not wedge the gate; race
+// the import against a timeout so a stuck module produces a deterministic
+// failure. (A leaked timer/handle can keep the process alive past the checks,
+// so the orchestrator force-exits on completion.)
+const withTimeout = (p, ms, label) => Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error(`import timed out after ${ms}ms: ${label}`)), ms).unref())]);
+
 const deltas = [];
 for (const [spec, info] of Object.entries(report.exports)) {
     if (importExceptionReason(spec) || !info.resolved) continue;
@@ -21,7 +27,7 @@ for (const [spec, info] of Object.entries(report.exports)) {
     const declaredTypes = info.types || [];
     let mod;
     try {
-        mod = await import(spec);
+        mod = await withTimeout(import(spec), 15000, spec);
     } catch (e) {
         deltas.push({ spec, kind: "IMPORT-THREW", detail: e?.message ?? String(e) });
         continue;

--- a/scripts/release-gate/fixture/checks/completeness.mjs
+++ b/scripts/release-gate/fixture/checks/completeness.mjs
@@ -1,0 +1,35 @@
+// Gate check 3 — build-drop detection. The .d.ts (checked by tsc) and the .js
+// (run at runtime) are validated separately; nothing else asserts they AGREE. A
+// value symbol present in the published .d.ts but dropped from the .js is the
+// canonical tsup publish-boundary bug and passes the other checks silently. For
+// each subpath, diff enumerated .d.ts value-exports vs runtime Object.keys.
+// Any delta fails the gate. Reads gen-cov/report.json produced by oracle.mjs.
+import { readFileSync } from "node:fs";
+import { importExceptionReason } from "./allowlist.mjs";
+
+const report = JSON.parse(readFileSync("./gen-cov/report.json", "utf8"));
+
+const deltas = [];
+for (const [spec, info] of Object.entries(report.exports)) {
+    if (importExceptionReason(spec) || !info.resolved) continue;
+    const declaredValues = info.values || [];
+    if (declaredValues.length === 0) continue;
+    let mod;
+    try {
+        mod = await import(spec);
+    } catch (e) {
+        deltas.push({ spec, kind: "IMPORT-THREW", detail: e?.message ?? String(e) });
+        continue;
+    }
+    const runtimeKeys = new Set(Object.keys(mod));
+    const missing = declaredValues.filter((n) => !runtimeKeys.has(n));
+    if (missing.length) deltas.push({ spec, kind: "DECLARED-NOT-IN-RUNTIME", missing });
+}
+
+if (deltas.length === 0) {
+    console.log("completeness: OK — every .d.ts value export present in runtime Object.keys");
+    process.exit(0);
+}
+console.log(`completeness: FAIL — ${deltas.length} build-drop delta(s):`);
+for (const d of deltas) console.log(`  ${JSON.stringify(d)}`);
+process.exit(1);

--- a/scripts/release-gate/fixture/checks/completeness.mjs
+++ b/scripts/release-gate/fixture/checks/completeness.mjs
@@ -1,9 +1,14 @@
-// Gate check 3 — build-drop detection. The .d.ts (checked by tsc) and the .js
-// (run at runtime) are validated separately; nothing else asserts they AGREE. A
-// value symbol present in the published .d.ts but dropped from the .js is the
-// canonical tsup publish-boundary bug and passes the other checks silently. For
-// each subpath, diff enumerated .d.ts value-exports vs runtime Object.keys.
-// Any delta fails the gate. Reads gen-cov/report.json produced by oracle.mjs.
+// Gate check 3 — build-drop detection, both directions. The .d.ts (checked by
+// tsc) and the .js (run at runtime) are validated separately; this asserts they
+// AGREE on the value surface. Reads gen-cov/report.json produced by oracle.mjs.
+//   forward: a value declared in the .d.ts but absent from the runtime
+//            Object.keys = a value dropped by the build (the const-enum /
+//            EffectiveTransport class of bug).
+//   reverse: a name declared TYPE-ONLY in the .d.ts but present as a runtime
+//            value = a value mislabeled type-only at the barrel (`export type
+//            { X }` on a real value) → consumer `import { X }` + value use hits
+//            TS2693. The exact inverse of the const-enum bug.
+// Any delta fails the gate.
 import { readFileSync } from "node:fs";
 import { importExceptionReason } from "./allowlist.mjs";
 
@@ -13,7 +18,7 @@ const deltas = [];
 for (const [spec, info] of Object.entries(report.exports)) {
     if (importExceptionReason(spec) || !info.resolved) continue;
     const declaredValues = info.values || [];
-    if (declaredValues.length === 0) continue;
+    const declaredTypes = info.types || [];
     let mod;
     try {
         mod = await import(spec);
@@ -22,14 +27,16 @@ for (const [spec, info] of Object.entries(report.exports)) {
         continue;
     }
     const runtimeKeys = new Set(Object.keys(mod));
-    const missing = declaredValues.filter((n) => !runtimeKeys.has(n));
-    if (missing.length) deltas.push({ spec, kind: "DECLARED-NOT-IN-RUNTIME", missing });
+    const droppedValues = declaredValues.filter((n) => !runtimeKeys.has(n));
+    if (droppedValues.length) deltas.push({ spec, kind: "DECLARED-VALUE-NOT-IN-RUNTIME", names: droppedValues });
+    const mislabeled = declaredTypes.filter((n) => runtimeKeys.has(n));
+    if (mislabeled.length) deltas.push({ spec, kind: "RUNTIME-VALUE-DECLARED-TYPE-ONLY", names: mislabeled });
 }
 
 if (deltas.length === 0) {
-    console.log("completeness: OK — every .d.ts value export present in runtime Object.keys");
+    console.log("completeness: OK — .d.ts value exports ⇔ runtime Object.keys (both directions)");
     process.exit(0);
 }
-console.log(`completeness: FAIL — ${deltas.length} build-drop delta(s):`);
+console.log(`completeness: FAIL — ${deltas.length} delta(s):`);
 for (const d of deltas) console.log(`  ${JSON.stringify(d)}`);
 process.exit(1);

--- a/scripts/release-gate/fixture/checks/oracle.mjs
+++ b/scripts/release-gate/fixture/checks/oracle.mjs
@@ -1,0 +1,159 @@
+// Gate checks 1+2 — publish-boundary oracle over the installed (packed) build.
+// Mechanical, no hand-written references:
+//  (1) enumerate every `exports` subpath from each INSTALLED @connectum/* package.json
+//      and resolve each to a real file (broken export map => publish bug)
+//  (2) build a TS Program that namespace-imports every subpath with skipLibCheck:false
+//      under the realistic consumer tsconfig (DOM/fetch lib via target esnext)
+//      => any module-resolution or .d.ts error surfaces as a diagnostic
+//  + enumerate exports of every subpath via the type checker (value vs type),
+//      so nothing is silently skipped — written to gen-cov/report.json for the
+//      downstream completeness + runtime-import checks.
+// Output: gen-cov/report.json + console summary. Exit 1 on any failure.
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const ROOT = resolve(".");
+const NM = join(ROOT, "node_modules", "@connectum");
+
+// --- discover installed @connectum packages + their declared export subpaths ---
+const pkgs = readdirSync(NM).filter((d) => existsSync(join(NM, d, "package.json")));
+const specs = []; // { spec, pkg, subpath, declared, target, resolved }
+const exportMapFindings = [];
+for (const pkg of pkgs.sort()) {
+    const pjPath = join(NM, pkg, "package.json");
+    const pj = JSON.parse(readFileSync(pjPath, "utf8"));
+    const exp = pj.exports;
+    if (!exp || typeof exp !== "object") {
+        exportMapFindings.push(`@connectum/${pkg}: NO exports map (exports=${JSON.stringify(exp)})`);
+        continue;
+    }
+    for (const key of Object.keys(exp)) {
+        if (key === "./package.json") continue;
+        const spec = key === "." ? `@connectum/${pkg}` : `@connectum/${pkg}/${key.slice(2)}`;
+        // resolve the import/types/default target for existence check
+        const cond = exp[key];
+        const candidates = [];
+        const collect = (v) => {
+            if (typeof v === "string") candidates.push(v);
+            else if (v && typeof v === "object") for (const k of Object.keys(v)) collect(v[k]);
+        };
+        collect(cond);
+        let allResolve = true;
+        const missing = [];
+        for (const rel of candidates) {
+            const abs = join(NM, pkg, rel);
+            if (!existsSync(abs)) {
+                allResolve = false;
+                missing.push(rel);
+            }
+        }
+        if (!allResolve) exportMapFindings.push(`${spec}: export target(s) missing on disk: ${missing.join(", ")}`);
+        specs.push({ spec, pkg, subpath: key, candidates, resolved: allResolve });
+    }
+}
+
+// --- build synthetic entry that namespace-imports every subpath ---
+const lines = [];
+specs.forEach((s, i) => {
+    lines.push(`import * as s${i} from ${JSON.stringify(s.spec)};`);
+});
+specs.forEach((_, i) => {
+    lines.push(`export { s${i} };`);
+});
+mkdirSync(join(ROOT, "gen-cov"), { recursive: true });
+const entryPath = join(ROOT, "gen-cov", "__all.ts");
+writeFileSync(entryPath, `${lines.join("\n")}\n`);
+
+// --- TS program with the consumer tsconfig, skipLibCheck:false, verbatim off (probe file) ---
+const tsconfig = ts.readConfigFile(join(ROOT, "tsconfig.json"), ts.sys.readFile).config;
+const parsed = ts.parseJsonConfigFileContent(tsconfig, ts.sys, ROOT);
+const options = {
+    ...parsed.options,
+    skipLibCheck: false,
+    verbatimModuleSyntax: false,
+    noEmit: true,
+    noUnusedLocals: false,
+};
+const program = ts.createProgram([entryPath], options);
+const checker = program.getTypeChecker();
+const sf = program.getSourceFile(entryPath);
+
+// diagnostics scoped to our probe + global/options + lib graph
+const diags = [...program.getSyntacticDiagnostics(sf), ...program.getSemanticDiagnostics(sf), ...program.getGlobalDiagnostics(), ...program.getOptionsDiagnostics()];
+// also collect declaration-file diagnostics in any installed @connectum package
+// (covers both pkg.pr.new and file:-tarball installs — both land under @connectum)
+const connectumDtsDiags = program.getSemanticDiagnostics().filter((d) => (d.file?.fileName ?? "").includes("@connectum"));
+
+const fmtDiag = (d) => {
+    const msg = ts.flattenDiagnosticMessageText(d.messageText, "\n");
+    if (d.file && d.start != null) {
+        const { line, character } = d.file.getLineAndCharacterOfPosition(d.start);
+        return `${d.file.fileName}:${line + 1}:${character + 1} TS${d.code}: ${msg}`;
+    }
+    return `TS${d.code}: ${msg}`;
+};
+
+// --- enumerate exports of every subpath via checker ---
+const exportReport = {};
+const importDecls = sf.statements.filter(ts.isImportDeclaration);
+specs.forEach((s, i) => {
+    const decl = importDecls[i];
+    const modSym = checker.getSymbolAtLocation(decl.moduleSpecifier);
+    if (!modSym) {
+        exportReport[s.spec] = { resolved: false, error: "module symbol not found (unresolved)" };
+        return;
+    }
+    const exports = checker.getExportsOfModule(modSym);
+    const values = [],
+        types = [];
+    for (const ex of exports) {
+        let sym = ex;
+        if (sym.flags & ts.SymbolFlags.Alias) {
+            try {
+                sym = checker.getAliasedSymbol(ex);
+            } catch {}
+        }
+        const f = sym.flags;
+        const isValue = !!(f & ts.SymbolFlags.Value);
+        const isType = !!(f & (ts.SymbolFlags.Type | ts.SymbolFlags.Interface | ts.SymbolFlags.TypeAlias | ts.SymbolFlags.TypeParameter | ts.SymbolFlags.EnumMember));
+        if (isValue) values.push(ex.getName());
+        else if (isType) types.push(ex.getName());
+        else values.push(ex.getName()); // namespaces etc.
+    }
+    exportReport[s.spec] = { resolved: true, valueCount: values.length, typeCount: types.length, values: values.sort(), types: types.sort() };
+});
+
+const allDiags = [...diags, ...connectumDtsDiags];
+const uniq = [...new Map(allDiags.map((d) => [fmtDiag(d), d])).values()];
+const errs = uniq.filter((d) => d.category === ts.DiagnosticCategory.Error);
+
+const report = {
+    target: process.env.GATE_TARGET ?? "(unspecified)",
+    packages: pkgs.length,
+    subpaths: specs.length,
+    exportMapFindings,
+    unresolvedSubpaths: specs.filter((s) => !s.resolved).map((s) => s.spec),
+    tsErrorCount: errs.length,
+    tsErrors: errs.map(fmtDiag),
+    exports: exportReport,
+};
+writeFileSync(join(ROOT, "gen-cov", "report.json"), JSON.stringify(report, null, 2));
+
+console.log(`packages=${report.packages} subpaths=${report.subpaths}`);
+console.log(`export-map findings: ${exportMapFindings.length}`);
+for (const f of exportMapFindings) console.log(`  EXPORTMAP ${f}`);
+console.log(`unresolved subpaths: ${report.unresolvedSubpaths.length}`);
+for (const s of report.unresolvedSubpaths) console.log(`  UNRESOLVED ${s}`);
+console.log(`TS errors: ${errs.length}`);
+for (const e of errs.slice(0, 60)) console.log(`  TSERR ${fmtDiag(e)}`);
+let totV = 0,
+    totT = 0;
+for (const k of Object.keys(exportReport)) {
+    totV += exportReport[k].valueCount || 0;
+    totT += exportReport[k].typeCount || 0;
+}
+console.log(`total value exports enumerated=${totV}, type exports enumerated=${totT}`);
+process.exit(errs.length || exportMapFindings.length || report.unresolvedSubpaths.length ? 1 : 0);

--- a/scripts/release-gate/fixture/checks/runtime-import.mjs
+++ b/scripts/release-gate/fixture/checks/runtime-import.mjs
@@ -1,0 +1,52 @@
+// Gate check 4 — runtime importability. Does every published subpath actually
+// import() under Node ESM? Catches .js that throws on load, ESM/CJS interop
+// breaks, a stripped node: builtin, missing default. Each import is raced
+// against a timeout so a hanging module can't wedge the run. A subpath with
+// zero declared value-exports (type-only, e.g. ./types) is expected to yield an
+// empty namespace — not a failure (cross-referenced via gen-cov/report.json).
+// Import-exception entries (executable / plugin `.`) are skipped with a reason.
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { importExceptionReason } from "./allowlist.mjs";
+
+const report = JSON.parse(readFileSync("./gen-cov/report.json", "utf8"));
+const NM = resolve("node_modules", "@connectum");
+const pkgs = readdirSync(NM).filter((d) => existsSync(join(NM, d, "package.json")));
+const specs = [];
+for (const pkg of pkgs.sort()) {
+    const pj = JSON.parse(readFileSync(join(NM, pkg, "package.json"), "utf8"));
+    for (const key of Object.keys(pj.exports || {})) {
+        if (key === "./package.json") continue;
+        specs.push(key === "." ? `@connectum/${pkg}` : `@connectum/${pkg}/${key.slice(2)}`);
+    }
+}
+
+const withTimeout = (p, ms) => Promise.race([p, new Promise((_, rej) => setTimeout(() => rej(new Error(`TIMEOUT ${ms}ms`)), ms).unref())]);
+
+let fail = 0;
+const rows = [];
+for (const spec of specs) {
+    const reason = importExceptionReason(spec);
+    if (reason) {
+        rows.push(["  ", spec, `skip — ${reason}`]);
+        continue;
+    }
+    const declaredValues = report.exports[spec]?.values?.length ?? null;
+    try {
+        const mod = await withTimeout(import(spec), 15000);
+        const total = Object.keys(mod).length;
+        // type-only subpath (0 declared value-exports) → empty namespace is expected
+        if (total === 0 && declaredValues === 0) rows.push(["  ", spec, "ok (type-only: 0 runtime exports, expected)"]);
+        else if (total === 0) {
+            fail++;
+            rows.push(["XX", spec, `EMPTY namespace but .d.ts declares ${declaredValues} value export(s)`]);
+        } else rows.push(["  ", spec, `ok (${total} runtime exports)`]);
+    } catch (e) {
+        fail++;
+        rows.push(["XX", spec, `IMPORT FAILED: ${e?.message ?? e}`]);
+    }
+}
+
+for (const [mark, spec, status] of rows) console.log(`${mark} ${spec} :: ${status}`);
+console.log(`runtime-import: ${rows.length} subpaths, failures=${fail}`);
+process.exit(fail ? 1 : 0);

--- a/scripts/release-gate/fixture/checks/usage-typecheck.mjs
+++ b/scripts/release-gate/fixture/checks/usage-typecheck.mjs
@@ -1,0 +1,40 @@
+// Gate check 6 — consumer USAGE type-check. oracle.mjs proves the .d.ts graph is
+// well-formed and resolves; it does NOT instantiate generics, call functions
+// with typed arguments, or assign typed parameters. This check compiles a
+// cast-free usage fixture (src/usage.ts) against the PACKED .d.ts under the
+// realistic consumer tsconfig (verbatimModuleSyntax:true, strict) and fails on
+// any diagnostic — catching signature regressions a consumer writing documented
+// code would hit even when the declarations are well-formed.
+import { createRequire } from "node:module";
+import { join, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const ROOT = resolve(".");
+
+const tsconfig = ts.readConfigFile(join(ROOT, "tsconfig.json"), ts.sys.readFile).config;
+const parsed = ts.parseJsonConfigFileContent(tsconfig, ts.sys, ROOT);
+// skipLibCheck:true — we want diagnostics on OUR usage site, not inside lib/.d.ts
+// internals (those are covered by oracle.mjs with skipLibCheck:false).
+const options = { ...parsed.options, skipLibCheck: true, noEmit: true };
+
+const entry = join(ROOT, "src", "usage.ts");
+const program = ts.createProgram([entry], options);
+
+const fmt = (d) => {
+    const m = ts.flattenDiagnosticMessageText(d.messageText, "\n");
+    if (d.file && d.start != null) {
+        const { line, character } = d.file.getLineAndCharacterOfPosition(d.start);
+        return `${d.file.fileName}:${line + 1}:${character + 1} TS${d.code}: ${m}`;
+    }
+    return `TS${d.code}: ${m}`;
+};
+
+const diags = ts.getPreEmitDiagnostics(program).filter((d) => (d.file?.fileName ?? "").endsWith("src/usage.ts"));
+if (diags.length === 0) {
+    console.log("usage-typecheck: OK — documented consumer signatures type-check against the packed .d.ts");
+    process.exit(0);
+}
+console.log(`usage-typecheck: FAIL — ${diags.length} diagnostic(s) on consumer usage:`);
+for (const d of diags) console.log(`  ${fmt(d)}`);
+process.exit(1);

--- a/scripts/release-gate/fixture/checks/usage-typecheck.mjs
+++ b/scripts/release-gate/fixture/checks/usage-typecheck.mjs
@@ -30,7 +30,9 @@ const fmt = (d) => {
     return `TS${d.code}: ${m}`;
 };
 
-const diags = ts.getPreEmitDiagnostics(program).filter((d) => (d.file?.fileName ?? "").endsWith("src/usage.ts"));
+// Normalize separators — TS file names use `/`, but guard against `\` so the
+// filter can't silently pass (hiding diagnostics) on Windows.
+const diags = ts.getPreEmitDiagnostics(program).filter((d) => (d.file?.fileName ?? "").replace(/\\/g, "/").endsWith("/src/usage.ts"));
 if (diags.length === 0) {
     console.log("usage-typecheck: OK — documented consumer signatures type-check against the packed .d.ts");
     process.exit(0);

--- a/scripts/release-gate/fixture/package.json
+++ b/scripts/release-gate/fixture/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "connectum-release-gate-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#gen/*": "./gen/*"
+  },
+  "scripts": {
+    "buf:generate": "buf generate"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.11.0",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-node": "^2.1.1",
+    "@connectum/auth": "1.0.0",
+    "@connectum/cli": "1.0.0",
+    "@connectum/core": "1.0.0",
+    "@connectum/events": "1.0.0",
+    "@connectum/events-amqp": "1.0.0",
+    "@connectum/events-kafka": "1.0.0",
+    "@connectum/events-nats": "1.0.0",
+    "@connectum/events-redis": "1.0.0",
+    "@connectum/healthcheck": "1.0.0",
+    "@connectum/interceptors": "1.0.0",
+    "@connectum/otel": "1.0.0",
+    "@connectum/protoc-gen-catalog": "1.0.0",
+    "@connectum/reflection": "1.0.0",
+    "@connectum/test-fixtures": "1.0.0",
+    "@connectum/testing": "1.0.0"
+  },
+  "devDependencies": {
+    "@bufbuild/buf": "^1.65.0",
+    "@bufbuild/protoc-gen-es": "^2.11.0",
+    "@types/node": "^25.2.0",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/scripts/release-gate/fixture/package.json
+++ b/scripts/release-gate/fixture/package.json
@@ -10,9 +10,9 @@
     "buf:generate": "buf generate"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.11.0",
-    "@connectrpc/connect": "^2.1.1",
-    "@connectrpc/connect-node": "^2.1.1",
+    "@bufbuild/protobuf": "2.12.0",
+    "@connectrpc/connect": "2.1.2",
+    "@connectrpc/connect-node": "2.1.2",
     "@connectum/auth": "1.0.0",
     "@connectum/cli": "1.0.0",
     "@connectum/core": "1.0.0",
@@ -30,10 +30,10 @@
     "@connectum/testing": "1.0.0"
   },
   "devDependencies": {
-    "@bufbuild/buf": "^1.65.0",
-    "@bufbuild/protoc-gen-es": "^2.11.0",
-    "@types/node": "^25.2.0",
-    "typescript": "^5.9.3"
+    "@bufbuild/buf": "1.70.0",
+    "@bufbuild/protoc-gen-es": "2.12.0",
+    "@types/node": "25.9.3",
+    "typescript": "5.9.3"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/scripts/release-gate/fixture/proto/greeter/v1/greeter.proto
+++ b/scripts/release-gate/fixture/proto/greeter/v1/greeter.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package greeter.v1;
+
+// Minimal service exercising all four RPC cardinalities so the generated
+// catalog (protoc-gen-connectum-catalog) covers unary + server-stream +
+// client-stream + bidi typing of ctx.call / ctx.stream.
+service GreeterService {
+  // Unary.
+  rpc SayHello(HelloRequest) returns (HelloReply);
+  // Server streaming.
+  rpc SayHelloStream(HelloRequest) returns (stream HelloReply);
+  // Client streaming.
+  rpc SayHelloCollect(stream HelloRequest) returns (HelloReply);
+  // Bidirectional streaming.
+  rpc SayHelloChat(stream HelloRequest) returns (stream HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/scripts/release-gate/fixture/src/smoke.ts
+++ b/scripts/release-gate/fixture/src/smoke.ts
@@ -2,15 +2,26 @@
 // Scope: gap functions NOT already exercised by example e2e — pure / in-process
 // only (no brokers). Each check is isolated; asserts real semantics where known.
 import assert from "node:assert";
+import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
-import { GreeterService } from "../gen/greeter/v1/greeter_pb.ts";
+import { GreeterService, HelloReplySchema, HelloRequestSchema } from "../gen/greeter/v1/greeter_pb.ts";
 
 let pass = 0;
 const fails: string[] = [];
 function check(name: string, fn: () => void) {
     try {
         fn();
+        pass++;
+        console.log(`  ok   ${name}`);
+    } catch (e) {
+        fails.push(`${name}: ${(e as Error)?.message ?? e}`);
+        console.log(`  FAIL ${name} :: ${(e as Error)?.message ?? e}`);
+    }
+}
+async function checkAsync(name: string, fn: () => Promise<void>) {
+    try {
+        await fn();
         pass++;
         console.log(`  ok   ${name}`);
     } catch (e) {
@@ -36,6 +47,14 @@ check("core.mergeCatalogs merges two catalogs", () => {
     const a = core.defineCatalog({ "greeter.v1.GreeterService": GreeterService });
     const merged = core.mergeCatalogs(a, core.defineCatalog({}));
     assert.ok(merged);
+});
+check("core.mergeCatalogs throws CatalogConfigError on duplicate typeName", () => {
+    const a = core.defineCatalog({ "greeter.v1.GreeterService": GreeterService });
+    assert.throws(
+        () => core.mergeCatalogs(a, a),
+        (e: unknown) => e instanceof core.CatalogConfigError || (e as Error).name === "CatalogConfigError",
+        "expected CatalogConfigError on duplicate typeName",
+    );
 });
 check("core.CatalogConfigError is an Error subclass", () => {
     const e = new core.CatalogConfigError("x");
@@ -161,6 +180,14 @@ check("testing.createMockContext returns a Context for a catalog", () => {
     });
     assert.ok(ctx && typeof ctx === "object");
     assert.strictEqual(typeof ctx.call, "function");
+});
+await checkAsync("testing.createMockContext drives ctx.call against a mock (real dispatch)", async () => {
+    const ctx = testing.createMockContext({
+        catalog: core.defineCatalog({ "greeter.v1.GreeterService": GreeterService }),
+        mocks: [testing.mockService(GreeterService, { sayHello: (req: { name: string }) => create(HelloReplySchema, { message: `mocked:${req.name}` }) })],
+    });
+    const res = await ctx.call("greeter.v1.GreeterService/SayHello", create(HelloRequestSchema, { name: "x" }));
+    assert.strictEqual((res as { message: string }).message, "mocked:x");
 });
 check("testing.mockResolver + mockService are callable", () => {
     assert.strictEqual(typeof testing.mockResolver, "function");

--- a/scripts/release-gate/fixture/src/smoke.ts
+++ b/scripts/release-gate/fixture/src/smoke.ts
@@ -1,0 +1,178 @@
+// Layer-2 behavioral smoke against the @137 (1.0.0) published artifacts.
+// Scope: gap functions NOT already exercised by example e2e — pure / in-process
+// only (no brokers). Each check is isolated; asserts real semantics where known.
+import assert from "node:assert";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { GreeterService } from "../gen/greeter/v1/greeter_pb.ts";
+
+let pass = 0;
+const fails: string[] = [];
+function check(name: string, fn: () => void) {
+    try {
+        fn();
+        pass++;
+        console.log(`  ok   ${name}`);
+    } catch (e) {
+        fails.push(`${name}: ${(e as Error)?.message ?? e}`);
+        console.log(`  FAIL ${name} :: ${(e as Error)?.message ?? e}`);
+    }
+}
+
+// ---------- @connectum/core: catalog ----------
+const core = await import("@connectum/core");
+check("core.defineCatalog accepts matching key===typeName", () => {
+    const cat = core.defineCatalog({ "greeter.v1.GreeterService": GreeterService });
+    assert.ok(cat, "catalog truthy");
+});
+check("core.defineCatalog throws on key !== typeName (CatalogConfigError)", () => {
+    assert.throws(
+        () => core.defineCatalog({ "wrong.Name": GreeterService } as never),
+        (e: unknown) => e instanceof core.CatalogConfigError || (e as Error).name === "CatalogConfigError",
+        "expected CatalogConfigError",
+    );
+});
+check("core.mergeCatalogs merges two catalogs", () => {
+    const a = core.defineCatalog({ "greeter.v1.GreeterService": GreeterService });
+    const merged = core.mergeCatalogs(a, core.defineCatalog({}));
+    assert.ok(merged);
+});
+check("core.CatalogConfigError is an Error subclass", () => {
+    const e = new core.CatalogConfigError("x");
+    assert.ok(e instanceof Error);
+});
+
+// ---------- @connectum/core: resolvers ----------
+check("core.singleTransportResolver wraps a transport into a resolver", () => {
+    const t = createGrpcTransport({ baseUrl: "http://localhost:1" });
+    const r = core.singleTransportResolver(t);
+    assert.strictEqual(typeof r, "function");
+});
+check("core.mapResolver constructs", () => {
+    const r = core.mapResolver({} as never);
+    assert.strictEqual(typeof r, "function");
+});
+check("core.dnsResolver constructs", () => {
+    const r = core.dnsResolver({ port: 5000 } as never);
+    assert.strictEqual(typeof r, "function");
+});
+check("core.perServiceEnvResolver constructs", () => {
+    const r = core.perServiceEnvResolver({} as never);
+    assert.strictEqual(typeof r, "function");
+});
+
+// ---------- @connectum/core: enabledServices + propagateHeaders + env ----------
+check("core.defaultPropagateHeaders is a non-empty list of trace headers", () => {
+    const h = core.defaultPropagateHeaders;
+    const arr = Array.isArray(h) ? h : [...(h as Iterable<string>)];
+    assert.ok(arr.length > 0, "non-empty");
+    assert.ok(
+        arr.some((x) => /trace|baggage/i.test(x)),
+        `contains a trace header: ${arr.join(",")}`,
+    );
+});
+check("core.matchServicesPattern('*', names) returns matching names", () => {
+    const r = core.matchServicesPattern("*", ["greeter.v1.GreeterService", "other.v1.Svc"]);
+    assert.ok(Array.isArray(r) && r.includes("greeter.v1.GreeterService"), `got ${JSON.stringify(r)}`);
+});
+check("core.parseServicesEnv parses a CSV list", () => {
+    const r = core.parseServicesEnv("a.B,c.D");
+    assert.ok(r);
+});
+check("core.safeParseEnvConfig returns a result for minimal env", () => {
+    const r = core.safeParseEnvConfig({ NODE_ENV: "production" } as never);
+    assert.ok(r);
+});
+
+// ---------- @connectum/interceptors: defaultFailurePredicate classification ----------
+const itc = await import("@connectum/interceptors");
+check("interceptors.defaultFailurePredicate: unavailable => true (infra)", () => {
+    assert.strictEqual(itc.defaultFailurePredicate(new ConnectError("x", Code.Unavailable)), true);
+});
+check("interceptors.defaultFailurePredicate: invalid_argument => false (business)", () => {
+    assert.strictEqual(itc.defaultFailurePredicate(new ConnectError("x", Code.InvalidArgument)), false);
+});
+check("interceptors.defaultFailurePredicate: non-ConnectError => true", () => {
+    assert.strictEqual(itc.defaultFailurePredicate(new Error("boom")), true);
+});
+check("interceptors.createDefaultInterceptors bare = [errorHandler, validation] only", () => {
+    const arr = itc.createDefaultInterceptors();
+    assert.ok(Array.isArray(arr) && arr.length === 2, `expected exactly 2, got ${(arr as unknown[]).length}`);
+});
+
+// ---------- @connectum/otel: provider getters ----------
+const otel = await import("@connectum/otel");
+check("otel.getTracer/getMeter/getLogger return objects pre-init (no-op safe)", () => {
+    assert.ok(otel.getTracer());
+    assert.ok(otel.getMeter());
+    assert.ok(otel.getLogger("consumer"));
+});
+check("otel.initProvider + shutdownProvider are functions", () => {
+    assert.strictEqual(typeof otel.initProvider, "function");
+    assert.strictEqual(typeof otel.shutdownProvider, "function");
+});
+
+// ---------- @connectum/auth: pure header helpers + pattern ----------
+const auth = await import("@connectum/auth");
+check("auth.setAuthHeaders/parseAuthHeaders round-trip preserves subject", () => {
+    const h = new Headers();
+    const ctx = { subject: "user-1", roles: ["admin"], scopes: ["read"], claims: { iss: "test" }, type: "jwt" };
+    auth.setAuthHeaders(h, ctx);
+    const parsed = auth.parseAuthHeaders(h);
+    assert.ok(parsed, "parsed truthy");
+    assert.strictEqual(parsed?.subject, "user-1");
+});
+check("auth.matchesMethodPattern discriminates matching vs non-matching", () => {
+    assert.strictEqual(auth.matchesMethodPattern("greeter.v1.GreeterService", "SayHello", ["greeter.v1.GreeterService/*"]), true);
+    assert.strictEqual(auth.matchesMethodPattern("greeter.v1.GreeterService", "SayHello", ["other.v1.Svc/X"]), false);
+});
+
+// ---------- @connectum/healthcheck ----------
+const hc = await import("@connectum/healthcheck");
+check("healthcheck.ServingStatus enum + manager singleton", () => {
+    assert.ok(hc.ServingStatus.SERVING != null);
+    assert.ok(hc.healthcheckManager);
+    const m = hc.createHealthcheckManager();
+    assert.ok(m);
+});
+
+// ---------- @connectum/events: bus + pure helpers ----------
+const ev = await import("@connectum/events");
+check("events.createEventBus with MemoryAdapter constructs", () => {
+    const bus = ev.createEventBus({ adapter: ev.MemoryAdapter() } as never);
+    assert.ok(bus);
+});
+check("events.matchPattern(pattern, topic): '*'=one segment, '>'=multi", () => {
+    assert.strictEqual(ev.matchPattern("orders.*", "orders.created"), true);
+    assert.strictEqual(ev.matchPattern("orders.*", "orders.created.v2"), false);
+    assert.strictEqual(ev.matchPattern("orders.>", "orders.created.v2"), true);
+});
+check("events.RetryableError/NonRetryableError are Error subclasses", () => {
+    assert.ok(new ev.RetryableError("x") instanceof Error);
+    assert.ok(new ev.NonRetryableError("x") instanceof Error);
+});
+
+// ---------- @connectum/testing: mocks ----------
+const testing = await import("@connectum/testing");
+check("testing.createMockContext returns a Context for a catalog", () => {
+    const ctx = testing.createMockContext({
+        catalog: core.defineCatalog({ "greeter.v1.GreeterService": GreeterService }),
+        mocks: [],
+    });
+    assert.ok(ctx && typeof ctx === "object");
+    assert.strictEqual(typeof ctx.call, "function");
+});
+check("testing.mockResolver + mockService are callable", () => {
+    assert.strictEqual(typeof testing.mockResolver, "function");
+    assert.strictEqual(typeof testing.mockService, "function");
+});
+check("testing.assertConnectError validates a ConnectError", () => {
+    const fn = testing.assertConnectError as (e: unknown, code?: unknown) => void;
+    fn(new ConnectError("x", Code.NotFound), Code.NotFound);
+});
+
+console.log(`\nLayer-2 smoke: pass=${pass} fail=${fails.length}`);
+if (fails.length) {
+    for (const f of fails) console.log(`  XX ${f}`);
+    process.exit(1);
+}

--- a/scripts/release-gate/fixture/src/smoke.ts
+++ b/scripts/release-gate/fixture/src/smoke.ts
@@ -181,13 +181,58 @@ check("testing.createMockContext returns a Context for a catalog", () => {
     assert.ok(ctx && typeof ctx === "object");
     assert.strictEqual(typeof ctx.call, "function");
 });
-await checkAsync("testing.createMockContext drives ctx.call against a mock (real dispatch)", async () => {
-    const ctx = testing.createMockContext({
-        catalog: core.defineCatalog({ "greeter.v1.GreeterService": GreeterService }),
-        mocks: [testing.mockService(GreeterService, { sayHello: (req: { name: string }) => create(HelloReplySchema, { message: `mocked:${req.name}` }) })],
-    });
-    const res = await ctx.call("greeter.v1.GreeterService/SayHello", create(HelloRequestSchema, { name: "x" }));
-    assert.strictEqual((res as { message: string }).message, "mocked:x");
+// Full catalog-call cardinality coverage: ctx.call (unary) + ctx.stream
+// (server/client/bidi) dispatched through createMockContext — the in-process
+// mock/local resolver path. Remote dispatch over a real gRPC transport
+// (createGrpcTransport) is exercised by the service-catalog example e2e (ctx.call)
+// and the transport-parity suite (createLocalTransport vs createGrpcTransport at
+// the service level); a full 2-server remote ctx.stream matrix is out of scope
+// for this smoke. See PR notes for the coverage map.
+const catalogCtx = testing.createMockContext({
+    catalog: core.defineCatalog({ "greeter.v1.GreeterService": GreeterService }),
+    mocks: [
+        testing.mockService(GreeterService, {
+            sayHello: (req: { name: string }) => create(HelloReplySchema, { message: `u:${req.name}` }),
+            async *sayHelloStream(req: { name: string }) {
+                yield create(HelloReplySchema, { message: `s:${req.name}` });
+            },
+            async sayHelloCollect(reqs: AsyncIterable<{ name: string }>) {
+                let last = "";
+                for await (const r of reqs) last = r.name;
+                return create(HelloReplySchema, { message: `c:${last}` });
+            },
+            async *sayHelloChat(reqs: AsyncIterable<{ name: string }>) {
+                for await (const r of reqs) yield create(HelloReplySchema, { message: `b:${r.name}` });
+            },
+        }),
+    ],
+});
+await checkAsync("ctx.call — unary dispatch through the catalog (mock/local)", async () => {
+    const res = await catalogCtx.call("greeter.v1.GreeterService/SayHello", create(HelloRequestSchema, { name: "x" }));
+    assert.strictEqual((res as { message: string }).message, "u:x");
+});
+await checkAsync("ctx.stream — server-stream dispatch (mock/local)", async () => {
+    const out: string[] = [];
+    for await (const r of catalogCtx.stream("greeter.v1.GreeterService/SayHelloStream")(create(HelloRequestSchema, { name: "x" }))) {
+        out.push((r as { message: string }).message);
+    }
+    assert.deepStrictEqual(out, ["s:x"]);
+});
+await checkAsync("ctx.stream — client-stream dispatch (mock/local)", async () => {
+    const h = catalogCtx.stream("greeter.v1.GreeterService/SayHelloCollect")();
+    h.send(create(HelloRequestSchema, { name: "a" }));
+    h.send(create(HelloRequestSchema, { name: "b" }));
+    const res = await h.close();
+    assert.strictEqual((res as { message: string }).message, "c:b");
+});
+await checkAsync("ctx.stream — bidi dispatch (mock/local)", async () => {
+    const h = catalogCtx.stream("greeter.v1.GreeterService/SayHelloChat")();
+    h.send(create(HelloRequestSchema, { name: "a" }));
+    h.send(create(HelloRequestSchema, { name: "b" }));
+    h.close();
+    const out: string[] = [];
+    for await (const r of h.responses) out.push((r as { message: string }).message);
+    assert.deepStrictEqual(out, ["b:a", "b:b"]);
 });
 check("testing.mockResolver + mockService are callable", () => {
     assert.strictEqual(typeof testing.mockResolver, "function");

--- a/scripts/release-gate/fixture/src/usage.ts
+++ b/scripts/release-gate/fixture/src/usage.ts
@@ -1,0 +1,45 @@
+// Consumer USAGE type-check fixture (cast-free). Compiled against the PACKED
+// .d.ts under the realistic consumer tsconfig (verbatimModuleSyntax:true,
+// strict). Exercises documented public signatures so a signature regression in
+// a published package — wrong arg count, narrowed parameter, dropped overload,
+// or a value mis-declared type-only — fails this fixture even when the .d.ts
+// graph is well-formed (which oracle.mjs already checks). NOT executed; type-
+// checked only. Mirrors the documented patterns in examples/getting-started.
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { createServer, defineCatalog, defineService } from "@connectum/core";
+import { createEventBus, MemoryAdapter } from "@connectum/events";
+import { createDefaultInterceptors, defaultFailurePredicate } from "@connectum/interceptors";
+import { GreeterService, HelloReplySchema, HelloRequestSchema } from "../gen/greeter/v1/greeter_pb.ts";
+
+// defineService — handlers for all four RPC cardinalities, as a consumer writes them.
+const greeterService = defineService(GreeterService, {
+    sayHello: (req) => create(HelloReplySchema, { message: `Hello, ${req.name}` }),
+    sayHelloStream: async function* (req) {
+        yield create(HelloReplySchema, { message: req.name });
+    },
+    sayHelloCollect: async (reqs) => {
+        let last = "";
+        for await (const r of reqs) last = r.name;
+        return create(HelloReplySchema, { message: last });
+    },
+    sayHelloChat: async function* (reqs) {
+        for await (const r of reqs) yield create(HelloReplySchema, { message: r.name });
+    },
+});
+
+// createServer — the documented options shape.
+export const server = createServer({
+    services: [greeterService],
+    port: 0,
+    interceptors: createDefaultInterceptors({ timeout: { duration: 5_000 } }),
+});
+
+// catalog + event bus + classification — documented construction signatures.
+export const catalog = defineCatalog({ "greeter.v1.GreeterService": GreeterService });
+export const bus = createEventBus({ adapter: MemoryAdapter() });
+export const failureIsInfra: boolean = defaultFailurePredicate(new ConnectError("x", Code.Unavailable));
+
+// message constructors round-trip with their generated schemas.
+const req = create(HelloRequestSchema, { name: "x" });
+export const reqName: string = req.name;

--- a/scripts/release-gate/fixture/tsconfig.json
+++ b/scripts/release-gate/fixture/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "gen/**/*.ts"]
+}

--- a/scripts/release-gate/run.mjs
+++ b/scripts/release-gate/run.mjs
@@ -1,0 +1,135 @@
+// Release publish-boundary gate — orchestrator.
+//
+// Validates the framework AS A THIRD-PARTY CONSUMER experiences it, against the
+// PACKED artifacts (never src/ or in-workspace dist/). Sets up a throwaway
+// consumer from ./fixture, installs every published @connectum/* package from
+// either a pkg-pr-new preview (pinned to a commit SHA) or local pnpm-packed
+// tarballs, generates the service catalog, then runs four publish-boundary
+// checks + the behavioral smoke.
+//
+// Usage:
+//   node scripts/release-gate/run.mjs --mode preview --ref <sha>   # pkg-pr-new
+//   node scripts/release-gate/run.mjs --mode pack                  # local tarballs
+//
+// Exit code is non-zero if any check fails.
+
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..", "..");
+const FIXTURE = join(HERE, "fixture");
+const WORK = join(REPO, ".gate-work");
+
+// Published packages (order irrelevant). Keep in sync with packages/*.
+const PKGS = [
+    "core",
+    "auth",
+    "interceptors",
+    "healthcheck",
+    "protoc-gen-catalog",
+    "reflection",
+    "cli",
+    "otel",
+    "testing",
+    "test-fixtures",
+    "events",
+    "events-nats",
+    "events-kafka",
+    "events-redis",
+    "events-amqp",
+];
+
+function arg(name) {
+    const i = process.argv.indexOf(`--${name}`);
+    return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const mode = arg("mode") ?? "preview";
+const ref = arg("ref");
+
+function sh(cmd, args, opts = {}) {
+    const r = spawnSync(cmd, args, { stdio: "inherit", cwd: WORK, ...opts });
+    return r.status ?? 1;
+}
+function die(msg) {
+    console.error(`release-gate: ${msg}`);
+    process.exit(1);
+}
+
+// --- 1. fresh workdir from the fixture ---
+rmSync(WORK, { recursive: true, force: true });
+mkdirSync(WORK, { recursive: true });
+cpSync(FIXTURE, WORK, { recursive: true });
+
+// --- 2. overrides: every @connectum/* → packed artifact ---
+let target;
+let overrideLines;
+if (mode === "preview") {
+    if (!ref) die("--mode preview requires --ref <commit-sha> (pkg-pr-new is pinned to a SHA, never a moving tag)");
+    target = `pkg-pr-new @${ref}`;
+    overrideLines = PKGS.map((p) => `  '@connectum/${p}': 'https://pkg.pr.new/Connectum-Framework/connectum/@connectum/${p}@${ref}'`);
+} else if (mode === "pack") {
+    target = "local pnpm pack";
+    const tarDir = join(WORK, "tarballs");
+    mkdirSync(tarDir, { recursive: true });
+    if (sh("pnpm", ["-w", "build"], { cwd: REPO })) die("workspace build failed");
+    for (const p of PKGS) {
+        if (sh("pnpm", ["pack", "--pack-destination", tarDir], { cwd: join(REPO, "packages", p) })) die(`pnpm pack failed for ${p}`);
+    }
+    const tarballs = readdirSync(tarDir);
+    const find = (p) => {
+        const hit = tarballs.find((f) => f.startsWith(`connectum-${p}-`));
+        if (!hit) die(`no tarball produced for @connectum/${p}`);
+        return join(tarDir, hit);
+    };
+    overrideLines = PKGS.map((p) => `  '@connectum/${p}': 'file:${find(p)}'`);
+} else {
+    die(`unknown --mode '${mode}' (expected preview|pack)`);
+}
+
+// pkg-pr-new tarballs cross-reference each other via pkg.pr.new URLs (exotic
+// subdeps), which pnpm 11 blocks by default; buf downloads its binary in a
+// build script. Allow both for this isolated consumer.
+const ws = [
+    "packages:",
+    "  - '.'",
+    "blockExoticSubdeps: false",
+    "allowBuilds:",
+    "  '@bufbuild/buf': true",
+    "  esbuild: true",
+    "  protobufjs: true",
+    "overrides:",
+    ...overrideLines,
+    "",
+].join("\n");
+writeFileSync(join(WORK, "pnpm-workspace.yaml"), ws);
+console.log(`release-gate: target = ${target}`);
+
+// --- 3. install + generate the catalog (codegen check) ---
+if (sh("pnpm", ["install", "--no-frozen-lockfile"])) die("consumer install failed");
+if (sh("pnpm", ["exec", "buf", "generate"])) die("catalog codegen (buf generate) failed");
+
+// --- 4. run the checks (cwd = workdir, so imports resolve from the packed install) ---
+const env = { ...process.env, GATE_TARGET: target };
+const checks = [
+    ["export-map + .d.ts graph (oracle)", ["node", "checks/oracle.mjs"]],
+    ["value-export completeness", ["node", "checks/completeness.mjs"]],
+    ["runtime importability", ["node", "checks/runtime-import.mjs"]],
+    ["behavioral smoke", ["node", "src/smoke.ts"]],
+];
+const failed = [];
+for (const [label, [cmd, ...args]] of checks) {
+    console.log(`\n=== ${label} ===`);
+    if (sh(cmd, args, { env })) failed.push(label);
+}
+
+// --- 5. verdict ---
+console.log(`\n=== release-gate verdict (${target}) ===`);
+if (failed.length === 0) {
+    console.log("PASS — publish boundary + behavioral smoke green");
+    process.exit(0);
+}
+console.log(`FAIL — ${failed.length} check(s) failed: ${failed.join(", ")}`);
+process.exit(1);

--- a/scripts/release-gate/run.mjs
+++ b/scripts/release-gate/run.mjs
@@ -80,7 +80,11 @@ if (mode === "preview") {
     }
     const tarballs = readdirSync(tarDir);
     const find = (p) => {
-        const hit = tarballs.find((f) => f.startsWith(`connectum-${p}-`));
+        // `connectum-${p}-` is a PREFIX of sibling names (connectum-events- is a
+        // prefix of connectum-events-kafka-), so anchor on the version digit that
+        // follows the package name: `connectum-events-1...` vs `connectum-events-kafka-1...`.
+        const re = new RegExp(`^connectum-${p}-\\d`);
+        const hit = tarballs.find((f) => re.test(f));
         if (!hit) die(`no tarball produced for @connectum/${p}`);
         return join(tarDir, hit);
     };

--- a/scripts/release-gate/run.mjs
+++ b/scripts/release-gate/run.mjs
@@ -118,6 +118,7 @@ const checks = [
     ["value-export completeness", ["node", "checks/completeness.mjs"]],
     ["runtime importability", ["node", "checks/runtime-import.mjs"]],
     ["node: builtin prefixes", ["node", "checks/builtins.mjs"]],
+    ["consumer usage type-check", ["node", "checks/usage-typecheck.mjs"]],
     ["behavioral smoke", ["node", "src/smoke.ts"]],
 ];
 const failed = [];

--- a/scripts/release-gate/run.mjs
+++ b/scripts/release-gate/run.mjs
@@ -117,6 +117,7 @@ const checks = [
     ["export-map + .d.ts graph (oracle)", ["node", "checks/oracle.mjs"]],
     ["value-export completeness", ["node", "checks/completeness.mjs"]],
     ["runtime importability", ["node", "checks/runtime-import.mjs"]],
+    ["node: builtin prefixes", ["node", "checks/builtins.mjs"]],
     ["behavioral smoke", ["node", "src/smoke.ts"]],
 ];
 const failed = [];


### PR DESCRIPTION
## Summary

Adds a release-time gate that validates the framework **as a third-party consumer experiences it** — against the **packed** artifacts (a pkg-pr-new preview pinned to a commit SHA, or local pnpm-packed tarballs), never `src/` or in-workspace `dist/`. This catches publish-boundary defects invisible to the framework build, `tsc`, and the type-stripped examples — the class of bug that shipped in the 1.0.0 preview (#156).

## What it checks

`scripts/release-gate/run.mjs` builds a throwaway consumer from `scripts/release-gate/fixture`, installs every published `@connectum/*` package, generates the service catalog, then runs:

1. **export-map** — every `exports` subpath resolves to a real file.
2. **`.d.ts` graph** — namespace-imports every subpath and type-checks the full declaration graph with `skipLibCheck:false` under a realistic consumer tsconfig (DOM/fetch lib via `target esnext`); enumerates value/type exports.
3. **completeness (both directions)** — every `.d.ts` value export is present at runtime (build-drop), and no runtime value is mislabeled type-only (the inverse).
4. **runtime importability** — every subpath `import()`s under Node ESM (type-only subpaths and executable/plugin entries handled via a documented allowlist).
5. **node: builtin prefixes** — no prefix-only builtin (`node:test`/`sqlite`/`sea`) ships with its prefix stripped, across every package's dist.
6. **consumer usage type-check** — a cast-free fixture compiles documented signatures (`defineService`, `createServer`, `createDefaultInterceptors`, `defineCatalog`, `createEventBus`, …) against the packed `.d.ts`, catching signature regressions.
7. **behavioral smoke** — public functions not covered by example e2e, including a real `ctx.call` dispatch against a mock.

## CI

A `release-gate` job in `snapshot.yml` runs on every PR to `main`, after the pkg-pr-new snapshot publishes, against that PR's pre-release build.

## Verification

Self-tested red/green against real builds: green on the fixed 1.0.0 build; red on the pre-fix build (catches the core const-enum drop + the parity `node:test` import break, the latter via two independent checks). Repo `typecheck` + `lint` + `test:unit` green. `pnpm release:gate` (local pack) / `release:gate:preview --ref <sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a publish-boundary release gate for `@connectum/*` packages, including export-map validation, full type-graph correctness, runtime ESM subpath import checks, Node builtin prefix checks, consumer usage type-checks, and a behavior smoke test.

* **Chores**
  * Introduced GitHub Actions automation to run the release gate on pull requests.
  * Added release-gate tooling and documentation, plus fixture configurations and fixtures used by the checks.
  * Updated `.gitignore` to exclude gate/temporary directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->