### PR TITLE
fix(changeset): stop peer-dependents forcing a major bump in the fixed group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,5 +11,8 @@
   "privatePackages": {
     "version": true,
     "tag": false
+  },
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }


### PR DESCRIPTION
## Summary

The release version computation escalated **any** patch/minor change to a **major** (2.0.0) bump of the whole fixed group. Surfaced by the first post-1.0 minor changeset (`@connectum/events` — PR #166): `changeset status` reported 2.0.0 instead of 1.1.0.

## Root cause

Six packages declare an internal `@connectum/*` as a **peerDependency**:

- `healthcheck`, `reflection` → peer on `@connectum/core`
- `events-amqp`, `events-kafka`, `events-nats`, `events-redis` → peer on `@connectum/events`

Changesets' **default** bumps a peer-dependent to **major** on *any* bump of its peer dependency (peer changes are treated as breaking). In the `fixed: [["@connectum/*"]]` group, every changeset bumps **all** packages (including `core`/`events`), so those peer-dependents went major — and the fixed group escalated the entire group to **2.0.0**, even for a patch.

This is why patch worked (no peer escalation observed in isolation) but minor/major surfaced 2.0.0: the bug bites whenever the peer dependency (`core`/`events`) is in the bump set, which the fixed group guarantees.

## Fix

Set `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true`. A peer-dependent now majors **only when the peer range is actually violated**. The internal peers use `workspace:^` (`^1.0.0`), which a `1.1.0` minor does not violate, so the group bumps correctly.

## Verification

`changeset status` on this branch:

```
Packages to be bumped at minor:
- @connectum/core 1.1.0
- @connectum/events 1.1.0
- @connectum/healthcheck 1.1.0
- ... (all 15 → 1.1.0, no major)
```

Isolated empirically: a clean 2-package fixed group bumps minor correctly; the regression reproduced only with the real peer-dependency graph, and disappears with this option.

## Impact

Config-only (no package code/version change → no changeset). Once merged, the auto-managed Version Packages PR regenerates from **2.0.0 → 1.1.0** (consuming the pending `cli` patch + `events` minor changesets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3
