### PR TITLE
fix(cli): read version from package.json so --version matches the release

### DIFF
--- a/.changeset/cli-version-from-package-json.md
+++ b/.changeset/cli-version-from-package-json.md
@@ -1,0 +1,5 @@
+---
+"@connectum/cli": patch
+---
+
+Read the CLI version from `package.json` so `connectum --version` always reports the real published release. It previously printed a hand-maintained string (`0.2.0-alpha.2`) that had drifted from the actual package version.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,13 +10,18 @@
  * @mergeModuleWith <project>
  */
 
+import { readFileSync } from "node:fs";
 import { defineCommand, runMain } from "citty";
 import { protoSyncCommand } from "./commands/proto-sync.ts";
+
+// Read the version from package.json so `connectum --version` always reports the
+// real published release instead of a hand-maintained (and drift-prone) string.
+const { version } = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version: string };
 
 const main = defineCommand({
     meta: {
         name: "connectum",
-        version: "0.2.0-alpha.2",
+        version,
         description: "CLI tools for Connectum gRPC/ConnectRPC framework",
     },
     subCommands: {


### PR DESCRIPTION
## Summary

`connectum --version` printed a hardcoded `0.2.0-alpha.2` that had drifted from
the published package version. It now reads the version from `package.json` at
runtime, so `--version` always matches the release.

## Verification

- Build + `node dist/index.js --version` → `1.0.0`
- `tsc --noEmit` clean

## Release impact

This is a runtime fix to a **published** package, so it carries a patch
changeset. Because `@connectum/*` is a fixed-version group, merging this bumps
all packages to **1.0.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `connectum --version` to correctly report the actual published package version instead of displaying an outdated pre-release string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->