### PR TITLE
feat(core): createCatalogClient — catalog-typed client usable outside a Server

### DIFF
--- a/.changeset/core-catalog-client.md
+++ b/.changeset/core-catalog-client.md
@@ -1,0 +1,9 @@
+---
+"@connectum/core": minor
+---
+
+Add `createCatalogClient({ catalog, resolver })` — a standalone, catalog-typed client usable OUTSIDE a `Server`. Out-of-process callers (a Temporal worker, a scheduler, a CLI) now get the same typed, resolver-routed `call` (unary) and `stream` (server/client/bidi) ergonomics as the in-handler `ctx.call`/`ctx.stream`, keyed off the generated `ConnectumCallMap`/`ConnectumStreamMap`, without constructing a `Server`.
+
+It resolves every target through the supplied `RemoteResolver` (`singleTransportResolver`/`mapResolver`/`dnsResolver`/`perServiceEnvResolver`) and dispatches over the returned `Transport`, caching the transport per `(typeName, endpoint)`. Because there is no in-process/local path, a service the resolver cannot resolve fails with `Code.Unavailable`; the rest of the error model mirrors `ctx.call` (`Unimplemented` for an unknown service/method, `Internal` when the resolver throws). Unlike `ctx.call`, `CallOptions` are applied verbatim — there is no inbound request, so the signal/deadline are not cascaded or clamped, no inbound headers are propagated, and no `ContextValues` are forwarded.
+
+Additive only: `ctx.call`/`ctx.stream`/`createServer` behavior and public types are unchanged.

--- a/packages/core/src/catalogClient.ts
+++ b/packages/core/src/catalogClient.ts
@@ -1,0 +1,181 @@
+/**
+ * Catalog client — the catalog-typed `call`/`stream` surface usable OUTSIDE a
+ * `Server`.
+ *
+ * In-handler `ctx.call`/`ctx.stream` give catalog-typed, resolver-routed
+ * cross-service calls — but only where a {@link Context} exists, i.e. inside a
+ * Connectum service handler. An out-of-process caller (a Temporal worker, a
+ * scheduler, a CLI) has no `Server` and no `HandlerContext`, so it would
+ * otherwise hand-build `createClient(Service, transport)` per service and lose
+ * the service-catalog typing and the {@link RemoteResolver} wiring.
+ *
+ * {@link createCatalogClient} closes that gap: it produces the SAME typed `call`
+ * (unary) and `stream` (server/client/bidi) surface as the handler `ctx`, keyed
+ * off the generated {@link ConnectumCallMap}/{@link ConnectumStreamMap}, but
+ * resolves every target purely through the supplied {@link RemoteResolver}.
+ * There is no in-process/local path here (no `Server`, no mounted services), so
+ * a service the resolver cannot resolve is a clear `ConnectError`.
+ *
+ * Cascade differences vs. `ctx.call` (there is no inbound request to cascade
+ * from): `signal`/`timeoutMs`/`headers` are taken verbatim from
+ * {@link CallOptions}; `timeoutMs` is NOT clamped (nothing to clamp against),
+ * no inbound headers are propagated, and no `ContextValues` are forwarded.
+ *
+ * @module catalogClient
+ */
+
+import type { DescMessage, DescMethodStreaming, DescMethodUnary } from "@bufbuild/protobuf";
+import { Code, ConnectError, type Transport } from "@connectrpc/connect";
+import {
+    type CallFrame,
+    dispatchUnaryCall,
+    lookupCatalogMethod,
+    openBidiStream,
+    openClientStream,
+    openServerStream,
+    type ResolveStream,
+    resolveRemoteTransportOrThrow,
+} from "./catalogDispatcher.ts";
+import type { BidiStreamHandle, CallOptions, CatalogCall, CatalogStream, ClientStreamHandle } from "./context.ts";
+import type { RemoteResolver } from "./remoteResolver.ts";
+import type { ServiceCatalog } from "./serviceCatalog.ts";
+
+/**
+ * Options for {@link createCatalogClient}.
+ */
+export interface CreateCatalogClientOptions {
+    /**
+     * The service catalog (a `Record<typeName, DescService>`) that backs typed
+     * dispatch — the same object passed to `createServer({ catalog })`.
+     */
+    catalog: ServiceCatalog;
+    /**
+     * Maps a target service `typeName` to a ConnectRPC `Transport`. Required:
+     * unlike a `Server`, a catalog client has no in-process/local path, so every
+     * call is routed through the resolver. A resolver that returns `null` for a
+     * target makes that call fail with `Code.Unavailable`.
+     */
+    resolver: RemoteResolver;
+}
+
+/**
+ * A standalone, catalog-typed client. Exposes the SAME `call` (unary) and
+ * `stream` (server/client/bidi) surface as the handler {@link Context}, keyed
+ * off {@link ConnectumCallMap}/{@link ConnectumStreamMap}, without constructing
+ * a `Server`.
+ */
+export interface CatalogClient {
+    /**
+     * Invoke a unary service in the catalog over the resolver-supplied
+     * transport. With no augmentation of {@link ConnectumCallMap} this is
+     * statically uncallable — exactly as on the handler `ctx`.
+     *
+     * Errors mirror `ctx.call`: no catalog / unknown service / unknown method /
+     * wrong kind → `Code.FailedPrecondition`/`Code.Unimplemented`; resolver
+     * returns `null` → `Code.Unavailable`; resolver throws → `Code.Internal`
+     * (cause preserved).
+     */
+    call: CatalogCall;
+    /**
+     * Open a streaming call to a service in the catalog over the
+     * resolver-supplied transport. Returns the same kind-specific factory as
+     * `ctx.stream` (server-streaming → `AsyncIterable`; client-/bidi-streaming →
+     * push handles).
+     */
+    stream: CatalogStream;
+}
+
+/**
+ * Build a standalone {@link CatalogClient} from a {@link ServiceCatalog} and a
+ * {@link RemoteResolver}.
+ *
+ * @example
+ * ```ts
+ * import { createCatalogClient, mapResolver } from "@connectum/core";
+ * import { serviceCatalog } from "./gen/catalog.ts"; // @connectum/protoc-gen-catalog
+ *
+ * const client = createCatalogClient({
+ *   catalog: serviceCatalog,
+ *   resolver: mapResolver({
+ *     "fleet.v1.FleetService": createGrpcTransport({ baseUrl: process.env.FLEET_ADDR }),
+ *   }),
+ * });
+ *
+ * // Fully typed off the generated catalog — same surface as ctx.call:
+ * const trip = await client.call("trip.v1.TripService/StartTrip", { vehicleId });
+ * ```
+ */
+export function createCatalogClient(options: CreateCatalogClientOptions): CatalogClient {
+    const { catalog, resolver } = options;
+
+    // Cache the resolved transport per unique (typeName, endpoint) key, matching
+    // the Server's `_resolveRemoteTransport` so the resolver runs at most once
+    // per route (mirrors the RemoteResolver caching contract).
+    const transportCache = new Map<string, Transport>();
+
+    function resolveTransport(typeName: string, endpoint: string | undefined, caller: string): Transport {
+        const key = `${typeName} ${endpoint ?? ""}`;
+        const cached = transportCache.get(key);
+        if (cached !== undefined) return cached;
+        const transport = resolveRemoteTransportOrThrow(resolver, typeName, endpoint, caller);
+        transportCache.set(key, transport);
+        return transport;
+    }
+
+    /**
+     * Build the per-call frame from {@link CallOptions} directly. No inbound
+     * request exists out-of-process, so nothing cascades: the signal/deadline/
+     * headers are used verbatim and no `ContextValues` are forwarded.
+     */
+    function buildFrame(callOptions: CallOptions | undefined): CallFrame {
+        return {
+            signal: callOptions?.signal,
+            timeoutMs: callOptions?.timeoutMs,
+            headers: callOptions?.headers,
+            contextValues: undefined,
+        };
+    }
+
+    // `call` is async so that EVERY failure (lookup, resolution, transport)
+    // surfaces as a rejected promise — identical to the handler `ctx.call`,
+    // whose `_dispatchUnary` is itself async. Callers always `await`.
+    const call = (async (method: string, request: unknown, callOptions?: CallOptions): Promise<unknown> => {
+        const { typeName, descMethod } = lookupCatalogMethod(catalog, method, "catalogClient.call");
+        if (descMethod.methodKind !== "unary") {
+            throw new ConnectError(`catalogClient.call: "${method}" is a streaming method — use client.stream instead.`, Code.Unimplemented);
+        }
+        const transport = resolveTransport(typeName, callOptions?.endpoint, "catalogClient.call");
+        return dispatchUnaryCall(transport, descMethod as DescMethodUnary<DescMessage, DescMessage>, request, buildFrame(callOptions));
+    }) as CatalogCall;
+
+    const stream = ((method: string): unknown => makeStreamHandle(method)) as CatalogStream;
+
+    // The lazy resolution thunk for a streaming call: resolve the transport and
+    // snapshot the frame. Deferred into the opener body so a resolver/transport
+    // failure surfaces on iteration/`close()`, matching the handler `ctx.stream`.
+    function streamResolver(typeName: string, callOptions: CallOptions | undefined): ResolveStream {
+        return () => ({
+            transport: resolveTransport(typeName, callOptions?.endpoint, "catalogClient.stream"),
+            frame: buildFrame(callOptions),
+        });
+    }
+
+    function makeStreamHandle(method: string): unknown {
+        const { typeName, descMethod } = lookupCatalogMethod(catalog, method, "catalogClient.stream");
+        switch (descMethod.methodKind) {
+            case "server_streaming":
+                return (request: unknown, callOptions?: CallOptions): AsyncIterable<unknown> =>
+                    openServerStream(streamResolver(typeName, callOptions), descMethod as DescMethodStreaming<DescMessage, DescMessage>, request);
+            case "client_streaming":
+                return (callOptions?: CallOptions): ClientStreamHandle<unknown, unknown> =>
+                    openClientStream(streamResolver(typeName, callOptions), descMethod as DescMethodStreaming<DescMessage, DescMessage>);
+            case "bidi_streaming":
+                return (callOptions?: CallOptions): BidiStreamHandle<unknown, unknown> =>
+                    openBidiStream(streamResolver(typeName, callOptions), descMethod as DescMethodStreaming<DescMessage, DescMessage>);
+            default:
+                throw new ConnectError(`catalogClient.stream: "${method}" is a unary method — use client.call instead.`, Code.Unimplemented);
+        }
+    }
+
+    return { call, stream };
+}

--- a/packages/core/src/catalogDispatcher.ts
+++ b/packages/core/src/catalogDispatcher.ts
@@ -16,9 +16,10 @@
  */
 
 import type { DescMessage, DescMethod, DescMethodStreaming, DescMethodUnary, DescService, MessageInitShape } from "@bufbuild/protobuf";
-import type { HandlerContext, ServiceImpl, Transport } from "@connectrpc/connect";
+import type { ContextValues, HandlerContext, ServiceImpl, Transport } from "@connectrpc/connect";
 import { Code, ConnectError } from "@connectrpc/connect";
 import type { BidiStreamHandle, CallOptions, ClientStreamHandle, ConnectumServiceImpl, Context } from "./context.ts";
+import type { RemoteResolver } from "./remoteResolver.ts";
 import type { ServiceCatalog } from "./serviceCatalog.ts";
 import { createInputQueue, singleInput } from "./streamBridge.ts";
 
@@ -92,6 +93,196 @@ function sanitizeCallError(error: unknown): unknown {
 }
 
 /**
+ * The per-call dispatch frame: everything the underlying ConnectRPC
+ * `Transport.unary`/`Transport.stream` needs beyond the method + request.
+ *
+ * The handler {@link Context} fills it from the inbound `HandlerContext`
+ * (signal/deadline cascade, propagated headers, `hctx.values`); the standalone
+ * `CatalogClient` fills it from the caller's {@link CallOptions} (no inbound
+ * request to cascade from, so `contextValues` is omitted).
+ *
+ * @internal
+ */
+export interface CallFrame {
+    readonly signal: AbortSignal | undefined;
+    readonly timeoutMs: number | undefined;
+    readonly headers: HeadersInit | undefined;
+    readonly contextValues: ContextValues | undefined;
+}
+
+/**
+ * A lazy resolution thunk for a streaming call: produces the target
+ * `Transport` together with the per-call {@link CallFrame}. Streaming openers
+ * call it INSIDE their iterator/IIFE/generator body, never eagerly, so a
+ * resolver/transport failure and the deadline snapshot surface on
+ * iteration/`close()` — preserving the documented `ctx.stream` timing.
+ *
+ * @internal
+ */
+export type ResolveStream = () => { transport: Transport; frame: CallFrame };
+
+/**
+ * Resolve a catalog method key `"${typeName}/${Method}"` to its
+ * `(typeName, DescMethod)` against a concrete {@link ServiceCatalog}. Throws the
+ * operational `ConnectError` for a missing catalog / unknown service / unknown
+ * method (the unary-vs-stream kind check is left to the caller).
+ *
+ * Shared verbatim by the handler {@link Context} dispatcher and the standalone
+ * `CatalogClient`, so both surface identical error codes.
+ *
+ * @internal
+ */
+export function lookupCatalogMethod(catalog: ServiceCatalog | undefined, method: string, caller = "ctx"): { typeName: string; descMethod: DescMethod } {
+    const parts = splitMethodKey(method);
+    if (parts === null) {
+        throw new ConnectError(`${caller}: malformed method key "${method}" (expected "\${typeName}/\${Method}").`, Code.Unimplemented);
+    }
+    const { typeName, methodName } = parts;
+
+    if (catalog === undefined) {
+        throw new ConnectError(`${caller}: no catalog is configured; pass createServer({ catalog }) to enable cross-service calls.`, Code.FailedPrecondition);
+    }
+
+    const descriptor = catalog[typeName];
+    if (descriptor === undefined) {
+        throw new ConnectError(`${caller}: unknown service "${typeName}" (no such key in the catalog).`, Code.Unimplemented);
+    }
+
+    const descMethod = descriptor.methods.find((m) => m.name === methodName);
+    if (descMethod === undefined) {
+        throw new ConnectError(`${caller}: "${typeName}" has no method "${methodName}".`, Code.Unimplemented);
+    }
+    return { typeName, descMethod };
+}
+
+/**
+ * Resolve a remote service to a `Transport` via a {@link RemoteResolver},
+ * mapping the two failure modes to the same `ConnectError` codes `ctx.call`
+ * uses: a resolver that throws → `Code.Internal` (cause preserved), a resolver
+ * that returns `null` → `Code.Unavailable`.
+ *
+ * Used by the standalone `CatalogClient` (which has no in-process/local path);
+ * the server-side dispatcher applies the same mapping inline in
+ * {@link CatalogDispatcher._resolveTransport} after first trying the local
+ * transport.
+ *
+ * @internal
+ */
+export function resolveRemoteTransportOrThrow(resolver: RemoteResolver, typeName: string, endpoint: string | undefined, caller = "ctx.call"): Transport {
+    let transport: Transport | null;
+    try {
+        transport = resolver(endpoint !== undefined ? { typeName, endpoint } : { typeName });
+    } catch (cause) {
+        throw new ConnectError(`${caller}: the resolver threw while resolving "${typeName}".`, Code.Internal, undefined, undefined, cause);
+    }
+    if (transport === null) {
+        const at = endpoint !== undefined ? ` (endpoint "${endpoint}")` : "";
+        throw new ConnectError(`${caller}: no route for "${typeName}"${at}: the resolver returned null.`, Code.Unavailable);
+    }
+    return transport;
+}
+
+/**
+ * The shared unary tail: invoke an already-resolved `transport.unary` with the
+ * computed {@link CallFrame}, returning the response message and sanitizing any
+ * propagated `ConnectError` (see {@link sanitizeCallError}). Both the handler
+ * `ctx.call` and the standalone `CatalogClient.call` end here.
+ *
+ * @internal
+ */
+export async function dispatchUnaryCall(transport: Transport, descMethod: DescMethodUnary<DescMessage, DescMessage>, request: unknown, frame: CallFrame): Promise<unknown> {
+    try {
+        const response = await transport.unary(descMethod, frame.signal, frame.timeoutMs, frame.headers, request as MessageInitShape<DescMessage>, frame.contextValues);
+        return response.message;
+    } catch (error) {
+        throw sanitizeCallError(error);
+    }
+}
+
+/**
+ * The shared server-streaming tail: one request in, an `AsyncIterable` of
+ * responses out, over an already-resolved `transport` with the computed
+ * {@link CallFrame}.
+ *
+ * @internal
+ */
+export function openServerStream(resolve: ResolveStream, descMethod: DescMethodStreaming<DescMessage, DescMessage>, request: unknown): AsyncIterable<unknown> {
+    return {
+        async *[Symbol.asyncIterator]() {
+            try {
+                // Resolution is LAZY (on first iteration), so a resolver/transport
+                // failure — and the deadline snapshot taken inside the frame —
+                // surface here, not when the factory was invoked.
+                const { transport, frame } = resolve();
+                const input = singleInput(request as MessageInitShape<DescMessage>);
+                const response = await transport.stream(descMethod, frame.signal, frame.timeoutMs, frame.headers, input, frame.contextValues);
+                yield* response.message;
+            } catch (error) {
+                throw sanitizeCallError(error);
+            }
+        },
+    };
+}
+
+/**
+ * The shared client-streaming tail: push N requests, `close()` resolves the
+ * single response. Resolution is lazy — a resolver/transport failure surfaces
+ * on `await close()` (the response IIFE), never on factory invocation.
+ *
+ * @internal
+ */
+export function openClientStream(resolve: ResolveStream, descMethod: DescMethodStreaming<DescMessage, DescMessage>): ClientStreamHandle<unknown, unknown> {
+    const queue = createInputQueue<MessageInitShape<DescMessage>>();
+    const responsePromise = (async (): Promise<unknown> => {
+        try {
+            const { transport, frame } = resolve();
+            const response = await transport.stream(descMethod, frame.signal, frame.timeoutMs, frame.headers, queue.iterable, frame.contextValues);
+            for await (const message of response.message) {
+                return message;
+            }
+            throw new ConnectError(`ctx.stream: client-streaming "${descMethod.name}" produced no response.`, Code.Internal);
+        } catch (error) {
+            throw sanitizeCallError(error);
+        }
+    })();
+    // Avoid an unhandled rejection before the caller awaits close().
+    responsePromise.catch(() => {});
+    return {
+        send: (request) => queue.push(request as MessageInitShape<DescMessage>),
+        close: () => {
+            queue.close();
+            return responsePromise;
+        },
+    };
+}
+
+/**
+ * The shared bidi-streaming tail: push requests while iterating `responses`;
+ * `close()` ends the send half. Resolution is lazy — a resolver/transport
+ * failure surfaces when `responses` is first iterated, never on factory
+ * invocation.
+ *
+ * @internal
+ */
+export function openBidiStream(resolve: ResolveStream, descMethod: DescMethodStreaming<DescMessage, DescMessage>): BidiStreamHandle<unknown, unknown> {
+    const queue = createInputQueue<MessageInitShape<DescMessage>>();
+    async function* responses(): AsyncIterable<unknown> {
+        try {
+            const { transport, frame } = resolve();
+            const response = await transport.stream(descMethod, frame.signal, frame.timeoutMs, frame.headers, queue.iterable, frame.contextValues);
+            yield* response.message;
+        } catch (error) {
+            throw sanitizeCallError(error);
+        }
+    }
+    return {
+        send: (request) => queue.push(request as MessageInitShape<DescMessage>),
+        close: () => queue.close(),
+        responses: responses(),
+    };
+}
+
+/**
  * Per-server engine that materializes `ctx.call` and wraps user handlers so
  * they receive a Connectum {@link Context}.
  *
@@ -151,56 +342,19 @@ export class CatalogDispatcher {
         }
 
         const transport = this._resolveTransport(typeName, options?.endpoint);
-
-        // Cascade: inject the inbound signal/deadline unless explicitly overridden.
-        const signal = options?.signal ?? hctx.signal;
-        const timeoutMs = clampTimeout(options?.timeoutMs, hctx.timeoutMs());
-        const headers = this._buildHeaders(hctx, options);
-
-        try {
-            const response = await transport.unary(
-                descMethod as DescMethodUnary<DescMessage, DescMessage>,
-                signal,
-                timeoutMs,
-                headers,
-                request as MessageInitShape<DescMessage>,
-                hctx.values,
-            );
-            return response.message;
-        } catch (error) {
-            throw sanitizeCallError(error);
-        }
+        const frame = this._buildFrame(hctx, options);
+        return dispatchUnaryCall(transport, descMethod as DescMethodUnary<DescMessage, DescMessage>, request, frame);
     }
 
     /**
-     * Resolve a catalog method key to its `(typeName, DescMethod)`. Throws the
-     * operational `ConnectError` for a missing catalog / unknown service /
-     * unknown method (the kind check is left to the caller).
+     * Resolve a catalog method key to its `(typeName, DescMethod)`. Delegates to
+     * the shared {@link lookupCatalogMethod} against this host's catalog (kind
+     * check left to the caller).
      *
      * @internal
      */
     private _lookupCatalogMethod(method: string): { typeName: string; descMethod: DescMethod } {
-        const parts = splitMethodKey(method);
-        if (parts === null) {
-            throw new ConnectError(`ctx: malformed method key "${method}" (expected "\${typeName}/\${Method}").`, Code.Unimplemented);
-        }
-        const { typeName, methodName } = parts;
-
-        const catalog = this.host.catalog;
-        if (catalog === undefined) {
-            throw new ConnectError("ctx: no catalog is configured; pass createServer({ catalog }) to enable cross-service calls.", Code.FailedPrecondition);
-        }
-
-        const descriptor = catalog[typeName];
-        if (descriptor === undefined) {
-            throw new ConnectError(`ctx: unknown service "${typeName}" (no such key in the catalog).`, Code.Unimplemented);
-        }
-
-        const descMethod = descriptor.methods.find((m) => m.name === methodName);
-        if (descMethod === undefined) {
-            throw new ConnectError(`ctx: "${typeName}" has no method "${methodName}".`, Code.Unimplemented);
-        }
-        return { typeName, descMethod };
+        return lookupCatalogMethod(this.host.catalog, method);
     }
 
     /**
@@ -225,91 +379,52 @@ export class CatalogDispatcher {
         }
     }
 
+    /**
+     * The lazy resolution thunk for a server-side streaming call: resolve the
+     * transport (local or remote) and snapshot the cascade frame. Deferred into
+     * the opener body so timing matches the documented `ctx.stream` contract —
+     * operational failures + the deadline snapshot surface on iteration/`close()`.
+     *
+     * @internal
+     */
+    private _streamResolver(typeName: string, options: CallOptions | undefined, hctx: HandlerContext): ResolveStream {
+        return () => ({
+            transport: this._resolveTransport(typeName, options?.endpoint),
+            frame: this._buildFrame(hctx, options),
+        });
+    }
+
     /** Server-streaming: one request in, an `AsyncIterable` of responses out. @internal */
     private _serverStream(typeName: string, descMethod: DescMethod, request: unknown, options: CallOptions | undefined, hctx: HandlerContext): AsyncIterable<unknown> {
-        const dispatcher = this;
-        return {
-            async *[Symbol.asyncIterator]() {
-                try {
-                    const { transport, signal, timeoutMs, headers } = dispatcher._prepareStream(typeName, options, hctx);
-                    const input = singleInput(request as MessageInitShape<DescMessage>);
-                    const response = await transport.stream(descMethod as DescMethodStreaming<DescMessage, DescMessage>, signal, timeoutMs, headers, input, hctx.values);
-                    yield* response.message;
-                } catch (error) {
-                    throw sanitizeCallError(error);
-                }
-            },
-        };
+        return openServerStream(this._streamResolver(typeName, options, hctx), descMethod as DescMethodStreaming<DescMessage, DescMessage>, request);
     }
 
     /** Client-streaming: push N requests, `close()` resolves the single response. @internal */
     private _clientStream(typeName: string, descMethod: DescMethod, options: CallOptions | undefined, hctx: HandlerContext): ClientStreamHandle<unknown, unknown> {
-        const queue = createInputQueue<MessageInitShape<DescMessage>>();
-        const responsePromise = (async (): Promise<unknown> => {
-            try {
-                const { transport, signal, timeoutMs, headers } = this._prepareStream(typeName, options, hctx);
-                const response = await transport.stream(descMethod as DescMethodStreaming<DescMessage, DescMessage>, signal, timeoutMs, headers, queue.iterable, hctx.values);
-                for await (const message of response.message) {
-                    return message;
-                }
-                throw new ConnectError(`ctx.stream: client-streaming "${descMethod.name}" produced no response.`, Code.Internal);
-            } catch (error) {
-                throw sanitizeCallError(error);
-            }
-        })();
-        // Avoid an unhandled rejection before the caller awaits close().
-        responsePromise.catch(() => {});
-        return {
-            send: (request) => queue.push(request as MessageInitShape<DescMessage>),
-            close: () => {
-                queue.close();
-                return responsePromise;
-            },
-        };
+        return openClientStream(this._streamResolver(typeName, options, hctx), descMethod as DescMethodStreaming<DescMessage, DescMessage>);
     }
 
     /** Bidi-streaming: push requests while iterating `responses`; `close()` ends the send half. @internal */
     private _bidiStream(typeName: string, descMethod: DescMethod, options: CallOptions | undefined, hctx: HandlerContext): BidiStreamHandle<unknown, unknown> {
-        const queue = createInputQueue<MessageInitShape<DescMessage>>();
-        return {
-            send: (request) => queue.push(request as MessageInitShape<DescMessage>),
-            close: () => queue.close(),
-            responses: this._bidiResponses(typeName, descMethod, options, hctx, queue.iterable),
-        };
-    }
-
-    /** @internal */
-    private async *_bidiResponses(
-        typeName: string,
-        descMethod: DescMethod,
-        options: CallOptions | undefined,
-        hctx: HandlerContext,
-        input: AsyncIterable<MessageInitShape<DescMessage>>,
-    ): AsyncIterable<unknown> {
-        try {
-            const { transport, signal, timeoutMs, headers } = this._prepareStream(typeName, options, hctx);
-            const response = await transport.stream(descMethod as DescMethodStreaming<DescMessage, DescMessage>, signal, timeoutMs, headers, input, hctx.values);
-            yield* response.message;
-        } catch (error) {
-            throw sanitizeCallError(error);
-        }
+        return openBidiStream(this._streamResolver(typeName, options, hctx), descMethod as DescMethodStreaming<DescMessage, DescMessage>);
     }
 
     /**
-     * Resolve transport + cascade for a streaming call (shared by all kinds).
+     * Compose the {@link CallFrame} for a server-side catalog call from the
+     * inbound `HandlerContext`: cascade the signal/deadline (unless overridden),
+     * build the propagated + explicit headers, and forward `hctx.values`. This
+     * is the cascade behavior that `ctx.call`/`ctx.stream` have always applied —
+     * computed identically for unary and every streaming kind.
      *
      * @internal
      */
-    private _prepareStream(
-        typeName: string,
-        options: CallOptions | undefined,
-        hctx: HandlerContext,
-    ): { transport: Transport; signal: AbortSignal; timeoutMs: number | undefined; headers: Headers | undefined } {
-        const transport = this._resolveTransport(typeName, options?.endpoint);
-        const signal = options?.signal ?? hctx.signal;
-        const timeoutMs = clampTimeout(options?.timeoutMs, hctx.timeoutMs());
-        const headers = this._buildHeaders(hctx, options);
-        return { transport, signal, timeoutMs, headers };
+    private _buildFrame(hctx: HandlerContext, options: CallOptions | undefined): CallFrame {
+        return {
+            signal: options?.signal ?? hctx.signal,
+            timeoutMs: clampTimeout(options?.timeoutMs, hctx.timeoutMs()),
+            headers: this._buildHeaders(hctx, options),
+            contextValues: hctx.values,
+        };
     }
 
     /**

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -103,6 +103,25 @@ export type StreamReturn<E> = E extends { kind: "server-stream"; request: infer 
         : never;
 
 /**
+ * The typed **unary** catalog-call surface: `call(method, request, options?)`
+ * keyed off {@link ConnectumCallMap}. Shared by the handler {@link Context} and
+ * the standalone `CatalogClient` (`createCatalogClient`) so both expose an
+ * identical, fully-typed `call`.
+ *
+ * @typeParam K - A `"${typeName}/${Method}"` key of {@link ConnectumCallMap}.
+ */
+export type CatalogCall = <K extends keyof ConnectumCallMap>(method: K, request: ConnectumCallMap[K]["request"], options?: CallOptions) => Promise<ConnectumCallMap[K]["response"]>;
+
+/**
+ * The typed **streaming** catalog-call surface: `stream(method)` returns a
+ * kind-specific factory keyed off {@link ConnectumStreamMap}. Shared by the
+ * handler {@link Context} and the standalone `CatalogClient`.
+ *
+ * @typeParam K - A `"${typeName}/${Method}"` key of {@link ConnectumStreamMap}.
+ */
+export type CatalogStream = <K extends keyof ConnectumStreamMap>(method: K) => StreamReturn<ConnectumStreamMap[K]>;
+
+/**
  * The context object passed to every Connectum service handler.
  *
  * Extends ConnectRPC's `HandlerContext` (all of its fields remain available)
@@ -120,7 +139,7 @@ export interface Context extends HandlerContext {
      *
      * @typeParam K - A `"${typeName}/${Method}"` key of {@link ConnectumCallMap}.
      */
-    call<K extends keyof ConnectumCallMap>(method: K, request: ConnectumCallMap[K]["request"], options?: CallOptions): Promise<ConnectumCallMap[K]["response"]>;
+    call: CatalogCall;
 
     /**
      * Open a streaming call to a service in the catalog. Returns a kind-specific
@@ -133,7 +152,7 @@ export interface Context extends HandlerContext {
      *
      * @typeParam K - A `"${typeName}/${Method}"` key of {@link ConnectumStreamMap}.
      */
-    stream<K extends keyof ConnectumStreamMap>(method: K): StreamReturn<ConnectumStreamMap[K]>;
+    stream: CatalogStream;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,10 +17,14 @@
 // SERVER API
 // =============================================================================
 
+// Standalone catalog client — the catalog-typed call/stream surface usable
+// OUTSIDE a Server (workers, schedulers, CLIs).
+export type { CatalogClient, CreateCatalogClientOptions } from "./catalogClient.ts";
+export { createCatalogClient } from "./catalogClient.ts";
 // Service catalog — declarative cross-service call primitives
 export { CatalogConfigError } from "./catalogErrors.ts";
 // Handler context (ctx.call / ctx.stream) + handler implementation types
-export type { BidiStreamHandle, CallOptions, ClientStreamHandle, ConnectumMethodImpl, ConnectumServiceImpl, Context, StreamReturn } from "./context.ts";
+export type { BidiStreamHandle, CallOptions, CatalogCall, CatalogStream, ClientStreamHandle, ConnectumMethodImpl, ConnectumServiceImpl, Context, StreamReturn } from "./context.ts";
 // Service registration
 export type { ServiceDefinition, ServiceOptions } from "./defineService.ts";
 export { defineLazyService, defineService } from "./defineService.ts";

--- a/packages/core/tests/integration/catalogClient.test.ts
+++ b/packages/core/tests/integration/catalogClient.test.ts
@@ -1,0 +1,287 @@
+/**
+ * createCatalogClient — the catalog-typed call/stream surface usable OUTSIDE a
+ * Server (issue #170: workers / schedulers / CLIs).
+ *
+ * Drives REAL in-memory dispatch: a `createRouterTransport` stub stands in for
+ * the remote service, wired through the same `RemoteResolver` factories
+ * (`singleTransportResolver`/`mapResolver`) that the in-handler `ctx.call`
+ * uses. Asserts that a typed unary `call` reaches the resolved transport and
+ * returns its response, that the transport is cached per route, that the typed
+ * `stream` surface performs a real server-streaming dispatch (not a dead knob),
+ * and that the operational error model mirrors `ctx.call`
+ * (Unavailable / Internal / Unimplemented).
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createRouterTransport, type Transport } from "@connectrpc/connect";
+import { createCatalogClient } from "../../src/catalogClient.ts";
+import { mapResolver, singleTransportResolver } from "../../src/remoteResolver.ts";
+import { defineCatalog } from "../../src/serviceCatalog.ts";
+import { type EchoRequest, type EchoResponse, EchoService } from "../fixtures/echo/v1/echo_pb.ts";
+import { type Count, CountSchema, type Item, ItemSchema, StreamingService } from "../fixtures/streaming/v1/streaming_pb.ts";
+
+// Hand-written catalog augmentation (the same shape the buf plugin emits): one
+// ConnectumCallMap entry per unary RPC, one ConnectumStreamMap entry per
+// streaming RPC. Includes deliberately-bogus keys to exercise the guards.
+// Keys must not collide with other test files' `declare module` augmentations:
+// `tsc` merges every `ConnectumCallMap`/`ConnectumStreamMap` augmentation in the
+// program into one interface, so a duplicate key with a different shape is a
+// hard error. `streaming.v1.StreamingService/Echo` and `echo.v1.EchoService/Echo`
+// share `ctxCall.test.ts`'s shapes (consistent → fine); the deliberately-bogus
+// guard keys below are namespaced uniquely to this suite.
+declare module "../../src/serviceCatalog.ts" {
+    interface ConnectumCallMap {
+        "streaming.v1.StreamingService/Echo": { request: Item; response: Item };
+        "echo.v1.EchoService/Echo": { request: EchoRequest; response: EchoResponse };
+        "phantom.v1.PhantomService/Vanish": { request: Item; response: Item };
+        "streaming.v1.StreamingService/Absent": { request: Item; response: Item };
+    }
+    interface ConnectumStreamMap {
+        "streaming.v1.StreamingService/Server": { request: Item; response: Item; kind: "server-stream" };
+        "streaming.v1.StreamingService/Client": { request: Item; response: Count; kind: "client-stream" };
+        "streaming.v1.StreamingService/Bidi": { request: Item; response: Item; kind: "bidi" };
+    }
+}
+
+/** A router-transport serving StreamingService (unary + all streaming kinds), tagged with `marker`. */
+function makeStreamingRemote(marker: string): Transport {
+    return createRouterTransport((router) => {
+        router.service(StreamingService, {
+            echo: (req) => create(ItemSchema, { value: `${marker}:${req.value}`, sequence: req.sequence }),
+            async *server(req) {
+                for (let i = 0; i < 3; i++) {
+                    yield create(ItemSchema, { value: `${marker}:${req.value}:${i}`, sequence: i });
+                }
+            },
+            client: async (reqs) => {
+                let total = 0;
+                for await (const _ of reqs) total++;
+                return create(CountSchema, { total });
+            },
+            async *bidi(reqs) {
+                for await (const req of reqs) {
+                    yield create(ItemSchema, { value: `${marker}:${req.value}`, sequence: req.sequence });
+                }
+            },
+        });
+    });
+}
+
+const catalog = defineCatalog({
+    [StreamingService.typeName]: StreamingService,
+    [EchoService.typeName]: EchoService,
+});
+
+describe("createCatalogClient — unary call (no Server)", () => {
+    it("dispatches a typed unary call over the resolver-supplied transport and returns the response", async () => {
+        const client = createCatalogClient({
+            catalog,
+            resolver: singleTransportResolver(makeStreamingRemote("remote")),
+        });
+
+        const res = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "hi", sequence: 7 }));
+        assert.strictEqual(res.value, "remote:hi", "must reach the resolved transport's handler");
+        assert.strictEqual(res.sequence, 7, "response must round-trip through the real transport");
+    });
+
+    it("is fully typed off the catalog (compile-time surface)", async () => {
+        const client = createCatalogClient({ catalog, resolver: singleTransportResolver(makeStreamingRemote("t")) });
+
+        // The response is inferred as the catalog's response type (Item), not
+        // `unknown`: accessing `.value`/`.sequence` only compiles because of it.
+        const res: Item = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "x", sequence: 0 }));
+        assert.strictEqual(typeof res.value, "string");
+
+        // @ts-expect-error — wrong request message type for this key
+        client.call("streaming.v1.StreamingService/Echo", create(CountSchema, { total: 1 })).catch(() => {});
+
+        // @ts-expect-error — key absent from ConnectumCallMap
+        client.call("not.a.Real/Method", create(ItemSchema, { value: "x", sequence: 0 })).catch(() => {});
+    });
+
+    it("routes per typeName via mapResolver — only the mapped service resolves", async () => {
+        const client = createCatalogClient({
+            catalog,
+            resolver: mapResolver({ [StreamingService.typeName]: makeStreamingRemote("mapped") }),
+        });
+        const res = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "x", sequence: 0 }));
+        assert.strictEqual(res.value, "mapped:x");
+    });
+
+    it("caches the resolved transport per (typeName, endpoint) — resolver runs at most once", async () => {
+        let resolverCalls = 0;
+        const remote = makeStreamingRemote("C");
+        const client = createCatalogClient({
+            catalog,
+            resolver: ({ typeName }) => {
+                resolverCalls += typeName === StreamingService.typeName ? 1 : 0;
+                return remote;
+            },
+        });
+
+        const a = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "1", sequence: 0 }));
+        const b = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "2", sequence: 0 }));
+        assert.strictEqual(a.value, "C:1");
+        assert.strictEqual(b.value, "C:2");
+        assert.strictEqual(resolverCalls, 1, "transport must be cached after the first call");
+    });
+
+    it("forwards CallOptions.headers verbatim (no inbound request to propagate from)", async () => {
+        const HEADER = "x-trace-test";
+        const headerRemote = createRouterTransport((router) => {
+            router.service(StreamingService, {
+                echo: (_req, ctx) => create(ItemSchema, { value: ctx.requestHeader.get(HEADER) ?? "none", sequence: 0 }),
+                async *server() {},
+                client: async () => create(CountSchema, { total: 0 }),
+                async *bidi() {},
+            });
+        });
+        const client = createCatalogClient({ catalog, resolver: singleTransportResolver(headerRemote) });
+        const res = await client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "x", sequence: 0 }), { headers: { [HEADER]: "abc" } });
+        assert.strictEqual(res.value, "abc", "explicit header must reach the transport");
+    });
+});
+
+describe("createCatalogClient — streaming (server-streaming) is a real dispatch", () => {
+    it("opens a typed server-stream over the resolved transport and yields every message", async () => {
+        const client = createCatalogClient({
+            catalog,
+            resolver: singleTransportResolver(makeStreamingRemote("S")),
+        });
+
+        const open = client.stream("streaming.v1.StreamingService/Server");
+        const received: string[] = [];
+        for await (const item of open(create(ItemSchema, { value: "go", sequence: 0 }))) {
+            received.push(item.value);
+        }
+        assert.deepStrictEqual(received, ["S:go:0", "S:go:1", "S:go:2"], "must yield the remote's full stream");
+    });
+
+    it("opens a typed client-stream: push N requests, close() resolves the aggregate", async () => {
+        const client = createCatalogClient({
+            catalog,
+            resolver: singleTransportResolver(makeStreamingRemote("CS")),
+        });
+        const handle = client.stream("streaming.v1.StreamingService/Client")();
+        handle.send(create(ItemSchema, { value: "a", sequence: 0 }));
+        handle.send(create(ItemSchema, { value: "b", sequence: 1 }));
+        const res = await handle.close();
+        assert.strictEqual(res.total, 2, "client-streaming must aggregate both pushed requests");
+    });
+
+    it("opens a typed bidi-stream: push requests while iterating echoed responses", async () => {
+        const client = createCatalogClient({
+            catalog,
+            resolver: singleTransportResolver(makeStreamingRemote("BS")),
+        });
+        const handle = client.stream("streaming.v1.StreamingService/Bidi")();
+        handle.send(create(ItemSchema, { value: "one", sequence: 0 }));
+        handle.send(create(ItemSchema, { value: "two", sequence: 1 }));
+        handle.close();
+        const received: string[] = [];
+        for await (const item of handle.responses) {
+            received.push(item.value);
+        }
+        assert.deepStrictEqual(received, ["BS:one", "BS:two"], "bidi must echo every pushed request back");
+    });
+
+    it("resolves the transport LAZILY: factory invocation does not throw on resolver-null; iteration does", async () => {
+        // Parity with ctx.stream's documented timing: a resolver/transport
+        // failure must surface on iteration/close(), never on factory call.
+        let resolverCalls = 0;
+        const client = createCatalogClient({
+            catalog,
+            resolver: () => {
+                resolverCalls++;
+                return null;
+            },
+        });
+
+        // server-streaming: invoking the factory must NOT throw or resolve.
+        const open = client.stream("streaming.v1.StreamingService/Server");
+        const stream = open(create(ItemSchema, { value: "x", sequence: 0 }));
+        assert.strictEqual(resolverCalls, 0, "resolver must not run until the stream is iterated");
+        await assert.rejects(
+            (async () => {
+                for await (const _ of stream) {
+                    // unreachable — resolution fails on first .next()
+                }
+            })(),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.Unavailable,
+        );
+        assert.strictEqual(resolverCalls, 1, "resolution must happen on iteration");
+
+        // client-streaming: failure surfaces on await close(), not on factory call.
+        const handle = client.stream("streaming.v1.StreamingService/Client")();
+        handle.send(create(ItemSchema, { value: "a", sequence: 0 }));
+        await assert.rejects(() => handle.close(), (err: unknown) => err instanceof ConnectError && err.code === Code.Unavailable);
+    });
+});
+
+describe("createCatalogClient — operational error model (mirrors ctx.call)", () => {
+    it("unresolved service (resolver returns null) → Code.Unavailable", async () => {
+        const client = createCatalogClient({ catalog, resolver: () => null });
+        await assert.rejects(
+            () => client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "x", sequence: 0 })),
+            (err: unknown) => {
+                assert.ok(err instanceof ConnectError, `expected ConnectError, got ${String(err)}`);
+                assert.strictEqual(err.code, Code.Unavailable);
+                return true;
+            },
+        );
+    });
+
+    it("resolver throws → Code.Internal (cause preserved)", async () => {
+        const boom = new Error("resolver exploded");
+        const client = createCatalogClient({
+            catalog,
+            resolver: () => {
+                throw boom;
+            },
+        });
+        await assert.rejects(
+            () => client.call("streaming.v1.StreamingService/Echo", create(ItemSchema, { value: "x", sequence: 0 })),
+            (err: unknown) => {
+                assert.ok(err instanceof ConnectError, `expected ConnectError, got ${String(err)}`);
+                assert.strictEqual(err.code, Code.Internal);
+                assert.strictEqual(err.cause, boom, "original cause must be preserved");
+                return true;
+            },
+        );
+    });
+
+    it("unknown service in the catalog → Code.Unimplemented", async () => {
+        const client = createCatalogClient({ catalog, resolver: singleTransportResolver(makeStreamingRemote("U")) });
+        await assert.rejects(
+            () => client.call("phantom.v1.PhantomService/Vanish", create(ItemSchema, { value: "x", sequence: 0 })),
+            (err: unknown) => {
+                assert.ok(err instanceof ConnectError);
+                assert.strictEqual((err as ConnectError).code, Code.Unimplemented);
+                return true;
+            },
+        );
+    });
+
+    it("known service, unknown method → Code.Unimplemented", async () => {
+        const client = createCatalogClient({ catalog, resolver: singleTransportResolver(makeStreamingRemote("U")) });
+        await assert.rejects(
+            () => client.call("streaming.v1.StreamingService/Absent", create(ItemSchema, { value: "x", sequence: 0 })),
+            (err: unknown) => {
+                assert.ok(err instanceof ConnectError);
+                assert.strictEqual((err as ConnectError).code, Code.Unimplemented);
+                return true;
+            },
+        );
+    });
+
+    it("calling a streaming method via .call → Code.Unimplemented (use .stream)", async () => {
+        const client = createCatalogClient({ catalog, resolver: singleTransportResolver(makeStreamingRemote("U")) });
+        await assert.rejects(
+            // @ts-expect-error — "Server" is a streaming key, not a ConnectumCallMap key
+            () => client.call("streaming.v1.StreamingService/Server", create(ItemSchema, { value: "x", sequence: 0 })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.Unimplemented,
+        );
+    });
+});

--- a/packages/core/tests/integration/ctxStream.test.ts
+++ b/packages/core/tests/integration/ctxStream.test.ts
@@ -173,6 +173,43 @@ describe("ctx.stream — validation", () => {
         await server.localClient(EchoService).secureEcho(create(EchoRequestSchema, { message: "x" }));
         assert.ok(captured instanceof ConnectError && captured.code === Code.Unimplemented, `expected Unimplemented, got: ${String(captured)}`);
     });
+
+    it("resolves a remote stream target LAZILY — the resolver runs on iteration, not on factory invocation", async () => {
+        // Regression lock: ctx.stream's transport resolution must stay lazy
+        // (documented on _makeStreamHandle). The stream target is NOT mounted
+        // locally, so it goes through the resolver; the factory call must not
+        // trigger it — only iterating the returned AsyncIterable must.
+        let resolverCalls = 0;
+        let observedCallsAtFactoryTime = -1;
+        let captured: unknown;
+        const server = createServer({
+            services: [
+                makeCaller(async (_req, ctx) => {
+                    const stream = ctx.stream("streaming.v1.StreamingService/Server")(create(ItemSchema, { value: "x", sequence: 0 }));
+                    observedCallsAtFactoryTime = resolverCalls; // must still be 0
+                    try {
+                        for await (const _ of stream) {
+                            // unreachable: resolver returns null → Unavailable on first .next()
+                        }
+                    } catch (err) {
+                        captured = err;
+                    }
+                    return create(EchoResponseSchema, { message: "done", timestamp: 0n });
+                }),
+            ],
+            // Only EchoService is local; StreamingService is reached remotely.
+            catalog: defineCatalog({ [EchoService.typeName]: EchoService, [StreamingService.typeName]: StreamingService }),
+            remoteResolver: ({ typeName }) => {
+                resolverCalls += typeName === StreamingService.typeName ? 1 : 0;
+                return null;
+            },
+        });
+
+        await server.localClient(EchoService).secureEcho(create(EchoRequestSchema, { message: "x" }));
+        assert.strictEqual(observedCallsAtFactoryTime, 0, "resolver must NOT run when the stream factory is invoked");
+        assert.strictEqual(resolverCalls, 1, "resolver must run exactly once, on iteration");
+        assert.ok(captured instanceof ConnectError && captured.code === Code.Unavailable, `expected Unavailable on iteration, got: ${String(captured)}`);
+    });
 });
 
 describe("ctx.stream — open items (escalated, not yet locked)", () => {


### PR DESCRIPTION
Closes #170.

## Problem

`ctx.call` / `ctx.stream` give catalog-typed, resolver-routed cross-service calls — but only inside a handler. An out-of-process caller (a Temporal worker, a scheduler, a CLI) has no `Server`, so it hand-builds `createClient(Service, createGrpcTransport({ baseUrl }))` per service and re-implements `*_ADDR` resolution, losing the catalog typing and the `RemoteResolver`. (Hit directly in the car-sharing Phase 2 Temporal worker.)

## Change

**`createCatalogClient({ catalog, resolver })`** — a standalone client exposing the **same strongly-typed** `call` (unary) and `stream` surface as the handler `ctx`, keyed off the generated `ConnectumCallMap` / `ConnectumStreamMap` (`<K extends keyof ConnectumCallMap>(method, request, opts) => Promise<…response>`), without a `Server`. It resolves every target through the supplied `RemoteResolver` and dispatches over the returned `Transport` (cached per `(typeName, endpoint)`). No in-process path → an unresolvable service fails with `Code.Unavailable`; the rest of the error model mirrors `ctx.call`. `CallOptions` are applied verbatim (no inbound request to cascade/clamp/propagate).

The dispatch core is **extracted from `catalogDispatcher`** and shared by both the handler `Context` and `createCatalogClient`, so `ctx.call`/`ctx.stream` behavior + public types are **unchanged**.

## Validation

- New `tests/integration/catalogClient.test.ts` — **14/14** (real dispatch over a mock transport + the full error model). A new lazy-stream-resolution regression lock added to `ctxStream.test.ts`.
- Full `@connectum/core` suite **324 tests, 0 fail** (no `ctx.call` regression from the refactor); build + typecheck + biome clean. Additive; changeset `@connectum/core` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a standalone catalog client factory enabling typed unary and streaming calls for out-of-process usage (Temporal workers, schedulers, CLIs, etc.) without constructing a server.
  * Supports the same typed interaction ergonomics as in-process context calls.
  * Includes consistent error handling and transport caching per endpoint.

* **Documentation**
  * Added new public API exports for catalog client functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->