### PR TITLE
docs(otel): align README .env example with real defaults; drop no-op env var

### DIFF
--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -214,12 +214,9 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf  # "http/protobuf" or "grpc"
 OTEL_EXPORTER_OTLP_HEADERS=x-api-key=secret
 
 # Batch span processor
-OTEL_BSP_SCHEDULE_DELAY=5000
-OTEL_BSP_MAX_QUEUE_SIZE=2048
-OTEL_BSP_MAX_EXPORT_BATCH_SIZE=512
-
-# Ignored instrumentations (comma-separated)
-OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns
+OTEL_BSP_SCHEDULE_DELAY=1000
+OTEL_BSP_MAX_QUEUE_SIZE=1000
+OTEL_BSP_MAX_EXPORT_BATCH_SIZE=100
 ```
 
 ## Main Exports
@@ -543,10 +540,6 @@ type BatchSpanProcessorOptions = {
 - `OTEL_BSP_MAX_QUEUE_SIZE` - Max queue size (default: 1000)
 - `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` - Max batch size (default: 100)
 - `OTEL_BSP_EXPORT_TIMEOUT` - Export timeout (ms, default: 10000)
-
-### Instrumentations
-
-- `OTEL_NODE_DISABLED_INSTRUMENTATIONS` - Comma-separated list of disabled instrumentations
 
 ## Examples
 


### PR DESCRIPTION
Follow-up to #160. The otel README .env example still showed the upstream OTel BSP defaults (5000/2048/512) while the Environment Variables table (correctly) documents Connectum's defaults (1000/1000/100, per `config.ts`); this aligns the example. Also removes `OTEL_NODE_DISABLED_INSTRUMENTATIONS` (both the .env example and the env-var list) — it only takes effect with `@opentelemetry/auto-instrumentations-node`, which this package does not ship, so the variable is a no-op.

Docs only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)