### PR TITLE
feat(events): opt-in strictTopics — reject unresolved publish topics

### DIFF
--- a/.changeset/events-strict-topics.md
+++ b/.changeset/events-strict-topics.md
@@ -1,0 +1,5 @@
+---
+"@connectum/events": minor
+---
+
+Add an opt-in `EventBusOptions.strictTopics`. By default, when `publish()` finds no explicit `publishOptions.topic` and the event type is covered by neither `routes` nor `publishes`, it silently falls back to the raw message `typeName` — a silent misconfiguration that can emit to a topic no subscriber expects. With `strictTopics: true`, that unresolved-topic case throws at the call site instead. Default stays `false` (backward-compatible).

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -72,6 +72,7 @@ export function deriveServiceName(serviceNames: readonly string[]): string | und
 export function createEventBus(options: EventBusOptions): EventBus & EventBusLike {
     const { adapter, routes = [], group, middleware: mwConfig } = options;
     const handlerTimeout = options.handlerTimeout ?? 30_000;
+    const strictTopics = options.strictTopics ?? false;
     const subscriptions: EventSubscription[] = [];
     let started = false;
     let starting = false;
@@ -326,7 +327,14 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
             // Create message instance and serialize
             const message = create(schema, data);
             const payload = toBinary(schema, message);
-            const eventType = publishOptions?.topic ?? publishTopicMap.get(schema.typeName) ?? schema.typeName;
+            const declaredTopic = publishOptions?.topic ?? publishTopicMap.get(schema.typeName);
+            if (strictTopics && declaredTopic === undefined) {
+                throw new Error(
+                    `Cannot resolve a topic for "${schema.typeName}" (strictTopics is enabled): it is covered by neither a subscriber route nor the publishes option, and no publishOptions.topic was given. ` +
+                        `Register the event service in routes/publishes so its (connectum.events.v1.event).topic is used, or pass publishOptions.topic explicitly.`,
+                );
+            }
+            const eventType = declaredTopic ?? schema.typeName;
 
             await adapter.publish(eventType, payload, publishOptions);
         },

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -335,6 +335,20 @@ export interface EventBusOptions {
      * Default: 30000 (30 seconds). Set to 0 for immediate abort.
      */
     drainTimeout?: number;
+    /**
+     * Reject a `publish()` whose topic cannot be resolved instead of silently
+     * falling back to the message `typeName`.
+     *
+     * By default, when no explicit `publishOptions.topic` is given and the event
+     * type is covered by neither `routes` nor `publishes`, `publish()` emits to
+     * the raw `schema.typeName` — a silent misconfiguration (the event may never
+     * reach subscribers expecting the proto-declared `(event).topic`). With
+     * `strictTopics: true`, that case throws so the misconfiguration surfaces at
+     * the call site.
+     *
+     * Default: `false` (backward-compatible silent fallback).
+     */
+    strictTopics?: boolean;
 }
 
 /**

--- a/packages/events/tests/unit/strict-topics.test.ts
+++ b/packages/events/tests/unit/strict-topics.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for opt-in strict publish-topic resolution (`strictTopics`).
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { create } from "@bufbuild/protobuf";
+import { EventOptionsSchema } from "../../gen/connectum/events/v1/options_pb.js";
+import { createEventBus } from "../../src/EventBus.ts";
+import { MemoryAdapter } from "../../src/MemoryAdapter.ts";
+
+/** A minimal valid EventOptions message instance for publish(). */
+const eventMsg = () => create(EventOptionsSchema, {});
+
+describe("strictTopics", () => {
+    let bus: ReturnType<typeof createEventBus> | null = null;
+
+    afterEach(async () => {
+        if (bus) {
+            await bus.stop();
+            bus = null;
+        }
+    });
+
+    it("rejects a publish whose topic cannot be resolved when strictTopics is true", async () => {
+        // No routes and no publishes cover EventOptions, so the topic would
+        // otherwise silently fall back to the typeName.
+        bus = createEventBus({ adapter: MemoryAdapter(), strictTopics: true });
+        await bus.start();
+        await assert.rejects(bus.publish(EventOptionsSchema, eventMsg()), /strictTopics/);
+    });
+
+    it("allows an explicit publishOptions.topic under strictTopics", async () => {
+        bus = createEventBus({ adapter: MemoryAdapter(), strictTopics: true });
+        await bus.start();
+        await assert.doesNotReject(bus.publish(EventOptionsSchema, eventMsg(), { topic: "explicit.topic" }));
+    });
+
+    it("silently falls back to the typeName by default (strictTopics off)", async () => {
+        bus = createEventBus({ adapter: MemoryAdapter() });
+        await bus.start();
+        await assert.doesNotReject(bus.publish(EventOptionsSchema, eventMsg()));
+    });
+});


### PR DESCRIPTION
Closes #173.

## Problem

`EventBus.publish()` resolves the topic as `publishOptions?.topic ?? publishTopicMap.get(typeName) ?? typeName`. When neither `routes` nor `publishes` covers the event type and no explicit topic is given, it **silently** publishes to the raw `typeName` — a misconfiguration that emits to a topic no subscriber expects, invisible at the call site (only the missing delivery downstream reveals it).

## Change

Add an opt-in `EventBusOptions.strictTopics`. With `strictTopics: true`, an unresolved topic (no `publishOptions.topic`, not covered by `routes`/`publishes`) **throws** at the `publish()` call site instead of falling back. Default stays `false` (backward-compatible). Aligns with "no hidden behavioral logic" — the silent fallback becomes opt-out.

## Validation

- New `tests/unit/strict-topics.test.ts` — **3/3**: throws on an unresolved topic under strict mode; allows an explicit `publishOptions.topic`; default still falls back silently.
- Full events unit suite **107/107**; build + typecheck + biome clean. Changeset `@connectum/events` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3