### PR TITLE
feat(auth): RS256 + JWKS test helpers in @connectum/auth/testing

### DIFF
--- a/.changeset/auth-rs256-jwks-test-helper.md
+++ b/.changeset/auth-rs256-jwks-test-helper.md
@@ -1,0 +1,5 @@
+---
+"@connectum/auth": minor
+---
+
+Add RS256 + JWKS test helpers to `@connectum/auth/testing`. The existing `createTestJwt` is HS256-only, but the production-realistic path with an external IdP is RS256 validated through a JWKS endpoint (`createJwtAuthInterceptor({ jwksUri })`). The new `generateRsaTestKeypair()`, `startTestJwksServer()`, and `createTestJwtRS256()` let you test that path without hand-rolling a keypair + JWKS server + minter — the minted token is verified through the same `createRemoteJWKSet` branch production uses.

--- a/packages/auth/src/testing/index.ts
+++ b/packages/auth/src/testing/index.ts
@@ -8,4 +8,12 @@
 
 export { createMockAuthContext } from "./mock-context.ts";
 export { createTestJwt, TEST_JWT_SECRET } from "./test-jwt.ts";
+export {
+    createTestJwtRS256,
+    generateRsaTestKeypair,
+    type RsaTestKeypair,
+    startTestJwksServer,
+    TEST_JWT_KID,
+    type TestJwksServer,
+} from "./test-jwt-rs256.ts";
 export { withAuthContext } from "./with-context.ts";

--- a/packages/auth/src/testing/test-jwt-rs256.ts
+++ b/packages/auth/src/testing/test-jwt-rs256.ts
@@ -1,0 +1,156 @@
+/**
+ * RS256 + JWKS test utilities.
+ *
+ * The production-realistic auth path with an external IdP is RS256 signed
+ * tokens validated through a JWKS endpoint — i.e. `createJwtAuthInterceptor({
+ * jwksUri })`, the `jose.createRemoteJWKSet` branch. Testing that path needs an
+ * RSA keypair, a JWKS endpoint to publish the public key, and a token signed by
+ * the private key with a matching `kid`. These helpers provide exactly that, so
+ * consumers do not hand-roll a keypair + JWKS server + minter in every project.
+ *
+ * NOT for production use — the keys are generated per call for tests only.
+ *
+ * @example Round-trip against the production `jwksUri` branch
+ * ```typescript
+ * import {
+ *   generateRsaTestKeypair,
+ *   startTestJwksServer,
+ *   createTestJwtRS256,
+ * } from '@connectum/auth/testing';
+ * import { createJwtAuthInterceptor } from '@connectum/auth';
+ *
+ * const keypair = await generateRsaTestKeypair();
+ * const jwks = await startTestJwksServer(keypair.publicJwk);
+ *
+ * const auth = createJwtAuthInterceptor({
+ *   jwksUri: jwks.url,
+ *   issuer: 'https://issuer.example',
+ *   audience: 'my-api',
+ *   algorithms: ['RS256'],
+ * });
+ *
+ * const token = await createTestJwtRS256(
+ *   keypair.privateKey,
+ *   { sub: 'user-123', roles: ['admin'] },
+ *   { kid: keypair.kid, issuer: 'https://issuer.example', audience: 'my-api' },
+ * );
+ *
+ * // ...exercise the interceptor with `Authorization: Bearer ${token}`...
+ * await jwks.close();
+ * ```
+ *
+ * @module testing/test-jwt-rs256
+ */
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import * as jose from "jose";
+
+/** Default `kid` shared by the generated keypair and the minted tokens. */
+export const TEST_JWT_KID = "connectum-test-key";
+
+/** A generated RSA test keypair plus the public JWK to publish at a JWKS endpoint. */
+export interface RsaTestKeypair {
+    /** Private signing key — pass to {@link createTestJwtRS256}. */
+    readonly privateKey: CryptoKey;
+    /** Public verification key. */
+    readonly publicKey: CryptoKey;
+    /** Public JWK (carries `kid`, `alg: "RS256"`, `use: "sig"`) — serve at the JWKS endpoint. */
+    readonly publicJwk: jose.JWK;
+    /** Key id shared by `publicJwk` and the token header (load-bearing for JWKS key selection). */
+    readonly kid: string;
+}
+
+/**
+ * Generate an RSA (RS256) test keypair and the matching public JWK.
+ *
+ * The returned `publicJwk` carries the `kid`/`alg`/`use` a JWKS endpoint
+ * publishes, and the same `kid` must be set on every token minted for it
+ * (otherwise `createRemoteJWKSet` fails key selection).
+ *
+ * @param kid - Key id to stamp on the JWK; defaults to {@link TEST_JWT_KID}.
+ */
+export async function generateRsaTestKeypair(kid: string = TEST_JWT_KID): Promise<RsaTestKeypair> {
+    const { privateKey, publicKey } = await jose.generateKeyPair("RS256", { extractable: true });
+    const publicJwk: jose.JWK = { ...(await jose.exportJWK(publicKey)), kid, alg: "RS256", use: "sig" };
+    return { privateKey, publicKey, publicJwk, kid };
+}
+
+/** A running in-process JWKS server. */
+export interface TestJwksServer {
+    /** The JWKS URL — pass as `jwksUri` to `createJwtAuthInterceptor`. */
+    readonly url: string;
+    /** Origin (no path), e.g. `http://127.0.0.1:<port>`. */
+    readonly origin: string;
+    /** Stop the server. Call after the test (e.g. in `after`). */
+    close(): Promise<void>;
+}
+
+/**
+ * Start an ephemeral in-process JWKS server publishing the given public JWK(s)
+ * at `/.well-known/jwks.json` on a random loopback port.
+ *
+ * @param jwks - One public JWK or an array (from {@link generateRsaTestKeypair}).
+ */
+export async function startTestJwksServer(jwks: jose.JWK | readonly jose.JWK[]): Promise<TestJwksServer> {
+    const keys = Array.isArray(jwks) ? jwks : [jwks as jose.JWK];
+    const body = JSON.stringify({ keys });
+
+    const server = createServer((req, res) => {
+        if (req.url === "/.well-known/jwks.json") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(body);
+            return;
+        }
+        res.writeHead(404).end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    const origin = `http://127.0.0.1:${port}`;
+
+    return {
+        url: `${origin}/.well-known/jwks.json`,
+        origin,
+        close: () =>
+            new Promise<void>((resolve, reject) => {
+                server.close((err) => (err ? reject(err) : resolve()));
+            }),
+    };
+}
+
+/**
+ * Mint an RS256 test JWT signed by the private key from
+ * {@link generateRsaTestKeypair}, with a `kid` header matching the published JWK.
+ *
+ * NOT for production use.
+ *
+ * @param privateKey - Private key from {@link generateRsaTestKeypair}.
+ * @param payload - JWT claims (e.g. `sub`, `roles`, `scope`).
+ * @param options - `kid` (required, must match the published JWK) plus optional
+ *   `issuer`/`audience`/`expiresIn` (default `"1h"`).
+ */
+export async function createTestJwtRS256(
+    privateKey: CryptoKey,
+    payload: Record<string, unknown>,
+    options: {
+        kid: string;
+        issuer?: string;
+        audience?: string;
+        expiresIn?: string;
+    },
+): Promise<string> {
+    let builder = new jose.SignJWT(payload)
+        .setProtectedHeader({ alg: "RS256", kid: options.kid })
+        .setIssuedAt()
+        .setExpirationTime(options.expiresIn ?? "1h");
+
+    if (options.issuer) {
+        builder = builder.setIssuer(options.issuer);
+    }
+    if (options.audience) {
+        builder = builder.setAudience(options.audience);
+    }
+
+    return await builder.sign(privateKey);
+}

--- a/packages/auth/tests/unit/test-jwt-rs256.test.ts
+++ b/packages/auth/tests/unit/test-jwt-rs256.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the RS256 + JWKS test helpers.
+ *
+ * Drives the helpers through the PRODUCTION `jwksUri` branch of
+ * `createJwtAuthInterceptor` (`createRemoteJWKSet`) — the same path an external
+ * IdP (Ory Oathkeeper, Auth0, …) exercises — so the helpers are proven against
+ * real verification, not a stub.
+ */
+
+import assert from "node:assert";
+import { after, before, describe, it } from "node:test";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { createMockRequest } from "@connectum/testing";
+import { getAuthContext } from "../../src/context.ts";
+import { createJwtAuthInterceptor } from "../../src/jwt-auth-interceptor.ts";
+import { createTestJwtRS256, generateRsaTestKeypair, type RsaTestKeypair, startTestJwksServer, TEST_JWT_KID, type TestJwksServer } from "../../src/testing/test-jwt-rs256.ts";
+
+const REQ = { service: "test.Service", method: "Method" } as const;
+const ISSUER = "https://issuer.example";
+const AUDIENCE = "test-api";
+
+describe("testing/test-jwt-rs256", () => {
+    let keypair: RsaTestKeypair;
+    let jwks: TestJwksServer;
+
+    before(async () => {
+        keypair = await generateRsaTestKeypair();
+        jwks = await startTestJwksServer(keypair.publicJwk);
+    });
+
+    after(async () => {
+        await jwks.close();
+    });
+
+    const jwtInterceptor = () =>
+        createJwtAuthInterceptor({
+            jwksUri: jwks.url,
+            issuer: ISSUER,
+            audience: AUDIENCE,
+            algorithms: ["RS256"],
+            claimsMapping: { roles: "roles" },
+        });
+
+    it("generateRsaTestKeypair publishes a JWK with kid/alg/use", () => {
+        assert.equal(keypair.kid, TEST_JWT_KID);
+        assert.equal(keypair.publicJwk.kid, TEST_JWT_KID);
+        assert.equal(keypair.publicJwk.alg, "RS256");
+        assert.equal(keypair.publicJwk.use, "sig");
+    });
+
+    it("startTestJwksServer serves the public key at /.well-known/jwks.json", async () => {
+        const res = await fetch(jwks.url);
+        assert.equal(res.status, 200);
+        const body = (await res.json()) as { keys: Array<{ kid?: string }> };
+        assert.equal(body.keys.length, 1);
+        assert.equal(body.keys[0]?.kid, TEST_JWT_KID);
+    });
+
+    it("a minted RS256 token validates through createJwtAuthInterceptor({ jwksUri }) and populates the AuthContext", async () => {
+        let ctx: ReturnType<typeof getAuthContext>;
+        const next = async () => {
+            ctx = getAuthContext();
+            return { message: {} };
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: minimal next stub for the interceptor under test
+        const handler = jwtInterceptor()(next as any);
+
+        const token = await createTestJwtRS256(keypair.privateKey, { sub: "user-123", roles: ["admin"] }, { kid: keypair.kid, issuer: ISSUER, audience: AUDIENCE });
+        const req = createMockRequest(REQ);
+        req.header.set("authorization", `Bearer ${token}`);
+        // biome-ignore lint/suspicious/noExplicitAny: mock request
+        await handler(req as any);
+
+        // biome-ignore lint/style/noNonNullAssertion: set by the handler above
+        assert.equal(ctx!.subject, "user-123");
+        // biome-ignore lint/style/noNonNullAssertion: set by the handler above
+        assert.deepEqual(ctx!.roles, ["admin"]);
+    });
+
+    it("rejects a token with the wrong issuer", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: minimal next stub for the interceptor under test
+        const handler = jwtInterceptor()((async () => ({ message: {} })) as any);
+        const token = await createTestJwtRS256(keypair.privateKey, { sub: "u" }, { kid: keypair.kid, issuer: "https://evil.example", audience: AUDIENCE });
+        const req = createMockRequest(REQ);
+        req.header.set("authorization", `Bearer ${token}`);
+        // biome-ignore lint/suspicious/noExplicitAny: mock request
+        await assert.rejects(handler(req as any), (err: unknown) => err instanceof ConnectError && err.code === Code.Unauthenticated);
+    });
+
+    it("rejects a token signed by an unpublished key (kid mismatch / bad signature)", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: minimal next stub for the interceptor under test
+        const handler = jwtInterceptor()((async () => ({ message: {} })) as any);
+        const other = await generateRsaTestKeypair("other-key");
+        const token = await createTestJwtRS256(other.privateKey, { sub: "u" }, { kid: keypair.kid, issuer: ISSUER, audience: AUDIENCE });
+        const req = createMockRequest(REQ);
+        req.header.set("authorization", `Bearer ${token}`);
+        // biome-ignore lint/suspicious/noExplicitAny: mock request
+        await assert.rejects(handler(req as any), (err: unknown) => err instanceof ConnectError && err.code === Code.Unauthenticated);
+    });
+});


### PR DESCRIPTION
Closes #172.

## Problem

`@connectum/auth/testing` only offers HS256 (`createTestJwt` + `TEST_JWT_SECRET`). The production-realistic path with an external IdP is **RS256 validated through a JWKS endpoint** — `createJwtAuthInterceptor({ jwksUri })`, the `jose.createRemoteJWKSet` branch. Testing it forced every project to hand-roll an RSA keypair + a JWKS HTTP server + a token minter with a matching `kid` (we did exactly that in the `car-sharing` Phase 4 Ory example).

## Change

Add three helpers to `@connectum/auth/testing`:

- `generateRsaTestKeypair(kid?)` → `{ privateKey, publicKey, publicJwk (kid/alg/use), kid }`
- `startTestJwksServer(jwk | jwk[])` → `{ url, origin, close() }` — an ephemeral in-process `/.well-known/jwks.json`
- `createTestJwtRS256(privateKey, payload, { kid, issuer?, audience?, expiresIn? })`

The minted token is verified through the **same `createRemoteJWKSet` branch production uses**, so tests exercise the real validation path, not a stub.

## Validation

- New unit test `tests/unit/test-jwt-rs256.test.ts` drives a full round-trip through `createJwtAuthInterceptor({ jwksUri })` (accepts a valid token + populates the AuthContext; rejects wrong-issuer and unpublished-key tokens) — **5/5**.
- Full auth unit suite **175/175**; build + typecheck + biome clean.
- Additive only; `jose` was already a dependency. Changeset: `@connectum/auth` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3