### PR TITLE
fix: preserve node: protocol prefix on builtin imports (cross-runtime)

### DIFF
--- a/.changeset/fix-node-protocol-prefix.md
+++ b/.changeset/fix-node-protocol-prefix.md
@@ -1,0 +1,20 @@
+---
+"@connectum/core": patch
+"@connectum/auth": patch
+"@connectum/interceptors": patch
+"@connectum/healthcheck": patch
+"@connectum/reflection": patch
+"@connectum/cli": patch
+"@connectum/otel": patch
+"@connectum/test-fixtures": patch
+"@connectum/protoc-gen-catalog": patch
+"@connectum/events": patch
+"@connectum/events-nats": patch
+"@connectum/events-kafka": patch
+"@connectum/events-redis": patch
+"@connectum/events-amqp": patch
+---
+
+fix: preserve the `node:` protocol prefix on builtin imports
+
+tsup strips the `node:` prefix from builtin imports by default (`removeNodeProtocol: true`). The bare forms (`crypto`, `fs`, `http2`, …) are valid Node aliases, but the `node:` prefix is the portable specifier across runtimes — Deno resolves builtins prefix-first (bare forms are not guaranteed), and prefix-only builtins like `node:test` have no bare alias at all. Every package now sets `removeNodeProtocol: false`, so the published artifacts keep the prefix on every builtin import for maximum cross-runtime portability (Node / Bun / Deno). No runtime behavior change on Node. (`@connectum/testing` already carried this fix.)

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -11,4 +11,6 @@ export default defineConfig({
     // are emitted as separate chunks instead of being bundled into the main auth build.
     // Package consumers should expect multiple ESM output files/chunks from this config.
     splitting: true,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
     banner: { js: "#!/usr/bin/env node" },
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/events-amqp/tsup.config.ts
+++ b/packages/events-amqp/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/events-kafka/tsup.config.ts
+++ b/packages/events-kafka/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/events-nats/tsup.config.ts
+++ b/packages/events-nats/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/events-redis/tsup.config.ts
+++ b/packages/events-redis/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/events/tsup.config.ts
+++ b/packages/events/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/healthcheck/tsup.config.ts
+++ b/packages/healthcheck/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/interceptors/tsup.config.ts
+++ b/packages/interceptors/tsup.config.ts
@@ -20,4 +20,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/otel/tsup.config.ts
+++ b/packages/otel/tsup.config.ts
@@ -21,4 +21,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/protoc-gen-catalog/tsup.config.ts
+++ b/packages/protoc-gen-catalog/tsup.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
     banner: { js: "#!/usr/bin/env node" },
 });

--- a/packages/reflection/tsup.config.ts
+++ b/packages/reflection/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });

--- a/packages/test-fixtures/tsup.config.ts
+++ b/packages/test-fixtures/tsup.config.ts
@@ -8,4 +8,6 @@ export default defineConfig({
     clean: true,
     minify: false,
     splitting: false,
+    // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
+    removeNodeProtocol: false,
 });


### PR DESCRIPTION
## Summary

tsup strips the `node:` prefix from builtin imports by default (`removeNodeProtocol: true`). The bare forms (`crypto`, `fs`, `http2`, …) are valid Node aliases, but the `node:` prefix is the **portable** specifier across runtimes:
- **Deno** resolves builtins prefix-first — bare forms are not guaranteed.
- Prefix-only builtins (`node:test`, `node:sqlite`, `node:sea`) have **no** bare alias at all (this is the class that produced the `@connectum/testing/parity` break fixed in #156).

This sets `removeNodeProtocol: false` in all 14 remaining tsup configs (`@connectum/testing` already carried it) so every published artifact keeps the `node:` prefix on every builtin import, for maximum cross-runtime portability (Node / Bun / Deno).

## Verification
- `pnpm build` green; **zero bare builtin specifiers remain in any `dist/*.js`** (all `node:`-prefixed).
- repo `typecheck` + `test:unit` + `lint` green; `test:esbuild` green.
- One Bun watch-stream test is a pre-existing timing flake (passes on re-run) — unrelated to this change.
- No runtime behavior change on Node. Independently reviewed (Codex): "the right direction … no correctness issue."

🤖 Generated with [Claude Code](https://claude.com/claude-code)