### PR TITLE
feat(events): createBroadcastSubscribers fan-out helper + clearer duplicate-topic error

### DIFF
--- a/.changeset/events-broadcast-helper.md
+++ b/.changeset/events-broadcast-helper.md
@@ -1,0 +1,7 @@
+---
+"@connectum/events": minor
+---
+
+Add `createBroadcastSubscribers` for first-class fan-out wiring, and make the duplicate-topic error actionable.
+
+Delivering one event to N independent reactors (each its own consumer group) requires one EventBus per reactor — the per-bus duplicate-topic guard forbids two routes on the same topic on one bus, and a shared group load-balances on a real broker instead of broadcasting. `createBroadcastSubscribers({ adapter, reactors })` builds that one-bus-per-reactor wiring (accepting a shared adapter or a per-bus factory) and rejects duplicate groups. The `Duplicate event topic` error now explains the fix (separate buses + distinct groups for independent reactors) instead of only suggesting a proto-option change.

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -155,7 +155,11 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
 
                     for (const entry of router.entries) {
                         if (topicHandlerMap.has(entry.topic)) {
-                            throw new Error(`Duplicate event topic "${entry.topic}". Use (connectum.events.v1.event).topic option to disambiguate.`);
+                            throw new Error(
+                                `Duplicate event topic "${entry.topic}" on one EventBus — a topic can have at most one handler per bus. ` +
+                                    `For INDEPENDENT broadcast reactors on the same topic, give each its OWN EventBus with a distinct consumer group (see createBroadcastSubscribers). ` +
+                                    `To route DISTINCT events, give them distinct (connectum.events.v1.event).topic options.`,
+                            );
                         }
                         // Per-handler middleware overrides global when present
                         const effectiveMiddleware = entry.middleware !== undefined ? entry.middleware : middlewares;

--- a/packages/events/src/broadcast.ts
+++ b/packages/events/src/broadcast.ts
@@ -1,0 +1,98 @@
+/**
+ * Broadcast / fan-out helper.
+ *
+ * To deliver ONE published event to N INDEPENDENT reactors (each reacting on its
+ * own), each reactor must live on its OWN EventBus with its OWN consumer group:
+ *
+ *  - the per-bus duplicate-topic guard rejects two routes resolving to the same
+ *    topic on one bus, and
+ *  - on a real broker, a SHARED group load-balances (one reactor "steals" each
+ *    event) while DISTINCT groups give each reactor its own durable consumer.
+ *
+ * {@link createBroadcastSubscribers} builds that one-bus-per-reactor wiring from
+ * a list of reactors, so callers do not hand-roll N `createEventBus` calls.
+ *
+ * @module broadcast
+ */
+
+import type { EventBusLike } from "@connectum/core";
+import { createEventBus } from "./EventBus.ts";
+import type { EventAdapter, EventBus, EventRoute, MiddlewareConfig } from "./types.ts";
+
+/** One independent broadcast reactor: its consumer group + routes. */
+export interface BroadcastReactor {
+    /** Consumer group — MUST be DISTINCT per reactor for true fan-out (a shared group load-balances). */
+    readonly group: string;
+    /** The event routes (handlers) this reactor subscribes with. */
+    readonly routes: EventRoute[];
+    /** Optional per-reactor middleware (retry/DLQ/custom). */
+    readonly middleware?: MiddlewareConfig;
+}
+
+/** Options for {@link createBroadcastSubscribers}. */
+export interface BroadcastSubscribersOptions {
+    /**
+     * The broker adapter. Pass ONE shared instance (fine for `MemoryAdapter` in
+     * tests, where all buses share the in-memory registry) OR a factory invoked
+     * once per reactor (use this for real brokers so each reactor bus gets its
+     * own connection / durable consumer).
+     */
+    readonly adapter: EventAdapter | (() => EventAdapter);
+    /** The independent reactors — each becomes its own EventBus with its own group. */
+    readonly reactors: BroadcastReactor[];
+    /** Shared per-bus handler timeout (ms). */
+    readonly handlerTimeout?: number;
+    /** Shared per-bus drain timeout (ms). */
+    readonly drainTimeout?: number;
+    /** Shared abort signal for graceful shutdown. */
+    readonly signal?: AbortSignal;
+}
+
+/**
+ * Build one `EventBus` per reactor (each with its own consumer group) so a
+ * single published event fans out to ALL reactors independently.
+ *
+ * The returned buses are NOT started — start them yourself (e.g.
+ * `await Promise.all(buses.map((b) => b.start()))`) and stop them on shutdown.
+ *
+ * Throws if two reactors share a consumer group (that would load-balance / steal
+ * instead of fanning out).
+ *
+ * @example
+ * ```typescript
+ * const buses = createBroadcastSubscribers({
+ *   adapter: () => new NatsAdapter({ servers, stream: 'orders' }),
+ *   reactors: [
+ *     { group: 'pricing', routes: [pricingRoutes] },
+ *     { group: 'audit',   routes: [auditRoutes] },
+ *     { group: 'notify',  routes: [notifyRoutes] },
+ *   ],
+ * });
+ * await Promise.all(buses.map((bus) => bus.start()));
+ * ```
+ */
+export function createBroadcastSubscribers(options: BroadcastSubscribersOptions): Array<EventBus & EventBusLike> {
+    const seen = new Set<string>();
+    for (const reactor of options.reactors) {
+        if (seen.has(reactor.group)) {
+            throw new Error(
+                `createBroadcastSubscribers: duplicate consumer group "${reactor.group}". Each broadcast reactor needs a DISTINCT group for true fan-out — a shared group load-balances (one reactor steals each event) instead of broadcasting.`,
+            );
+        }
+        seen.add(reactor.group);
+    }
+
+    return options.reactors.map((reactor) =>
+        createEventBus({
+            adapter: typeof options.adapter === "function" ? options.adapter() : options.adapter,
+            routes: reactor.routes,
+            group: reactor.group,
+            // Spread optionals only when set — the package uses
+            // `exactOptionalPropertyTypes`, so an explicit `undefined` is rejected.
+            ...(reactor.middleware !== undefined ? { middleware: reactor.middleware } : {}),
+            ...(options.handlerTimeout !== undefined ? { handlerTimeout: options.handlerTimeout } : {}),
+            ...(options.drainTimeout !== undefined ? { drainTimeout: options.drainTimeout } : {}),
+            ...(options.signal !== undefined ? { signal: options.signal } : {}),
+        }),
+    );
+}

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -13,6 +13,8 @@
  * @mergeModuleWith <project>
  */
 
+// Broadcast / fan-out
+export { type BroadcastReactor, type BroadcastSubscribersOptions, createBroadcastSubscribers } from "./broadcast.ts";
 // EventBus factory
 export { createEventBus, deriveServiceName } from "./EventBus.ts";
 

--- a/packages/events/tests/unit/broadcast.test.ts
+++ b/packages/events/tests/unit/broadcast.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the broadcast / fan-out helper (`createBroadcastSubscribers`).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { EventOptionsSchema } from "../../gen/connectum/events/v1/options_pb.js";
+import { createBroadcastSubscribers } from "../../src/broadcast.ts";
+import { MemoryAdapter } from "../../src/MemoryAdapter.ts";
+import type { EventRoute } from "../../src/types.ts";
+
+// Minimal fake DescMethod/DescService (mirrors per-handler-middleware.test.ts):
+// a real schema (EventOptionsSchema) is used as the event message so the bus can
+// decode an empty payload; the topic falls back to its typeName.
+// biome-ignore lint/suspicious/noExplicitAny: minimal proto desc fake for tests
+function fakeDescMethod(localName: string, typeName: string, realInput: any) {
+    const input = Object.create(realInput, { typeName: { value: typeName, writable: false, enumerable: true } });
+    return { localName, input, proto: { options: undefined } };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal proto desc fake for tests
+function fakeDescService(typeName: string, methods: any[]) {
+    return { typeName, methods };
+}
+
+describe("createBroadcastSubscribers", () => {
+    it("throws when two reactors share a consumer group", () => {
+        assert.throws(
+            () =>
+                createBroadcastSubscribers({
+                    adapter: MemoryAdapter(),
+                    reactors: [
+                        { group: "shared", routes: [] },
+                        { group: "shared", routes: [] },
+                    ],
+                }),
+            /distinct group/i,
+        );
+    });
+
+    it("builds one independent, startable bus per reactor", () => {
+        const buses = createBroadcastSubscribers({
+            adapter: MemoryAdapter(),
+            reactors: [
+                { group: "a", routes: [] },
+                { group: "b", routes: [] },
+                { group: "c", routes: [] },
+            ],
+        });
+        assert.equal(buses.length, 3);
+        for (const bus of buses) {
+            assert.equal(typeof bus.start, "function");
+            assert.equal(typeof bus.stop, "function");
+        }
+    });
+
+    it("invokes the adapter factory once per reactor (own connection per bus)", () => {
+        let built = 0;
+        createBroadcastSubscribers({
+            adapter: () => {
+                built++;
+                return MemoryAdapter();
+            },
+            reactors: [
+                { group: "a", routes: [] },
+                { group: "b", routes: [] },
+            ],
+        });
+        assert.equal(built, 2);
+    });
+
+    it("fans one published event out to EVERY reactor (shared adapter)", async () => {
+        const topic = EventOptionsSchema.typeName;
+        const method = fakeDescMethod("onEvent", topic, EventOptionsSchema);
+        const service = fakeDescService("test.v1.BroadcastService", [method]);
+
+        const fired: string[] = [];
+        const reactorRoute =
+            (name: string): EventRoute =>
+            (router) => {
+                router.service(
+                    // biome-ignore lint/suspicious/noExplicitAny: fake service desc
+                    service as any,
+                    {
+                        onEvent: async () => {
+                            fired.push(name);
+                        },
+                        // biome-ignore lint/suspicious/noExplicitAny: fake handler map
+                    } as any,
+                );
+            };
+
+        const adapter = MemoryAdapter();
+        const buses = createBroadcastSubscribers({
+            adapter,
+            reactors: [
+                { group: "pricing", routes: [reactorRoute("pricing")] },
+                { group: "audit", routes: [reactorRoute("audit")] },
+                { group: "notify", routes: [reactorRoute("notify")] },
+            ],
+        });
+
+        try {
+            await Promise.all(buses.map((bus) => bus.start()));
+            await adapter.publish(topic, new Uint8Array());
+            assert.deepEqual([...fired].sort(), ["audit", "notify", "pricing"]);
+        } finally {
+            await Promise.all(buses.map((bus) => bus.stop()));
+        }
+    });
+});


### PR DESCRIPTION
Closes #174.

## Problem

Broadcasting one event to N **independent** reactors (each its own consumer group) requires N hand-wired `createEventBus` instances — the per-bus duplicate-topic guard forbids two routes on the same topic on one bus, and a shared group load-balances (steals) on a real broker. There was no fan-out helper, and the `Duplicate event topic` error only suggested changing the proto option (the wrong fix for the broadcast case).

## Change

- **`createBroadcastSubscribers({ adapter, reactors })`** — builds one `EventBus` per reactor (each with its own consumer group). `adapter` may be a shared instance (fine for `MemoryAdapter` tests) or a per-bus factory (real brokers need their own connection/durable consumer). Throws if two reactors share a group.
- The **`Duplicate event topic`** error now explains the fix: separate buses + distinct groups for independent reactors; distinct proto topics for distinct events.

## Validation

- New `tests/unit/broadcast.test.ts` — **4/4**: duplicate-group guard, one-bus-per-reactor, per-bus adapter factory, and true fan-out (one publish → all 3 reactors over a shared `MemoryAdapter`).
- Full events unit suite **108/108**; build + typecheck + biome clean. Additive; changeset `@connectum/events` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `createBroadcastSubscribers` helper to simplify fan-out event handling with one independent event bus per reactor, ensuring proper isolation between consumer groups.

* **Improvements**
  * Enhanced error message for duplicate event topics to provide clearer, more actionable guidance on proper bus and consumer group configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->