### PR TITLE
docs: correct package and root READMEs for the 1.0.0 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,70 +1,16 @@
 # Changelog
 
-All notable changes to the Connectum monorepo will be documented in this file.
+Connectum is a Changesets-managed monorepo. There is **no consolidated root
+changelog** — the per-package files and the GitHub Releases are canonical.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- **Per-package detail** — each package keeps its own changelog, maintained
+  automatically by [Changesets](https://github.com/changesets/changesets):
+  [`packages/<name>/CHANGELOG.md`](packages/) (e.g.
+  [`packages/core/CHANGELOG.md`](packages/core/CHANGELOG.md)).
 
-This is the root changelog consolidating changes across all `@connectum/*` packages.
-For per-package details, see each package's own `CHANGELOG.md`.
+- **Release highlights across all packages** — the GitHub Releases page,
+  generated from the consumed changesets at publish time:
+  <https://github.com/Connectum-Framework/connectum/releases>.
 
-## [0.2.0-beta.1] - 2026-02-12
-
-### Added
-
-- **@connectum/core**: 5-phase graceful shutdown with `shutdownSignal` and `ShutdownManager` supporting dependency-ordered hooks
-- **@connectum/core**: `builtinInterceptors` option -- custom interceptors now append after built-in ones
-- **@connectum/interceptors**: `createMethodFilterInterceptor` for per-service and per-method routing (ADR-014)
-- **@connectum/interceptors**: `createDefaultInterceptors()` factory for standard interceptor chain
-- **@connectum/otel**: `createOtelClientInterceptor` for client-side RPC tracing with context propagation
-- **@connectum/otel**: `getLogger()` -- unified correlated logger with auto-injected service name from active span (info/warn/error/debug + raw emit)
-- **@connectum/healthcheck**: extracted as a standalone protocol package
-- **@connectum/reflection**: extracted as a standalone protocol package
-- **@connectum/cli**: new package -- CLI tools for proto sync with integration tests
-
-### Changed
-
-- **@connectum/interceptors**: production-ready default chain with resilience patterns (errorHandler -> timeout -> bulkhead -> circuitBreaker -> retry -> fallback -> validation -> serializer)
-- **@connectum/interceptors**: retry logic switched to cockatiel library (exponential backoff)
-- **@connectum/interceptors**: removed domain-specific interceptors (redact, addToken); validation delegated to `@connectrpc/validate`
-- **@connectum/interceptors**: removed 30 biome-ignore directives, replaced `any` with explicit types
-- **@connectum/otel**: unified OTel interceptor, tracing logic moved out of `@connectum/interceptors`
-- **@connectum/healthcheck**: renamed `withHealthcheck` to `Healthcheck` API; singleton manager with embedded proto, gRPC spec compliance
-- **@connectum/reflection**: renamed `withReflection` to `Reflection` API
-- **@connectum/testing**: updated dependencies
-
-### Breaking Changes
-
-- **@connectum/core**: uniform registration API -- removed deprecated code paths
-- **@connectum/interceptors**: default interceptor chain restructured with resilience patterns; domain-specific interceptors removed
-- **@connectum/healthcheck**: singleton manager replaces previous API; proto definitions embedded in the package
-- **@connectum/reflection**: `withReflection()` renamed to `Reflection()`
-- **@connectum/proto**: removed gRPC health and reflection protos (now embedded in respective packages), dropped WKT exports, removed `extensions.ts`
-- **@connectum/utilities**: removed lifecycle and shutdown utilities (moved to `@connectum/core`)
-
-## [0.2.0-alpha.2] - 2026-02-06
-
-### Added
-
-- New `createServer()` API with explicit lifecycle control and event emitter (replaces the previous server factory)
-- Protocol plugin system for healthcheck and reflection registration
-- 9-package architecture across 4 layers (Layer 0-3)
-- Migration to buf CLI v2 for proto generation
-- GitHub organization [Connectum-Framework](https://github.com/Connectum-Framework) with multi-repo structure (connectum, docs, examples)
-
-### Changed
-
-- Renamed all packages from legacy namespace to `@connectum/*`
-- Restructured monorepo into 4 dependency layers: independent core (Layer 0), protocol implementations (Layer 1), integration (Layer 2), development tools (Layer 3)
-- Removed domain-specific packages (`database`, `observability`) -- framework is now generic
-- Switched to native TypeScript execution on Node.js 25.2.0+ (zero build step)
-- Adopted Biome for linting and formatting
-- Adopted Turborepo for build orchestration
-
-### Breaking Changes
-
-- All package names changed to `@connectum/*` scope
-- Server creation uses `createServer()` with named options instead of the previous factory
-- Enum usage replaced with `const` objects and `as const`
-- Explicit `import type` required (`verbatimModuleSyntax`)
-- `.js` extensions required in all import paths
+Each `@connectum/*` package is versioned together as a fixed group, so a given
+release tag corresponds to the same version across every package.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Modular framework for building gRPC/ConnectRPC microservices. Native TypeScript 
 | [`@connectum/healthcheck`](packages/healthcheck) | `Healthcheck()` — gRPC Health Check protocol + HTTP `/healthz`, `healthcheckManager` |
 | [`@connectum/reflection`](packages/reflection) | `Reflection()` — gRPC Server Reflection v1/v1alpha, `collectFileProtos()` |
 | [`@connectum/otel`](packages/otel) | `initProvider()` — OpenTelemetry tracing, metrics, logging; `traced()`, `getTracer()`, `getMeter()` |
-| [`@connectum/cli`](packages/cli) | CLI tooling for code generation and project scaffolding |
+| [`@connectum/cli`](packages/cli) | `connectum proto sync` — sync proto types from a running server via reflection |
 | [`@connectum/events`](packages/events) | `createEventBus()` — proto-first pub/sub with middleware (retry, DLQ), `MemoryAdapter` |
 | [`@connectum/events-nats`](packages/events-nats) | NATS JetStream adapter for EventBus |
 | [`@connectum/events-kafka`](packages/events-kafka) | Apache Kafka / Redpanda adapter for EventBus |

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -11,6 +11,9 @@ Authentication and authorization interceptors for Connectum.
 - **Gateway auth interceptor** -- extract pre-authenticated identity from API gateway headers (Kong, Envoy, etc.) with header-based trust verification
 - **Session auth interceptor** -- session-based authentication for frameworks like better-auth, lucia, etc.
 - **Authorization interceptor** -- declarative RBAC rules with first-match semantics and programmatic fallback
+- **Proto authorization interceptor** -- authorization driven by `connectum.auth.v1` proto custom options, with `getPublicMethods`/`resolveMethodAuth` reader utilities
+- **Client Bearer interceptor** -- client-side `Authorization: Bearer <token>` injection with static tokens or async refresh factories
+- **Client gateway interceptor** -- client-side service-to-service auth headers (gateway secret + subject + roles) for calls behind an API gateway
 - **AsyncLocalStorage context** -- zero-boilerplate access to auth context from any handler
 - **Header propagation** -- cross-service auth context forwarding (Envoy-style `x-auth-*` headers)
 - **LRU cache** -- in-memory credential verification caching with TTL expiration
@@ -20,12 +23,6 @@ Authentication and authorization interceptors for Connectum.
 
 ```bash
 pnpm add @connectum/auth
-```
-
-**Peer dependencies**:
-
-```bash
-pnpm add @connectrpc/connect
 ```
 
 ## Quick Start
@@ -532,6 +529,9 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `createGatewayAuthInterceptor` -- gateway-injected headers
 - `createSessionAuthInterceptor` -- session-based auth
 - `createAuthzInterceptor` -- declarative rules-based authorization
+- `createProtoAuthzInterceptor` -- proto-option-driven authorization (`connectum.auth.v1`)
+- `createClientBearerInterceptor` -- client-side Bearer token injection
+- `createClientGatewayInterceptor` -- client-side gateway service-to-service auth
 
 **Context management**:
 - `getAuthContext` -- get current AuthContext (or undefined)
@@ -550,6 +550,8 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `AuthzEffect` -- rule effect constants (`ALLOW`, `DENY`)
 - `AuthzDeniedError` -- authorization denied error class
 - `matchesMethodPattern` -- method pattern matching utility
+- `getPublicMethods` -- collect `skipMethods` patterns for proto-`public` methods from service descriptors
+- `resolveMethodAuth` -- resolve effective per-method auth config from proto options (cached)
 
 **Types** (TypeScript only):
 - `AuthContext`
@@ -559,6 +561,10 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `GatewayHeaderMapping`
 - `SessionAuthInterceptorOptions`
 - `AuthzInterceptorOptions`
+- `ProtoAuthzInterceptorOptions`
+- `ClientBearerInterceptorOptions`
+- `ClientGatewayInterceptorOptions`
+- `ResolvedMethodAuth`
 - `AuthzRule`
 - `CacheOptions`
 - `InterceptorFactory`
@@ -573,7 +579,7 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 
 ## Dependencies
 
-- `@connectrpc/connect` -- ConnectRPC core (peer dependency)
+- `@connectrpc/connect` -- ConnectRPC core (runtime dependency)
 - `jose` -- JWT/JWK/JWS verification
 
 ## Requirements

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,7 +96,7 @@ await server.start();
 
 ## Internal Architecture
 
-Starting with v0.2.0-beta, the `@connectum/core` module is split into 3 independent submodules, each responsible for its own domain:
+The `@connectum/core` module is split into independent submodules, each responsible for its own domain:
 
 ```
 core/src/
@@ -295,8 +295,8 @@ const { key, cert } = readTLSCertificates({
   certPath: './keys/server.crt',
 });
 
-// Get configured TLS path
-const configuredPath = tlsPath();
+// Configured TLS path (eagerly resolved string constant — use as a value, not a call)
+const configuredPath = tlsPath;
 ```
 
 ### SanitizableError Protocol
@@ -361,7 +361,7 @@ throw new PaymentError('Stripe declined', { stripeCode: 'card_declined', amount:
 | `isSanitizableError` | function | Type guard for `SanitizableError` |
 | `getTLSPath` | function | Get TLS path from environment |
 | `readTLSCertificates` | function | Read TLS key and certificate files |
-| `tlsPath` | function | Get configured TLS path |
+| `tlsPath` | const | Configured TLS path (eagerly resolved string) |
 | `parseEnvConfig` | function | Parse environment configuration (throws on invalid) |
 | `safeParseEnvConfig` | function | Parse environment configuration (returns result) |
 | `ConnectumEnvSchema` | const | Zod schema for environment variables |
@@ -380,6 +380,40 @@ throw new PaymentError('Stripe declined', { stripeCode: 'card_declined', amount:
 | `HttpHandler` | type | HTTP handler type |
 | `ProtocolContext` | type | Protocol context type |
 | `ConnectumEnv` | type | Environment configuration type |
+
+### Service catalog & transport
+
+| Export | Kind | Description |
+|--------|------|-------------|
+| `defineService` | function | Define a mountable service from a descriptor + register closure |
+| `defineLazyService` | function | Define a service whose implementation is resolved lazily |
+| `defineCatalog` | function | Build a typed `ServiceCatalog` for cross-service calls |
+| `mergeCatalogs` | function | Merge multiple catalogs into one |
+| `CatalogConfigError` | class | Error thrown for invalid catalog configuration |
+| `createLocalTransport` | function | Create an in-process transport for same-process service calls |
+| `CreateLocalTransportOptions` | type | Options for `createLocalTransport()` (client-side interceptors) |
+| `defaultPropagateHeaders` | const | Ready-made opt-in allow-list of W3C trace-context headers for `createServer({ propagateHeaders })` (nothing propagates by default) |
+| `dnsResolver` | function | Remote resolver that builds per-service targets from a DNS-style URL template |
+| `DnsResolverOptions` | type | Options for `dnsResolver()` (URL template, transport factory) |
+| `mapResolver` | function | Remote resolver backed by a static service→target map |
+| `perServiceEnvResolver` | function | Remote resolver reading per-service targets from env |
+| `PerServiceEnvResolverOptions` | type | Options for `perServiceEnvResolver()` (transport factory) |
+| `singleTransportResolver` | function | Remote resolver returning one transport for all services |
+| `resolveEffectiveTransport` | function | Resolve the effective transport (`plaintext-h1` / `h2c` / `tls-h1-negotiable` / `tls-h2-only`) from `tls` + `allowHTTP1` |
+| `TransportValidationError` | class | Error for bidi-streaming methods unsupported by the effective transport |
+| `TRANSPORT_VALIDATION_ERROR_CODE` | const | Error code for `TransportValidationError` |
+| `TransportValidationMode` | const | Transport validation mode values |
+| `EffectiveTransport` | const | Effective transport values |
+| `Context` | type | Handler context exposing `ctx.call` / `ctx.stream` |
+| `CallOptions` | type | Options for a `ctx.call` cross-service call |
+| `ServiceOptions` | type | Per-service options for `defineService()` |
+| `RemoteResolver` | type | Interface for resolving remote service transports |
+| `ResolverContext` | type | Context passed to a `RemoteResolver` |
+| `ServiceCatalog` | type | Typed registry of callable services |
+| `ConnectumCallMap` | type | Augmentable map of unary cross-service calls |
+| `ConnectumStreamMap` | type | Augmentable map of streaming cross-service calls |
+| `BidiStreamHandle` | type | Handle for a bidirectional stream from `ctx.stream` |
+| `ClientStreamHandle` | type | Handle for a client stream from `ctx.stream` |
 
 ## Configuration Types
 
@@ -457,9 +491,7 @@ See `@connectum/interceptors` package for `DefaultInterceptorOptions` and full d
 |----------|-------------|---------|
 | `PORT` | Server port | `5000` |
 | `LISTEN` | Server host | `0.0.0.0` |
-| `TLS_PATH` | Path to TLS certificates directory | - |
-| `TLS_KEY_PATH` | Path to TLS key file | - |
-| `TLS_CERT_PATH` | Path to TLS certificate file | - |
+| `TLS_DIR_PATH` | Directory containing the TLS key + cert (`server.key`/`server.crt`) that `tlsPath` resolves | - |
 | `NODE_ENV` | Environment (affects logger) | - |
 
 ## Examples
@@ -597,29 +629,6 @@ await server.start();
 // Note: Cannot add services after start()
 ```
 
-## Legacy API (Deprecated)
-
-The `Runner()` function is deprecated. Use `createServer()` instead.
-
-```typescript
-// Deprecated
-import { Runner } from '@connectum/core';
-const server = await Runner(options);
-
-// New API
-import { createServer } from '@connectum/core';
-const server = createServer(options);
-await server.start();
-```
-
-Key differences:
-- `createServer()` returns an unstarted server (call `.start()` explicitly)
-- Lifecycle hooks via EventEmitter (`server.on('ready', ...)`)
-- Explicit `.stop()` method instead of `.shutdown()`
-- Health check via `@connectum/healthcheck` package
-- Reflection via `@connectum/reflection` package
-- Server state available via `server.state`
-
 ## Documentation
 
 ### Getting Started
@@ -649,6 +658,7 @@ None — `@connectum/core` is Layer 0 with zero internal dependencies.
 - `@connectrpc/connect-node` - Node.js adapter
 - `@bufbuild/protobuf` - Protocol Buffers runtime
 - `env-var` - Environment variables management
+- `zod` - Environment configuration schema validation
 
 ## Requirements
 
@@ -667,7 +677,7 @@ None — `@connectum/core` is Layer 0 with zero internal dependencies.
 
 ## License
 
-MIT
+Apache-2.0
 
 ---
 

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -108,8 +108,8 @@ import { UserCreatedSchema } from '#gen/events_pb.js';
 
 export default (router: EventRouter) => {
   router.service(UserService, {
-    async userCreated(ctx) {
-      const event = ctx.event; // Typed from proto schema
+    async userCreated(event, ctx) {
+      // event is typed from the proto schema (first positional arg)
       console.log(`User created: ${event.name}`);
       // Auto-ack on successful return
     },
@@ -136,7 +136,7 @@ const bus = createEventBus({
     retry: {
       maxRetries: 3,           // Max retry attempts (default: 3)
       backoff: 'exponential',  // 'exponential' | 'linear' | 'fixed'
-      initialDelay: 200,       // Initial delay in ms (default: 200)
+      initialDelay: 200,       // Initial delay in ms (default: 1000)
       maxDelay: 30000,         // Max delay in ms (default: 30000)
       retryableErrors: (err) => !(err instanceof ValidationError),
     },
@@ -154,10 +154,7 @@ const bus = createEventBus({
   middleware: {
     dlq: {
       topic: 'service.dlq',        // DLQ topic name (required)
-      errorSerializer: (err) => ({  // Custom error serialization
-        message: err instanceof Error ? err.message : String(err),
-        stack: err instanceof Error ? err.stack : undefined,
-      }),
+      errorSerializer: (err) => (err instanceof Error ? err.message : String(err)),
     },
   },
 });
@@ -241,16 +238,18 @@ interface EventBus {
 |-----------|------|---------|-------------|
 | `metadata` | `Record<string, string>` | `undefined` | Event metadata / headers |
 | `topic` | `string` | `undefined` | Override the schema-derived event type / topic name |
+| `group` | `string` | `undefined` | Named group tag for workflow grouping |
 | `key` | `string` | `undefined` | Partition key (Kafka) or routing key |
 
 ### EventContext
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `event` | `T` | Deserialized event payload |
 | `eventType` | `string` | Event type / topic name |
 | `eventId` | `string` | Unique event identifier |
-| `metadata` | `Map<string, string>` | Event metadata |
+| `publishedAt` | `Date` | When the event was published |
+| `attempt` | `number` | Delivery attempt number (1-based) |
+| `metadata` | `ReadonlyMap<string, string>` | Event metadata |
 | `signal` | `AbortSignal` | Abort signal (shutdown + timeout) |
 | `ack()` | `() => Promise<void>` | Acknowledge event (idempotent) |
 | `nack(requeue?)` | `(requeue?: boolean) => Promise<void>` | Negative-acknowledge event |
@@ -260,7 +259,7 @@ interface EventBus {
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `topic` | `string` | required | DLQ topic name |
-| `errorSerializer` | `(error: unknown) => Record<string, unknown>` | Default serializer | Custom error serialization |
+| `errorSerializer` | `(error: unknown) => string` | `error.name` only | Custom error serialization |
 
 ### RetryOptions
 
@@ -268,8 +267,9 @@ interface EventBus {
 |-----------|------|---------|-------------|
 | `maxRetries` | `number` | `3` | Maximum retry attempts |
 | `backoff` | `'exponential' \| 'linear' \| 'fixed'` | `'exponential'` | Backoff strategy |
-| `initialDelay` | `number` | `200` | Initial delay in ms |
+| `initialDelay` | `number` | `1000` | Initial delay in ms |
 | `maxDelay` | `number` | `30000` | Maximum delay in ms |
+| `multiplier` | `number` | `2` | Multiplier for exponential backoff |
 | `retryableErrors` | `(err: unknown) => boolean` | All errors | Filter for retryable errors |
 
 ## MemoryAdapter

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -38,7 +38,7 @@ pnpm add @connectum/otel
 **Peer dependencies** (installed automatically):
 
 ```bash
-pnpm add @opentelemetry/api @opentelemetry/sdk-node
+pnpm add @opentelemetry/api @opentelemetry/sdk-trace-node
 ```
 
 ## Quick Start
@@ -197,8 +197,6 @@ await service.getUser("123");
 
 # Service metadata
 OTEL_SERVICE_NAME=my-service
-OTEL_SERVICE_VERSION=1.0.0
-OTEL_SERVICE_NAMESPACE=production
 
 # Trace exporter
 OTEL_TRACES_EXPORTER=otlp/http  # "otlp/http", "otlp/grpc", "console", or "none"
@@ -431,13 +429,12 @@ import {
   getOTLPSettings,
   getCollectorOptions,
   getBatchSpanProcessorOptions,
-  getIgnoredInstrumentations,
   ExporterType,
 } from "@connectum/otel";
 
 // Service metadata
 const metadata = getServiceMetadata();
-// { name: "my-service", version: "1.0.0", namespace: "production" }
+// { name: "my-service", version: "1.0.0" }
 
 // OTLP settings
 const otlpSettings = getOTLPSettings();
@@ -449,11 +446,7 @@ const collectorOptions = getCollectorOptions();
 
 // Batch span processor options
 const bspOptions = getBatchSpanProcessorOptions();
-// { scheduledDelayMillis: 5000, maxQueueSize: 2048, ... }
-
-// Ignored instrumentations
-const ignored = getIgnoredInstrumentations();
-// ["fs", "dns"]
+// { maxExportBatchSize: 100, maxQueueSize: 1000, scheduledDelayMillis: 1000, exportTimeoutMillis: 10000 }
 ```
 
 ### Provider Management
@@ -525,8 +518,6 @@ type BatchSpanProcessorOptions = {
 ### Service Metadata
 
 - `OTEL_SERVICE_NAME` - Service name (required)
-- `OTEL_SERVICE_VERSION` - Service version (optional)
-- `OTEL_SERVICE_NAMESPACE` - Service namespace (optional, e.g., "production")
 
 ### Exporters
 
@@ -548,10 +539,10 @@ type BatchSpanProcessorOptions = {
 
 ### Batch Span Processor
 
-- `OTEL_BSP_SCHEDULE_DELAY` - Schedule delay (ms, default: 5000)
-- `OTEL_BSP_MAX_QUEUE_SIZE` - Max queue size (default: 2048)
-- `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` - Max batch size (default: 512)
-- `OTEL_BSP_EXPORT_TIMEOUT` - Export timeout (ms, default: 30000)
+- `OTEL_BSP_SCHEDULE_DELAY` - Schedule delay (ms, default: 1000)
+- `OTEL_BSP_MAX_QUEUE_SIZE` - Max queue size (default: 1000)
+- `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` - Max batch size (default: 100)
+- `OTEL_BSP_EXPORT_TIMEOUT` - Export timeout (ms, default: 10000)
 
 ### Instrumentations
 
@@ -719,7 +710,7 @@ await repository.findById("123");
 
 ### Version pin rationale
 
-`@connectum/otel` pins the OpenTelemetry JS toolchain through the workspace catalog (currently `@opentelemetry/sdk-node` `^0.212.0`, which resolves `@opentelemetry/otlp-transformer` to a release predating the PR #6179 migration / PR #6225 revert cycle). The pin is intentional: it avoids the short-lived regression window and gives us a single place to coordinate a future bump once the hand-rolled serializer path stabilizes for all three signals. Monitor the upstream issues/PRs above before proposing a catalog bump.
+`@connectum/otel` pins the OpenTelemetry JS toolchain through the workspace catalog (currently `@opentelemetry/sdk-trace-node` `^2.8.0`, alongside `@opentelemetry/sdk-metrics` `^2.8.0` and `@opentelemetry/sdk-logs` `^0.219.0`, which resolves `@opentelemetry/otlp-transformer` to `0.219.0` — past the PR #6179 migration / PR #6225 revert cycle, with the hand-rolled logs serializer (PR #6390, since `0.215.0`) already in place while metrics and traces remain `protobufjs`-backed). The pin is intentional: it avoids the short-lived regression window and gives us a single place to coordinate a future bump once the hand-rolled serializer path stabilizes for all three signals. Monitor the upstream issues/PRs above before proposing a catalog bump.
 
 ### Guidance for high-volume span workloads
 
@@ -727,7 +718,7 @@ If you export more than ~10,000 spans/sec via OTLP/protobuf, plan around the cur
 
 - Prefer **batching** — the default `BatchSpanProcessor` tuned via `OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`, and `OTEL_BSP_EXPORT_TIMEOUT` (see [Environment Variables](#environment-variables)).
 - Consider **head or tail sampling** to reduce export volume before it reaches the serializer.
-- Watch SDK self-metrics exposed by recent `@opentelemetry/sdk-node` releases (e.g., span queue size and dropped spans) to detect exporter back-pressure.
+- Watch SDK self-metrics exposed by recent `@opentelemetry/sdk-trace-node` releases (e.g., span queue size and dropped spans) to detect exporter back-pressure.
 - Track the trace serializer migration via upstream [#6570](https://github.com/open-telemetry/opentelemetry-js/issues/6570) and the [#6221](https://github.com/open-telemetry/opentelemetry-js/issues/6221) follow-ups; a catalog bump will be coordinated through a Connectum release once the hand-rolled path covers traces.
 
 ## Known Limitations
@@ -750,10 +741,18 @@ If you export more than ~10,000 spans/sec via OTLP/protobuf, plan around the cur
 ### External Dependencies
 
 - `@opentelemetry/api` - OpenTelemetry API
-- `@opentelemetry/sdk-node` - OpenTelemetry SDK
-- `@opentelemetry/auto-instrumentations-node` - Auto-instrumentations
-- `@opentelemetry/exporter-trace-otlp-http` - OTLP HTTP exporter
-- `@opentelemetry/exporter-metrics-otlp-http` - OTLP metrics exporter
+- `@opentelemetry/api-logs` - OpenTelemetry Logs API
+- `@opentelemetry/sdk-trace-node` - Tracing SDK (Node.js)
+- `@opentelemetry/sdk-metrics` - Metrics SDK
+- `@opentelemetry/sdk-logs` - Logs SDK
+- `@opentelemetry/resources` - Resource detection
+- `@opentelemetry/semantic-conventions` - Semantic conventions
+- `@opentelemetry/exporter-trace-otlp-http` - OTLP HTTP trace exporter
+- `@opentelemetry/exporter-trace-otlp-grpc` - OTLP gRPC trace exporter
+- `@opentelemetry/exporter-metrics-otlp-http` - OTLP HTTP metrics exporter
+- `@opentelemetry/exporter-metrics-otlp-grpc` - OTLP gRPC metrics exporter
+- `@opentelemetry/exporter-logs-otlp-http` - OTLP HTTP logs exporter
+- `@opentelemetry/exporter-logs-otlp-grpc` - OTLP gRPC logs exporter
 - `env-var` - Environment variables
 
 ## Requirements
@@ -763,7 +762,7 @@ If you export more than ~10,000 spans/sec via OTLP/protobuf, plan around the cur
 
 ## License
 
-MIT
+Apache-2.0
 
 ---
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -10,7 +10,7 @@ Testing utilities for the Connectum framework. Provides mock factories, assertio
 pnpm add -D @connectum/testing
 ```
 
-**Peer dependencies**: `@connectrpc/connect`, `@bufbuild/protobuf`
+**Dependencies** (installed automatically): `@connectum/core`, `@connectum/test-fixtures`, `@connectrpc/connect`, `@connectrpc/connect-node`, `@bufbuild/protobuf`, `@opentelemetry/api`
 
 ## Quick Start
 
@@ -116,7 +116,8 @@ import { Code } from '@connectrpc/connect';
 
 // Success
 const next = createMockNext();
-const result = await handler(req, next);
+const handler = interceptor(next);
+const result = await handler(req);
 assert.strictEqual(next.mock.calls.length, 1);
 
 // Custom response message
@@ -147,7 +148,7 @@ import { assertConnectError } from '@connectum/testing';
 import { Code } from '@connectrpc/connect';
 
 // In rejects callback
-await assert.rejects(() => handler(req, next), (err: unknown) => {
+await assert.rejects(() => handler(req), (err: unknown) => {
   assertConnectError(err, Code.InvalidArgument, /validation failed/i);
   return true;
 });
@@ -434,6 +435,65 @@ transportParityTest("emits matching spans", {
 });
 ```
 
+## Service-Catalog Mocks
+
+For handlers that call other services through the catalog (`ctx.call` /
+`ctx.stream`), `@connectum/testing` ships an in-memory `RemoteResolver` and a
+mock `Context` factory so you can unit-test cross-service logic without a
+network hop.
+
+### `mockResolver()` / `mockService()`
+
+`mockResolver(mocks)` builds a `RemoteResolver` (from `@connectum/core`) backed
+by in-memory router transports. It returns `null` for any service not in the
+mock set, so it composes with real resolvers. Every mock response carries the
+`MOCK_RESPONSE_HEADER` (`"x-connectum-mock"`) so tests can assert the call was
+served by a mock. `mockService(service, impl)` is a type-safe constructor that
+pairs a service descriptor with a (partial) implementation typed against it.
+
+```typescript
+import { create } from "@bufbuild/protobuf";
+import { mockResolver, mockService } from "@connectum/testing";
+
+const resolver = mockResolver([
+  mockService(InventoryService, {
+    getStock: () => create(StockSchema, { units: 7 }),
+  }),
+]);
+```
+
+### `createMockContext()`
+
+Creates a Connectum `Context` whose `ctx.call` / `ctx.stream` resolve against
+the given mocks. It drives the same dispatch path as a live request (a real
+`Server` is built with the catalog and `mockResolver`), so resolver lookup,
+header propagation, and error semantics match production. Pass it as the second
+argument to a handler under test.
+
+```typescript
+import { create } from "@bufbuild/protobuf";
+import { defineCatalog } from "@connectum/core";
+import { createMockContext, mockService } from "@connectum/testing";
+
+const ctx = createMockContext({
+  catalog: defineCatalog({ [InventoryService.typeName]: InventoryService }),
+  mocks: [mockService(InventoryService, { getStock: () => create(StockSchema, { units: 7 }) })],
+});
+
+const res = await orderHandler(create(CreateOrderSchema, { sku: "x" }), ctx);
+```
+
+**Options (`CreateMockContextOptions`):**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `catalog` | `ServiceCatalog` | — | The catalog the handler-under-test calls into (required) |
+| `mocks` | `MockService[]` | — | Mock implementations served via the resolver path (required) |
+| `outgoingInterceptors` | `Interceptor[]` | `[]` | Outgoing interceptors (applied exactly as in production) |
+| `requestHeader` | `HeadersInit` | — | Inbound headers (seen by `ctx.requestHeader` + propagation) |
+| `timeoutMs` | `number` | — | Inbound deadline in ms (drives the `ctx.timeoutMs()` cascade) |
+| `propagateHeaders` | `string[]` | — | Header names propagated onto outgoing calls |
+
 ## Running Tests
 
 ```bash
@@ -450,7 +510,7 @@ pnpm test                                 # All packages
 ## Architecture
 
 - **Layer:** 2 (Tools) — depends on Layer 0 (@connectum/core) and external packages
-- **Dependencies:** `@connectum/core`, `@connectrpc/connect`, `@bufbuild/protobuf`
+- **Dependencies:** `@connectum/core`, `@connectum/test-fixtures`, `@connectrpc/connect`, `@connectrpc/connect-node`, `@bufbuild/protobuf`, `@opentelemetry/{api,sdk-metrics,sdk-trace-base}`
 - **Rationale:** Testing is a devDependency concern — production code must not pull test utilities ([ADR-003](https://github.com/Connectum-Framework/docs/blob/main/en/contributing/adr/003-package-decomposition.md))
 - **Test runner:** `node:test` built-in ([ADR-007](https://github.com/Connectum-Framework/docs/blob/main/en/contributing/adr/007-testing-strategy.md))
 


### PR DESCRIPTION
## Summary

Documentation-only pass that corrects every package and root README against the
**actual 1.0.0 source** (audited symbol-by-symbol against each package's
`src/index.ts`, not assumptions).

## Fixes

- **core** — remove the deleted `Runner()` API and the `tlsPath()`-as-function
  example (`tlsPath` is a resolved `const`); drop phantom env vars
  `TLS_PATH`/`TLS_KEY_PATH`/`TLS_CERT_PATH` (the code reads only `TLS_DIR_PATH`);
  complete the Exports Summary with the 1.0.0 service-catalog / transport surface
  (`defineService`, `defineCatalog`, resolvers, transport validation, …).
- **core, otel** — license is **Apache-2.0**, not MIT (matches `LICENSE` and every
  `package.json`).
- **otel** — remove references to the non-existent `@opentelemetry/sdk-node` and
  `getIgnoredInstrumentations`; correct the batch-span-processor defaults; drop the
  phantom `OTEL_SERVICE_VERSION` / `OTEL_SERVICE_NAMESPACE` env vars; fix a stale
  otlp-transformer version claim.
- **auth** — document the three previously-missing interceptor factories
  (`createProtoAuthzInterceptor`, `createClientBearerInterceptor`,
  `createClientGatewayInterceptor`) plus `getPublicMethods` / `resolveMethodAuth`.
- **events** — fix the handler signature example and retry defaults; add the missing
  `multiplier` and `group` option rows.
- **testing** — fix the false peer-dependency claim and the non-running
  `interceptor(next)` examples; document the service-catalog mock API.
- **root README** — correct the `@connectum/cli` description.
- **root CHANGELOG.md** — replace the abandoned manual changelog (stuck at
  `0.2.0-beta.1`, outside the Changesets model) with a pointer to the per-package
  `CHANGELOG.md` files and the GitHub Releases page.

## Verification

Every added export confirmed present in `src/index.ts`; no residual `MIT` / `Runner(` /
pre-1.0 version strings across any README; all code fences balanced; license
cross-checked against `LICENSE` + all 15 `package.json`.

## Release note

No changeset is included — this is documentation only. The corrected READMEs ship to
npm automatically with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-catalog mock utilities to testing package for improved test development.
  * Expanded auth interceptor options for proto authorization, bearer token injection, and gateway auth.

* **Documentation**
  * Updated all package READMEs to document current APIs and capabilities.
  * Clarified CLI's focus on `connectum proto sync` for proto type synchronization.
  * Updated events package retry defaults and EventContext metadata shape.
  * Refined OpenTelemetry integration guidance and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->