### PR TITLE
feat(events): resolve declared topic for publisher-only processes

### DIFF
--- a/.changeset/events-publishes-topic-resolution.md
+++ b/.changeset/events-publishes-topic-resolution.md
@@ -1,0 +1,5 @@
+---
+"@connectum/events": minor
+---
+
+Add `EventBusOptions.publishes` for publisher-only processes. A process that publishes an event without subscribing to it had no `routes`, so `publish()` fell back to the message `typeName` and silently emitted to the wrong topic whenever the event declared a custom `(connectum.events.v1.event).topic`. List the event service descriptors in `publishes` to resolve the declared topic from the proto option end-to-end, instead of hand-maintaining raw topic strings.

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -215,12 +215,23 @@ function createEventBus(options: EventBusOptions): EventBus
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `adapter` | `EventAdapter` | required | Broker adapter (NATS, Kafka, Redis, Memory) |
-| `routes` | `EventRoute[]` | `[]` | Event route handlers |
+| `routes` | `EventRoute[]` | `[]` | Event route handlers (subscriber side) |
+| `publishes` | `DescService[]` | `[]` | Event service descriptors this process publishes to (publisher side, no subscription) |
 | `middleware` | `MiddlewareConfig` | `{}` | Middleware configuration |
 | `group` | `string` | `undefined` | Consumer group name |
 | `signal` | `AbortSignal` | `undefined` | External abort signal |
 | `handlerTimeout` | `number` | `30000` | Per-handler timeout in ms |
 | `drainTimeout` | `number` | `30000` | Max ms to wait for in-flight handlers during shutdown |
+
+> **Publisher-only processes:** when a service publishes an event but does not subscribe to it (the usual split-microservices shape), it has no `routes`, so `publish()` would fall back to the message `typeName` — silently emitting to the wrong topic whenever the event declares a custom `(connectum.events.v1.event).topic`. List the event service descriptors in `publishes` so the declared topic is resolved from the proto option end-to-end, instead of hand-maintaining raw topic strings:
+>
+> ```typescript
+> import { OrderEventService } from '#gen/order/v1/order_pb.js';
+>
+> const bus = createEventBus({ adapter, publishes: [OrderEventService] });
+> await bus.start();
+> await bus.publish(OrderPlacedSchema, order); // → declared topic, not "order.v1.OrderPlaced"
+> ```
 
 ### EventBus Interface
 

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -17,6 +17,7 @@ import { EventRouterImpl } from "./EventRouter.ts";
 import { dlqMiddleware } from "./middleware/dlq.ts";
 import { retryMiddleware } from "./middleware/retry.ts";
 import { composeMiddleware } from "./middleware.ts";
+import { resolveTopicName } from "./topic.ts";
 import type { EventBus, EventBusOptions, EventContext, EventMiddleware, EventSubscription, PublishOptions, RawEvent } from "./types.ts";
 import { matchPattern } from "./wildcard.ts";
 
@@ -128,15 +129,25 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                     const derivedName = deriveServiceName(router.serviceNames);
                     await adapter.connect(derivedName ? { serviceName: derivedName } : undefined);
 
-                    // Build publish topic lookup: input message typeName → resolved topic
+                    // Build publish topic lookup: input message typeName → resolved topic.
+                    // Populated from BOTH subscriber routes and publish-only services
+                    // (`publishes`), so a pure publisher resolves the declared
+                    // `(event).topic` instead of silently falling back to the typeName.
                     publishTopicMap.clear();
-                    for (const entry of router.entries) {
-                        const messageType = entry.method.input.typeName;
+                    const setPublishTopic = (messageType: string, topic: string): void => {
                         const existingTopic = publishTopicMap.get(messageType);
-                        if (existingTopic !== undefined && existingTopic !== entry.topic) {
-                            throw new Error(`Ambiguous publish topic for "${messageType}": "${existingTopic}" and "${entry.topic}". Pass publishOptions.topic explicitly.`);
+                        if (existingTopic !== undefined && existingTopic !== topic) {
+                            throw new Error(`Ambiguous publish topic for "${messageType}": "${existingTopic}" and "${topic}". Pass publishOptions.topic explicitly.`);
                         }
-                        publishTopicMap.set(messageType, entry.topic);
+                        publishTopicMap.set(messageType, topic);
+                    };
+                    for (const entry of router.entries) {
+                        setPublishTopic(entry.method.input.typeName, entry.topic);
+                    }
+                    for (const service of options.publishes ?? []) {
+                        for (const method of service.methods) {
+                            setPublishTopic(method.input.typeName, resolveTopicName(method));
+                        }
                     }
 
                     // Build topic → handler map and compose middleware per topic

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -296,6 +296,18 @@ export interface EventBusOptions {
     adapter: EventAdapter;
     /** Event routes to register */
     routes?: EventRoute[];
+    /**
+     * Event service descriptors this bus publishes to (publish-only, no subscription).
+     *
+     * A process that only PUBLISHES events has no `routes`, so its publish-topic
+     * lookup would be empty and `publish()` would fall back to the message
+     * `typeName` — silently emitting to the wrong topic whenever the event
+     * declares a custom `(connectum.events.v1.event).topic`. List the event
+     * service descriptors here to populate the publish-topic lookup from their
+     * proto options, so the declared topic is used end-to-end without
+     * hand-maintaining raw topic strings. Subscribers still register via `routes`.
+     */
+    publishes?: DescService[];
     /** Consumer group name */
     group?: string;
     /** Middleware configuration */

--- a/packages/events/tests/unit/topic-auto-resolve.test.ts
+++ b/packages/events/tests/unit/topic-auto-resolve.test.ts
@@ -340,4 +340,47 @@ describe("EventBus topic auto-resolve", () => {
         assert.equal(published[1]!.eventType, "meshai.task.created");
         await bus.stop();
     });
+
+    it("publish with `publishes` (publisher-only, no routes) resolves the proto annotation topic", async () => {
+        const { adapter, published } = createTrackingAdapter();
+
+        // Pure publisher: a custom-topic event service, but NO routes (not a subscriber).
+        const method = fakeDescMethodWithTopic(
+            "taskCreated",
+            EventOptionsSchema.typeName,
+            "meshai.task.created",
+            EventOptionsSchema,
+        );
+        const service = fakeDescService("meshai.v1.TaskEventService", [method]);
+
+        const bus = createEventBus({
+            adapter,
+            publishes: [service],
+        });
+
+        await bus.start();
+        await bus.publish(EventOptionsSchema, {} as any);
+
+        assert.equal(published.length, 1);
+        assert.equal(
+            published[0]!.eventType,
+            "meshai.task.created",
+            "publisher-only bus should resolve the declared topic from `publishes`, not fall back to typeName",
+        );
+
+        await bus.stop();
+    });
+
+    it("conflicting topics for the same message across `publishes` throw on start", async () => {
+        const { adapter } = createTrackingAdapter();
+
+        const m1 = fakeDescMethodWithTopic("a", EventOptionsSchema.typeName, "topic.a", EventOptionsSchema);
+        const m2 = fakeDescMethodWithTopic("b", EventOptionsSchema.typeName, "topic.b", EventOptionsSchema);
+        const s1 = fakeDescService("svc.v1.A", [m1]);
+        const s2 = fakeDescService("svc.v1.B", [m2]);
+
+        const bus = createEventBus({ adapter, publishes: [s1, s2] });
+
+        await assert.rejects(() => bus.start(), /Ambiguous publish topic/);
+    });
 });


### PR DESCRIPTION
## Summary

Fixes a silent-wrong-topic footgun in the EventBus for publisher-only processes
(the canonical split-microservices shape).

### The bug

`publish()` resolves the topic from a lookup built **only from the local
process's subscriber `routes`**. A process that only *publishes* an event (does
not subscribe) has no routes → the lookup is empty → `publish()` falls back to
the message `typeName`. When the subscriber declared a custom
`(connectum.events.v1.event).topic`, the publisher emits to `typeName` instead —
**wrong topic, no error, event silently dropped.**

### The fix

New additive option `EventBusOptions.publishes: DescService[]`. Its methods' proto
`(event).topic` options populate the publish-topic lookup, so a pure publisher
resolves the declared topic end-to-end without hand-maintaining raw topic
strings. Subscribers still register via `routes`.

```typescript
const bus = createEventBus({ adapter, publishes: [OrderEventService] });
await bus.publish(OrderPlacedSchema, order); // → declared topic, not "order.v1.OrderPlaced"
```

### Validation (local)

- events unit **104/104** (incl. 2 new regression tests: publisher-only resolution + ambiguity guard)
- events integration **37/37**
- typecheck clean, lint clean, workspace build **18/18**

### Release impact

Additive option → `@connectum/events` **minor** changeset. Because `@connectum/*`
is a fixed-version group, the next release becomes **1.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `publishes` option to EventBusOptions for publisher-only processes to configure event publishing with proper topic resolution from proto declarations.

* **Bug Fixes**
  * Fixed topic resolution for publisher-only processes that publish events without subscriber routes, preventing incorrect message type name fallback.

* **Documentation**
  * Updated EventBus API documentation with the new `publishes` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->