### PR TITLE
feat(auth): internal (service-to-service) auth — per-service trust (ADR-029)

### DIFF
--- a/.changeset/auth-internal-service-auth.md
+++ b/.changeset/auth-internal-service-auth.md
@@ -1,0 +1,15 @@
+---
+"@connectum/auth": minor
+---
+
+Add a first-class `internal` (service-to-service) auth marker and interceptor (ADR-029), distinct from `public`. An `internal` method skips end-user (JWT) authentication but **requires an internal trust marker** — so promoting a method `public → internal` removes world-open exposure instead of merely renaming it, and the contract now audits as "internal" rather than "public".
+
+- **Proto:** `optional bool internal` added to `ServiceAuth` and `MethodAuth` (`connectum/auth/v1/options.proto`, additive). `resolveMethodAuth` surfaces `internal` with the same method-overrides-service precedence as `public`.
+- **`createInternalAuthInterceptor`** — for `internal` methods, authorizes via a pluggable per-service **trust source** (`(req) => AuthContext | null`) and rejects a missing/invalid marker as `Code.Unauthenticated`; non-`internal` methods are a no-op pass-through. Three trust-source factories ship:
+  - **`meshIdentityTrust({ allowlist, header? })`** — production default; verify a mesh-forwarded peer principal (Istio short-form ServiceAccount / SPIFFE id) against an allow-list carrying roles/scopes. Per-service by construction (the mesh issues each workload its own identity). The identity header is stripped after extraction (anti-spoofing).
+  - **`signedTokenTrust({ issuers, header? })`** — non-mesh per-service containment via per-service JWT/JWKS. **The JWKS lookup is issuer-bound**: the keyset is selected by the token's `iss` claim (`issuers[iss].jwksUri`, one `createRemoteJWKSet` per issuer) and verification is pinned to that same issuer. A single shared JWKS across issuers does NOT contain compromise (jose resolves the signing key by `kid` independently of `iss`), so a token claiming `iss: B` signed with A's key is rejected.
+  - **`sharedSecretTrust({ secret, header? })`** — **dev-only** fallback (single shared secret, constant-time compared). NOT per-service — one compromise forges all callers — and documented as such.
+- **`getInternalMethods(services)`** — mirrors `getPublicMethods`; feed both into the JWT interceptor's `skipMethods`.
+- **`createProtoAuthzInterceptor`** composes `internal` inclusively within its existing flow (one model, no parallel `requires_identity`): `internal` + identity + no `requires` → allow; `internal` + `requires {roles/scopes}` → the existing roles/scopes check against the internal identity; `internal` + no identity → `Unauthenticated`. The internal/JWT interceptors MUST run before `createProtoAuthzInterceptor` (they populate the `AuthContext` it consumes): `errorHandler → (jwtAuth | internalAuth) → protoAuthz`.
+
+Purely additive — existing `public` and gated behavior are unchanged.

--- a/packages/auth/proto/connectum/auth/v1/options.proto
+++ b/packages/auth/proto/connectum/auth/v1/options.proto
@@ -50,6 +50,14 @@ message MethodAuth {
   // Override the service-level default_policy for this method.
   // Valid values: "allow", "deny".
   optional string policy = 3;
+
+  // Mark the method as internal (service-to-service). Skips end-user (JWT)
+  // authentication, but requires an internal trust marker established by
+  // createInternalAuthInterceptor (a per-service trust source). Distinct from
+  // `public`: `public` is world-open (no auth at all); `internal` is reachable
+  // only by a trusted internal caller. A method is at most one of
+  // `public` / `internal` / gated. See ADR-029.
+  optional bool internal = 4;
 }
 
 // Default authorization configuration for all methods in a service.
@@ -65,6 +73,12 @@ message ServiceAuth {
   // Mark all methods in the service as public
   // (skip authentication and authorization).
   optional bool public = 3;
+
+  // Mark all methods in the service as internal (service-to-service).
+  // Skips end-user (JWT) authentication, but requires an internal trust
+  // marker established by createInternalAuthInterceptor. Method-level
+  // `internal` overrides this. See ADR-029.
+  optional bool internal = 4;
 }
 
 // Custom option for RPC methods.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -3,10 +3,11 @@
  *
  * Authentication and authorization interceptors for Connectum.
  *
- * Provides eight interceptor factories:
+ * Provides nine interceptor factories:
  * - createAuthInterceptor() — generic, pluggable authentication
  * - createJwtAuthInterceptor() — JWT convenience with jose
  * - createGatewayAuthInterceptor() — gateway-injected headers
+ * - createInternalAuthInterceptor() — internal (service-to-service) trust marker
  * - createSessionAuthInterceptor() — session-based auth (better-auth, etc.)
  * - createAuthzInterceptor() — declarative rules-based authorization
  * - createProtoAuthzInterceptor() — proto-option-driven authorization
@@ -34,13 +35,15 @@ export { AuthzDeniedError } from "./errors.ts";
 export { createGatewayAuthInterceptor } from "./gateway-auth-interceptor.ts";
 // Header utilities
 export { parseAuthHeaders, setAuthHeaders } from "./headers.ts";
+// Internal (service-to-service) auth
+export { createInternalAuthInterceptor, meshIdentityTrust, sharedSecretTrust, signedTokenTrust } from "./internal-auth-interceptor.ts";
 export { createJwtAuthInterceptor } from "./jwt-auth-interceptor.ts";
 // Method pattern matching
 export { matchesMethodPattern } from "./method-match.ts";
 // Proto-based authorization
 export { createProtoAuthzInterceptor } from "./proto/proto-authz-interceptor.ts";
 export type { ResolvedMethodAuth } from "./proto/reader.ts";
-export { getPublicMethods, resolveMethodAuth } from "./proto/reader.ts";
+export { getInternalMethods, getPublicMethods, resolveMethodAuth } from "./proto/reader.ts";
 export { createSessionAuthInterceptor } from "./session-auth-interceptor.ts";
 
 // Types and constants
@@ -55,9 +58,16 @@ export type {
     GatewayAuthInterceptorOptions,
     GatewayHeaderMapping,
     InterceptorFactory,
+    InternalAuthInterceptorOptions,
+    InternalTrustSource,
     JwtAuthInterceptorOptions,
+    MeshIdentityEntry,
+    MeshIdentityTrustOptions,
     ProtoAuthzInterceptorOptions,
     SessionAuthInterceptorOptions,
+    SharedSecretTrustOptions,
+    SignedTokenIssuer,
+    SignedTokenTrustOptions,
 } from "./types.ts";
 
 export { AUTH_HEADERS, AuthzEffect } from "./types.ts";

--- a/packages/auth/src/internal-auth-interceptor.ts
+++ b/packages/auth/src/internal-auth-interceptor.ts
@@ -1,0 +1,409 @@
+/**
+ * Internal (service-to-service) authentication interceptor (ADR-029).
+ *
+ * For `internal` methods, authorizes the call from a configurable per-service
+ * trust source rather than an end-user token, and rejects a missing/invalid
+ * marker as `Code.Unauthenticated`. Non-internal methods pass through unchanged.
+ *
+ * Ships three trust-source factories:
+ * - {@link meshIdentityTrust} — production default, per-service via the mesh.
+ * - {@link signedTokenTrust} — non-mesh, per-service JWT/JWKS with mandatory
+ *   issuer-bound key selection.
+ * - {@link sharedSecretTrust} — dev-only fallback (single shared secret).
+ *
+ * Chain ordering is load-bearing: this interceptor runs BEFORE
+ * `createProtoAuthzInterceptor` — it populates the `AuthContext` proto-authz
+ * consumes (`errorHandler -> (jwtAuth | internalAuth) -> protoAuthz`).
+ *
+ * @module internal-auth-interceptor
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Interceptor, StreamRequest, UnaryRequest } from "@connectrpc/connect";
+import { Code, ConnectError } from "@connectrpc/connect";
+import * as jose from "jose";
+import { authContextStorage } from "./context.ts";
+import { matchesMethodPattern } from "./method-match.ts";
+import type {
+    AuthContext,
+    InternalAuthInterceptorOptions,
+    InternalTrustSource,
+    MeshIdentityTrustOptions,
+    SharedSecretTrustOptions,
+    SignedTokenIssuer,
+    SignedTokenTrustOptions,
+} from "./types.ts";
+
+/**
+ * Create an internal (service-to-service) authentication interceptor.
+ *
+ * For methods matched by `internalMethods`, the configured `trustSource`
+ * authorizes the call and sets an `AuthContext`. A trust source returning
+ * `null` (or throwing) is rejected as `Code.Unauthenticated`. Non-internal
+ * methods are a no-op pass-through.
+ *
+ * MUST run BEFORE `createProtoAuthzInterceptor`: the internal interceptor
+ * populates the `AuthContext` that proto-authz's `internal` rule consumes.
+ *
+ * Each trust-source factory strips its own trust header after extraction on the
+ * internal path (accept and reject), to prevent a spoofed marker from being
+ * propagated downstream. NOTE: for NON-internal methods this interceptor is a
+ * pure pass-through and does NOT strip any trust headers — a request to a
+ * `public`/gated method carrying a forged identity header passes through
+ * untouched. In the supported deployments the mesh sidecar (or an upstream
+ * gateway) terminates the trust boundary and scrubs these headers on every
+ * route; do not rely on this interceptor to sanitize non-internal routes.
+ *
+ * @param options - Internal auth configuration.
+ * @returns ConnectRPC interceptor.
+ *
+ * @example Mesh deployment (production default)
+ * ```typescript
+ * import { createInternalAuthInterceptor, meshIdentityTrust, getInternalMethods } from '@connectum/auth';
+ *
+ * const internalAuth = createInternalAuthInterceptor({
+ *   internalMethods: getInternalMethods(services),
+ *   trustSource: meshIdentityTrust({
+ *     allowlist: [
+ *       { principal: 'cluster.local/ns/default/sa/trips', roles: ['worker'] },
+ *     ],
+ *   }),
+ * });
+ * ```
+ *
+ * @example Non-mesh, per-service signed tokens
+ * ```typescript
+ * import { createInternalAuthInterceptor, signedTokenTrust, getInternalMethods } from '@connectum/auth';
+ *
+ * const internalAuth = createInternalAuthInterceptor({
+ *   internalMethods: getInternalMethods(services),
+ *   trustSource: signedTokenTrust({
+ *     issuers: {
+ *       'trips-service': { jwksUri: 'https://trips/.well-known/jwks.json', claimsMapping: { roles: 'roles' } },
+ *       'billing-service': { jwksUri: 'https://billing/.well-known/jwks.json' },
+ *     },
+ *   }),
+ * });
+ * ```
+ */
+export function createInternalAuthInterceptor(options: InternalAuthInterceptorOptions): Interceptor {
+    const { trustSource, internalMethods } = options;
+
+    if (typeof trustSource !== "function") {
+        throw new Error("@connectum/auth: createInternalAuthInterceptor requires a trustSource function");
+    }
+
+    return (next) => async (req: UnaryRequest | StreamRequest) => {
+        const serviceName: string = req.service.typeName;
+        const methodName: string = req.method.name;
+
+        // Non-internal methods: no-op pass-through.
+        if (!matchesMethodPattern(serviceName, methodName, internalMethods)) {
+            return await next(req);
+        }
+
+        // Internal method: require a valid trust marker.
+        // A null result OR any thrown error from the trust source maps to
+        // Unauthenticated (never leak as Internal/Unknown).
+        let authContext: AuthContext | null;
+        try {
+            authContext = await trustSource(req);
+        } catch {
+            authContext = null;
+        }
+
+        if (!authContext) {
+            throw new ConnectError("Untrusted internal request", Code.Unauthenticated);
+        }
+
+        return await authContextStorage.run(authContext, () => next(req));
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Trust source (a): mesh identity allow-list
+// ---------------------------------------------------------------------------
+
+/**
+ * Trust source that verifies a mesh-forwarded peer identity against an
+ * allow-list (ADR-029 option (a) — production default, inherently per-service).
+ *
+ * In a service mesh the sidecar terminates mTLS and forwards the verified peer
+ * identity as a header (e.g. an Istio short-form ServiceAccount principal
+ * `cluster.local/ns/<ns>/sa/<name>`, or a SPIFFE id). The mesh issues each
+ * workload its OWN mTLS identity, so matching that forwarded principal against
+ * an allow-list is per-service by construction — compromising one workload
+ * cannot forge another's identity.
+ *
+ * The identity header is stripped after extraction to prevent downstream
+ * spoofing.
+ *
+ * @param options - Allow-list and the identity header name.
+ * @returns An {@link InternalTrustSource}.
+ */
+export function meshIdentityTrust(options: MeshIdentityTrustOptions): InternalTrustSource {
+    const { allowlist, header = "x-forwarded-client-principal", type = "mesh" } = options;
+
+    if (allowlist.length === 0) {
+        throw new Error("@connectum/auth: meshIdentityTrust requires a non-empty allowlist");
+    }
+
+    // Index by principal for O(1) lookup.
+    const byPrincipal = new Map(allowlist.map((entry) => [entry.principal, entry]));
+
+    return (req) => {
+        const principal = req.header.get(header);
+        // Strip the identity header regardless of outcome (anti-spoofing).
+        req.header.delete(header);
+
+        if (!principal) {
+            return null;
+        }
+        const entry = byPrincipal.get(principal);
+        if (!entry) {
+            return null;
+        }
+
+        const context: AuthContext = {
+            subject: entry.principal,
+            name: entry.name,
+            roles: entry.roles ? [...entry.roles] : [],
+            scopes: entry.scopes ? [...entry.scopes] : [],
+            claims: { principal: entry.principal },
+            type,
+        };
+        return context;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Trust source (b): per-service signed token (issuer-bound JWKS)
+// ---------------------------------------------------------------------------
+
+/** Resolve a value at a dot-notation path in an object. */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+    let current: unknown = obj;
+    for (const key of path.split(".")) {
+        if (current === null || current === undefined || typeof current !== "object") {
+            return undefined;
+        }
+        current = (current as Record<string, unknown>)[key];
+    }
+    return current;
+}
+
+/** Map verified token claims to roles/scopes/name per the issuer's claimsMapping. */
+function mapTokenClaims(
+    payload: jose.JWTPayload,
+    mapping: NonNullable<SignedTokenIssuer["claimsMapping"]> | undefined,
+): { name?: string; roles: string[]; scopes: string[]; subjectClaim?: string } {
+    const claims = payload as Record<string, unknown>;
+    const result: { name?: string; roles: string[]; scopes: string[]; subjectClaim?: string } = { roles: [], scopes: [] };
+    if (!mapping) {
+        // Default: scope claim (space-separated) if present.
+        if (typeof payload.scope === "string") {
+            result.scopes = payload.scope.split(" ").filter(Boolean);
+        }
+        return result;
+    }
+
+    if (mapping.subject) {
+        const val = getNestedValue(claims, mapping.subject);
+        if (typeof val === "string") result.subjectClaim = val;
+    }
+    if (mapping.name) {
+        const val = getNestedValue(claims, mapping.name);
+        if (typeof val === "string") result.name = val;
+    }
+    if (mapping.roles) {
+        const val = getNestedValue(claims, mapping.roles);
+        if (Array.isArray(val)) result.roles = val.filter((r): r is string => typeof r === "string");
+    }
+    if (mapping.scopes) {
+        const val = getNestedValue(claims, mapping.scopes);
+        if (typeof val === "string") result.scopes = val.split(" ").filter(Boolean);
+        else if (Array.isArray(val)) result.scopes = val.filter((s): s is string => typeof s === "string");
+    } else if (typeof payload.scope === "string") {
+        result.scopes = payload.scope.split(" ").filter(Boolean);
+    }
+
+    return result;
+}
+
+/** Strip an optional `Bearer ` prefix from a header value. */
+function stripBearer(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.toLowerCase().startsWith("bearer ")) {
+        return trimmed.slice(7).trim();
+    }
+    return trimmed;
+}
+
+/**
+ * Trust source that verifies a per-service signed JWT via issuer-bound JWKS
+ * (ADR-029 option (b) — non-mesh per-service containment, NOT a shared secret).
+ *
+ * Each caller signs a short-lived JWT with its OWN private key; this trust
+ * source verifies it against that service's published public key (JWKS).
+ * Compromising service A's key forges only A.
+ *
+ * **Hard security requirement — issuer-bound key selection (verified
+ * empirically with `jose`).** The keyset is selected by the token's claimed
+ * `iss` (`issuers[iss].jwksUri`), and `jose.jwtVerify` is pinned to that same
+ * `issuer`. Each issuer gets its OWN `createRemoteJWKSet` — no `jwtVerify` call
+ * ever receives a keyset containing more than one issuer's keys. A single shared
+ * JWKS holding multiple services' keys does NOT contain compromise: `jose`
+ * resolves the signing key by `kid` independently of the `iss` claim, so a token
+ * claiming `iss: "B"` signed with A's key (header `kid: kid_A`) would be accepted
+ * against a shared keyset. This per-issuer binding prevents that forge.
+ *
+ * The framework ships only the verification primitive; key issuance/rotation/
+ * JWKS publication belong to the deployment (SPIRE / the IdP / the mesh).
+ *
+ * @param options - Per-issuer JWKS configuration and the token header name.
+ * @returns An {@link InternalTrustSource}.
+ */
+export function signedTokenTrust(options: SignedTokenTrustOptions): InternalTrustSource {
+    const { issuers, header = "x-internal-token", type = "service" } = options;
+
+    const issuerKeys = Object.keys(issuers);
+    if (issuerKeys.length === 0) {
+        throw new Error("@connectum/auth: signedTokenTrust requires at least one issuer");
+    }
+
+    // One JWKSet per issuer (issuer-bound). NEVER a shared keyset across issuers.
+    const keysets = new Map<string, ReturnType<typeof jose.createRemoteJWKSet>>();
+    for (const iss of issuerKeys) {
+        const cfg = issuers[iss];
+        if (!cfg) continue;
+        keysets.set(iss, jose.createRemoteJWKSet(new URL(cfg.jwksUri)));
+    }
+
+    return async (req) => {
+        const raw = req.header.get(header);
+        // Strip the token header regardless of outcome (anti-spoofing).
+        req.header.delete(header);
+
+        if (!raw) {
+            return null;
+        }
+        const token = stripBearer(raw);
+        if (!token) {
+            return null;
+        }
+
+        // Selection only: read the claimed issuer WITHOUT trusting it.
+        let claimedIssuer: string | undefined;
+        try {
+            claimedIssuer = jose.decodeJwt(token).iss;
+        } catch {
+            return null;
+        }
+        if (typeof claimedIssuer !== "string") {
+            return null;
+        }
+
+        const cfg = issuers[claimedIssuer];
+        const keyset = keysets.get(claimedIssuer);
+        if (!cfg || !keyset) {
+            // Unknown / unconfigured issuer.
+            return null;
+        }
+
+        // Verify against ONLY this issuer's keyset, pinned to this same issuer.
+        // The `issuer` pin makes the iss claim load-bearing; the per-issuer
+        // keyset makes the kid load-bearing within that one issuer only.
+        const verifyOptions: jose.JWTVerifyOptions = {
+            issuer: claimedIssuer,
+            algorithms: cfg.algorithms ?? ["RS256"],
+        };
+        if (cfg.audience !== undefined) verifyOptions.audience = cfg.audience;
+        if (cfg.maxTokenAge !== undefined) verifyOptions.maxTokenAge = cfg.maxTokenAge;
+
+        let payload: jose.JWTPayload;
+        try {
+            ({ payload } = await jose.jwtVerify(token, keyset, verifyOptions));
+        } catch {
+            // Bad signature, no matching key, expired, wrong issuer, etc.
+            return null;
+        }
+
+        const mapped = mapTokenClaims(payload, cfg.claimsMapping);
+        // Subject from the VERIFIED payload: explicit subject claim, else sub, else iss.
+        const subject = mapped.subjectClaim ?? payload.sub ?? claimedIssuer;
+
+        const context: AuthContext = {
+            subject,
+            name: mapped.name,
+            roles: mapped.roles,
+            scopes: mapped.scopes,
+            claims: payload as Record<string, unknown>,
+            type,
+            expiresAt: payload.exp ? new Date(payload.exp * 1000) : undefined,
+        };
+        return context;
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Trust source (c): shared secret (DEV ONLY)
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time string comparison.
+ *
+ * `crypto.timingSafeEqual` throws on unequal-length buffers, which is itself a
+ * length oracle. Comparing SHA-256 digests (always 32 bytes) removes that:
+ * the digests are fixed-length and a mismatch is indistinguishable in time.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+    const enc = new TextEncoder();
+    // Hash to fixed length (32 bytes) so timingSafeEqual never sees unequal-length
+    // inputs — comparing the raw strings would throw on a length mismatch, which
+    // is itself a length oracle. SHA-256 digests are always equal length, so a
+    // mismatch is indistinguishable in time.
+    const da = createHash("sha256").update(enc.encode(a)).digest();
+    const db = createHash("sha256").update(enc.encode(b)).digest();
+    return timingSafeEqual(da, db);
+}
+
+/**
+ * Trust source that constant-time compares a single shared secret (ADR-029
+ * option (c)).
+ *
+ * **DEV-ONLY.** A single shared secret is NOT per-service: every legitimate
+ * caller holds the same secret, so one compromise forges ALL internal
+ * identities. Use {@link meshIdentityTrust} (mesh) or {@link signedTokenTrust}
+ * (non-mesh per-service JWT) in production. This factory exists only for local
+ * development and single-tenant low-trust-boundary setups, and is labeled as
+ * such so it is never mistaken for a containment-providing mode.
+ *
+ * @param options - The shared secret, header name, and the granted identity.
+ * @returns An {@link InternalTrustSource}.
+ */
+export function sharedSecretTrust(options: SharedSecretTrustOptions): InternalTrustSource {
+    const { secret, header = "x-internal-secret", subject = "internal", roles, scopes, type = "internal" } = options;
+
+    if (!secret) {
+        throw new Error("@connectum/auth: sharedSecretTrust requires a non-empty secret");
+    }
+
+    return (req) => {
+        const value = req.header.get(header);
+        // Strip the secret header regardless of outcome (anti-spoofing).
+        req.header.delete(header);
+
+        if (!value || !constantTimeEqual(value, secret)) {
+            return null;
+        }
+
+        const context: AuthContext = {
+            subject,
+            roles: roles ? [...roles] : [],
+            scopes: scopes ? [...scopes] : [],
+            claims: {},
+            type,
+        };
+        return context;
+    };
+}

--- a/packages/auth/src/proto/index.ts
+++ b/packages/auth/src/proto/index.ts
@@ -15,4 +15,4 @@ export { AuthRequirementsSchema, MethodAuthSchema, method_auth, ServiceAuthSchem
 export { createProtoAuthzInterceptor } from "./proto-authz-interceptor.ts";
 export type { ResolvedMethodAuth } from "./reader.ts";
 // Re-export reader utilities
-export { getPublicMethods, resolveMethodAuth } from "./reader.ts";
+export { getInternalMethods, getPublicMethods, resolveMethodAuth } from "./reader.ts";

--- a/packages/auth/src/proto/proto-authz-interceptor.ts
+++ b/packages/auth/src/proto/proto-authz-interceptor.ts
@@ -82,21 +82,28 @@ function evaluateRules(
  *
  * Authorization decision flow:
  * ```
- * 1. resolveMethodAuth(req.method)  -- read proto options
- * 2. public = true                  --> skip (allow without authn)
- * 3. Get auth context               -- lazy: don't throw yet
- * 4. requires defined, no context   --> throw Unauthenticated
- * 4b. requires defined, has context --> satisfiesRequirements? allow : deny
- * 5. policy = "allow"              --> allow
- * 6. policy = "deny"               --> deny
- * 7. Evaluate programmatic rules   -- unconditional rules work without context
- * 8. Fallback: authorize callback  --> requires auth context
- * 9. Apply defaultPolicy           --> deny without context = Unauthenticated
+ * 1.  resolveMethodAuth(req.method)  -- read proto options
+ * 2.  public = true                  --> skip (allow without authn)
+ * 3.  Get auth context               -- lazy: don't throw yet
+ * 3b. internal = true:               -- service-to-service (ADR-029)
+ *       no context                   --> throw Unauthenticated
+ *       no requires                  --> allow (any trusted internal caller)
+ *       has requires                 --> fall through to step 4 (inclusive roles)
+ * 4.  requires defined, no context   --> throw Unauthenticated
+ * 4b. requires defined, has context  --> satisfiesRequirements? allow : deny
+ * 5.  policy = "allow"              --> allow
+ * 6.  policy = "deny"               --> deny
+ * 7.  Evaluate programmatic rules   -- unconditional rules work without context
+ * 8.  Fallback: authorize callback  --> requires auth context
+ * 9.  Apply defaultPolicy           --> deny without context = Unauthenticated
  * ```
  *
  * IMPORTANT: This interceptor MUST run AFTER an authentication interceptor
  * in the chain (except for methods marked as `public` in proto options
- * or matched by unconditional programmatic rules).
+ * or matched by unconditional programmatic rules). For `internal` methods the
+ * upstream interceptor is {@link createInternalAuthInterceptor}; the chain order
+ * is `errorHandler -> (jwtAuth | internalAuth) -> protoAuthz` — the auth
+ * interceptors populate the `AuthContext` that this interceptor consumes.
  *
  * @param options - Proto authorization interceptor options
  * @returns ConnectRPC interceptor
@@ -139,6 +146,22 @@ export function createProtoAuthzInterceptor(options: ProtoAuthzInterceptorOption
 
         // Step 3: Get auth context (lazy -- don't throw yet, only when actually needed)
         const authContext = getAuthContext();
+
+        // Step 3b: Internal (service-to-service) methods (ADR-029).
+        // The internal identity is populated upstream by createInternalAuthInterceptor.
+        // Compose inclusively with the existing model: an internal method with no
+        // `requires` is reachable by any trusted internal caller; an internal method
+        // WITH `requires` falls through to the existing step-4 roles/scopes check
+        // against the same AuthContext (one model, no parallel requires_identity).
+        if (resolved.internal) {
+            if (!authContext) {
+                throw new ConnectError("Authentication required for authorization", Code.Unauthenticated);
+            }
+            if (resolved.requires === undefined) {
+                return await next(req);
+            }
+            // else: fall through to step 4 requires check (inclusive role composition)
+        }
 
         // Step 4: Check proto requirements (roles/scopes)
         if (resolved.requires !== undefined) {

--- a/packages/auth/src/proto/reader.ts
+++ b/packages/auth/src/proto/reader.ts
@@ -20,6 +20,12 @@ import { MethodAuthSchema, method_auth, ServiceAuthSchema, service_auth } from "
 export interface ResolvedMethodAuth {
     /** Whether the method is public (skip authn + authz). */
     readonly public: boolean;
+    /**
+     * Whether the method is internal (service-to-service): skip end-user (JWT)
+     * authentication, but require an internal trust marker established by
+     * {@link createInternalAuthInterceptor}. Distinct from `public`. See ADR-029.
+     */
+    readonly internal: boolean;
     /** Authorization policy: "allow", "deny", or undefined (use interceptor default). */
     readonly policy: "allow" | "deny" | undefined;
     /** Required roles and scopes, or undefined if none specified. */
@@ -39,6 +45,7 @@ const resolvedCache = new WeakMap<DescMethod, ResolvedMethodAuth>();
  */
 const DEFAULT_RESOLVED: ResolvedMethodAuth = {
     public: false,
+    internal: false,
     policy: undefined,
     requires: undefined,
 };
@@ -54,7 +61,8 @@ const DEFAULT_RESOLVED: ResolvedMethodAuth = {
  *
  * Priority (method overrides service):
  * ```
- * method.public       -> service.public        -> false
+ * method.public       -> service.public           -> false
+ * method.internal     -> service.internal         -> false
  * method.requires     -> service.default_requires -> undefined
  * method.policy       -> service.default_policy    -> undefined
  * ```
@@ -99,6 +107,11 @@ function computeMethodAuth(method: DescMethod): ResolvedMethodAuth {
     const servicePublicSet = svcAuth !== undefined && isFieldSet(svcAuth, ServiceAuthSchema.field.public);
     const isPublic = methodPublicSet ? mtdAuth?.public === true : servicePublicSet ? svcAuth?.public === true : false;
 
+    // Resolve `internal` field with the same presence-aware override logic as `public`.
+    const methodInternalSet = mtdAuth !== undefined && isFieldSet(mtdAuth, MethodAuthSchema.field.internal);
+    const serviceInternalSet = svcAuth !== undefined && isFieldSet(svcAuth, ServiceAuthSchema.field.internal);
+    const isInternal = methodInternalSet ? mtdAuth?.internal === true : serviceInternalSet ? svcAuth?.internal === true : false;
+
     // Resolve `requires` field.
     // Method-level requires overrides service-level default_requires.
     // A submessage field is undefined when not set in proto2.
@@ -125,7 +138,7 @@ function computeMethodAuth(method: DescMethod): ResolvedMethodAuth {
         policy = normalizePolicy(svcAuth.defaultPolicy);
     }
 
-    return { public: isPublic, policy, requires };
+    return { public: isPublic, internal: isInternal, policy, requires };
 }
 
 /**
@@ -169,6 +182,50 @@ export function getPublicMethods(services: readonly DescService[]): string[] {
         for (const method of service.methods) {
             const resolved = resolveMethodAuth(method);
             if (resolved.public) {
+                patterns.push(`${service.typeName}/${method.name}`);
+            }
+        }
+    }
+
+    return patterns;
+}
+
+/**
+ * Get the list of internal method patterns from a set of service descriptors.
+ *
+ * Iterates over all methods in the given services, resolves their auth
+ * configuration, and returns patterns for methods marked as `internal`.
+ *
+ * Mirrors {@link getPublicMethods}. Internal methods skip end-user (JWT)
+ * authentication — feed these into the JWT auth interceptor's `skipMethods`
+ * exactly like public methods — but, unlike public methods, they still require
+ * an internal trust marker established by {@link createInternalAuthInterceptor}.
+ *
+ * The returned patterns follow the `"service.typeName/method.name"` format
+ * used by `skipMethods` in auth interceptors.
+ *
+ * @param services - Service descriptors to scan
+ * @returns Array of method patterns in `"ServiceTypeName/MethodName"` format
+ *
+ * @example
+ * ```typescript
+ * import { getInternalMethods, getPublicMethods } from '@connectum/auth/proto';
+ *
+ * // JWT auth skips both public and internal methods;
+ * // the internal interceptor then enforces the trust marker on internal ones.
+ * const jwtAuth = createJwtAuthInterceptor({
+ *   jwksUri: '...',
+ *   skipMethods: [...getPublicMethods(services), ...getInternalMethods(services)],
+ * });
+ * ```
+ */
+export function getInternalMethods(services: readonly DescService[]): string[] {
+    const patterns: string[] = [];
+
+    for (const service of services) {
+        for (const method of service.methods) {
+            const resolved = resolveMethodAuth(method);
+            if (resolved.internal) {
                 patterns.push(`${service.typeName}/${method.name}`);
             }
         }

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -319,6 +319,163 @@ export interface GatewayAuthInterceptorOptions {
 }
 
 /**
+ * A pluggable internal trust source (ADR-029).
+ *
+ * Given the incoming request, returns an {@link AuthContext} for the calling
+ * service when the internal trust marker is present and valid, or `null` when
+ * it is missing/invalid. {@link createInternalAuthInterceptor} converts `null`
+ * (and any thrown error from the trust source) into `Code.Unauthenticated`.
+ *
+ * The returned `AuthContext.subject` is the service identity; `roles`/`scopes`
+ * come from the trust source (allow-list entry or verified token claims) so the
+ * call composes with the existing `requires {roles,scopes}` authz model.
+ *
+ * @param req - The request (read-only access to headers).
+ * @returns AuthContext for a trusted internal caller, or null to reject.
+ */
+export type InternalTrustSource = (req: { header: Headers }) => AuthContext | null | Promise<AuthContext | null>;
+
+/**
+ * Options for {@link createInternalAuthInterceptor}.
+ */
+export interface InternalAuthInterceptorOptions {
+    /**
+     * The trust source that authorizes an internal call.
+     *
+     * Use one of the provided factories — {@link meshIdentityTrust} (production
+     * default, per-service via the mesh), {@link signedTokenTrust} (non-mesh,
+     * per-service JWT/JWKS with mandatory issuer-bound key selection), or
+     * {@link sharedSecretTrust} (dev-only fallback) — or supply a custom one.
+     */
+    readonly trustSource: InternalTrustSource;
+    /**
+     * Method patterns that are internal (service-to-service). Typically the
+     * output of `getInternalMethods(services)`. The interceptor enforces the
+     * trust marker only on these methods; all other methods pass through
+     * unchanged (no-op).
+     *
+     * Patterns: `"Service/Method"`, `"Service/*"`, or `"*"`.
+     */
+    readonly internalMethods: readonly string[];
+}
+
+/**
+ * An allow-list entry for {@link meshIdentityTrust}, mapping a verified mesh
+ * identity (the forwarded peer principal) to its authorization context.
+ */
+export interface MeshIdentityEntry {
+    /**
+     * The mesh-forwarded peer identity to match, e.g. an Istio short-form
+     * ServiceAccount principal `cluster.local/ns/<ns>/sa/<name>` or a SPIFFE id.
+     */
+    readonly principal: string;
+    /** Roles granted to this caller (compose via `requires {roles}`). */
+    readonly roles?: readonly string[] | undefined;
+    /** Scopes granted to this caller (compose via `requires {scopes}`). */
+    readonly scopes?: readonly string[] | undefined;
+    /** Optional human-readable name for the calling service. */
+    readonly name?: string | undefined;
+}
+
+/**
+ * Options for {@link meshIdentityTrust}.
+ */
+export interface MeshIdentityTrustOptions {
+    /**
+     * Allow-list of permitted mesh identities. Each entry maps a forwarded peer
+     * principal to its roles/scopes. A request whose identity is not on the
+     * list is rejected.
+     */
+    readonly allowlist: readonly MeshIdentityEntry[];
+    /**
+     * Header carrying the mesh-forwarded peer identity.
+     * @default "x-forwarded-client-principal"
+     */
+    readonly header?: string | undefined;
+    /** Credential type set on the resulting AuthContext. @default "mesh" */
+    readonly type?: string | undefined;
+}
+
+/**
+ * Per-issuer JWKS configuration for {@link signedTokenTrust}.
+ *
+ * The JWKS lookup is issuer-bound: the keyset is selected by the token's `iss`
+ * claim and verification is pinned to that same issuer. This is a hard security
+ * requirement — a single shared JWKS holding multiple services' keys does NOT
+ * contain compromise (jose resolves the key by `kid` independently of `iss`).
+ */
+export interface SignedTokenIssuer {
+    /** The issuer's JWKS endpoint URL (its own keyset only). */
+    readonly jwksUri: string;
+    /** Expected audience(s) for tokens from this issuer. */
+    readonly audience?: string | string[] | undefined;
+    /** Allowed signing algorithms. @default ["RS256"] */
+    readonly algorithms?: string[] | undefined;
+    /** Maximum token age (seconds or string like "2h"). */
+    readonly maxTokenAge?: number | string | undefined;
+    /**
+     * Mapping from token claims to AuthContext fields (dot-notation paths).
+     * `subject` defaults to `sub ?? iss`; `roles`/`scopes` to none unless mapped.
+     */
+    readonly claimsMapping?:
+        | {
+              readonly subject?: string | undefined;
+              readonly name?: string | undefined;
+              readonly roles?: string | undefined;
+              readonly scopes?: string | undefined;
+          }
+        | undefined;
+}
+
+/**
+ * Options for {@link signedTokenTrust}.
+ */
+export interface SignedTokenTrustOptions {
+    /**
+     * Per-issuer configuration keyed by the issuer (`iss`) value. The keyset is
+     * selected by the token's claimed issuer and verification is pinned to that
+     * same issuer — never a single shared keyset across issuers.
+     */
+    readonly issuers: Readonly<Record<string, SignedTokenIssuer>>;
+    /**
+     * Header carrying the service token. The value may be a bare token or a
+     * `Bearer <token>` value.
+     * @default "x-internal-token"
+     */
+    readonly header?: string | undefined;
+    /** Credential type set on the resulting AuthContext. @default "service" */
+    readonly type?: string | undefined;
+}
+
+/**
+ * Options for {@link sharedSecretTrust}.
+ *
+ * DEV-ONLY: a single shared secret is NOT per-service — one compromise forges
+ * all callers. Use {@link meshIdentityTrust} or {@link signedTokenTrust} in
+ * production. See ADR-029.
+ */
+export interface SharedSecretTrustOptions {
+    /** The shared secret, constant-time compared against the header value. */
+    readonly secret: string;
+    /**
+     * Header carrying the shared secret.
+     * @default "x-internal-secret"
+     */
+    readonly header?: string | undefined;
+    /**
+     * Subject identity assigned to a trusted call.
+     * @default "internal"
+     */
+    readonly subject?: string | undefined;
+    /** Roles granted to a trusted caller. */
+    readonly roles?: readonly string[] | undefined;
+    /** Scopes granted to a trusted caller. */
+    readonly scopes?: readonly string[] | undefined;
+    /** Credential type set on the resulting AuthContext. @default "internal" */
+    readonly type?: string | undefined;
+}
+
+/**
  * Session-based auth interceptor options.
  *
  * Two-step authentication: verify session token, then map session data to AuthContext.

--- a/packages/auth/tests/helpers/proto-test-helpers.ts
+++ b/packages/auth/tests/helpers/proto-test-helpers.ts
@@ -68,7 +68,7 @@ export function createFakeMethod(service: DescService, name: string, methodOptio
  * @param authConfig - Auth configuration for the method.
  * @returns Protobuf MethodOptions with the method_auth extension.
  */
-export function createMethodOptions(authConfig: { public?: boolean; policy?: string; requires?: { roles?: string[]; scopes?: string[] } }) {
+export function createMethodOptions(authConfig: { public?: boolean; internal?: boolean; policy?: string; requires?: { roles?: string[]; scopes?: string[] } }) {
     const opts = create(MethodOptionsSchema);
     const init: Record<string, unknown> = {
         policy: authConfig.policy ?? "",
@@ -76,6 +76,10 @@ export function createMethodOptions(authConfig: { public?: boolean; policy?: str
     // Only set public when explicitly provided to preserve proto2 field presence semantics
     if (authConfig.public !== undefined) {
         init.public = authConfig.public;
+    }
+    // Only set internal when explicitly provided (proto2 field presence semantics)
+    if (authConfig.internal !== undefined) {
+        init.internal = authConfig.internal;
     }
     if (authConfig.requires) {
         init.requires = create(AuthRequirementsSchema, {
@@ -98,7 +102,7 @@ export function createMethodOptions(authConfig: { public?: boolean; policy?: str
  * @param authConfig - Auth configuration for the service.
  * @returns Protobuf ServiceOptions with the service_auth extension.
  */
-export function createServiceOptions(authConfig: { defaultPolicy?: string; public?: boolean; defaultRequires?: { roles?: string[]; scopes?: string[] } }) {
+export function createServiceOptions(authConfig: { defaultPolicy?: string; public?: boolean; internal?: boolean; defaultRequires?: { roles?: string[]; scopes?: string[] } }) {
     const opts = create(ServiceOptionsSchema);
     const init: Record<string, unknown> = {
         defaultPolicy: authConfig.defaultPolicy ?? "",
@@ -106,6 +110,10 @@ export function createServiceOptions(authConfig: { defaultPolicy?: string; publi
     // Only set public when explicitly provided to preserve proto2 field presence semantics
     if (authConfig.public !== undefined) {
         init.public = authConfig.public;
+    }
+    // Only set internal when explicitly provided (proto2 field presence semantics)
+    if (authConfig.internal !== undefined) {
+        init.internal = authConfig.internal;
     }
     if (authConfig.defaultRequires) {
         init.defaultRequires = create(AuthRequirementsSchema, {

--- a/packages/auth/tests/integration/internal-auth-chain.test.ts
+++ b/packages/auth/tests/integration/internal-auth-chain.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Integration tests for the INTERNAL AUTH -> PROTO AUTHZ interceptor chain (ADR-029).
+ *
+ * Exercises the LOAD-BEARING seam: createInternalAuthInterceptor must run
+ * BEFORE createProtoAuthzInterceptor and populate the AuthContext that
+ * proto-authz's `internal` rule consumes (`errorHandler -> internalAuth ->
+ * protoAuthz`). The unit tests cover each half in isolation; these tests prove
+ * the two compose correctly end-to-end with the real interceptors chained.
+ */
+
+import assert from "node:assert";
+import { describe, it, mock } from "node:test";
+import { Code } from "@connectrpc/connect";
+import { assertConnectError } from "@connectum/testing";
+import { getAuthContext } from "../../src/context.ts";
+import { createInternalAuthInterceptor, meshIdentityTrust } from "../../src/internal-auth-interceptor.ts";
+import { createProtoAuthzInterceptor } from "../../src/proto/proto-authz-interceptor.ts";
+import type { AuthContext } from "../../src/types.ts";
+import { buildChainedHandler } from "../helpers/mock-request.ts";
+import { createFakeMethod, createFakeService, createMethodOptions, createProtoMockRequest } from "../helpers/proto-test-helpers.ts";
+
+const PRINCIPAL = "cluster.local/ns/default/sa/trips";
+const PRINCIPAL_HEADER = "x-forwarded-client-principal";
+
+describe("Internal Auth Chain (INTERNAL AUTH -> PROTO AUTHZ) — Integration (ADR-029)", () => {
+    // service has default_policy deny so an internal method MUST be allowed by
+    // the internal rule, not by any default-allow shortcut.
+    const service = createFakeService({ typeName: "trips.v1.TripService" });
+    const internalMethod = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true }), { register: true });
+    const internalGatedMethod = createFakeMethod(service, "EndTrip", createMethodOptions({ internal: true, requires: { roles: ["worker"] } }), { register: true });
+
+    function chain(allowlist: Parameters<typeof meshIdentityTrust>[0]["allowlist"]) {
+        const internalAuth = createInternalAuthInterceptor({
+            internalMethods: ["trips.v1.TripService/RecordTrip", "trips.v1.TripService/EndTrip"],
+            trustSource: meshIdentityTrust({ allowlist }),
+        });
+        const protoAuthz = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+        return { internalAuth, protoAuthz };
+    }
+
+    it("positive: allow-listed principal flows identity through the chain to the handler", async () => {
+        const { internalAuth, protoAuthz } = chain([{ principal: PRINCIPAL, roles: ["worker"], scopes: ["trip:write"] }]);
+
+        let seenInHandler: AuthContext | undefined;
+        const next = mock.fn(async () => {
+            seenInHandler = getAuthContext();
+            return { message: {} };
+        });
+        const handler = buildChainedHandler(internalAuth, protoAuthz, next);
+
+        const req = createProtoMockRequest(service, internalMethod, new Headers({ [PRINCIPAL_HEADER]: PRINCIPAL }));
+        await handler(req);
+
+        assert.strictEqual(next.mock.calls.length, 1, "handler reached through the real chain");
+        // Identity set by the internal interceptor is visible in the handler
+        // (proves internalAuth ran before protoAuthz and the store propagated).
+        assert.strictEqual(seenInHandler?.subject, PRINCIPAL);
+        assert.deepStrictEqual([...(seenInHandler?.roles ?? [])], ["worker"]);
+        assert.strictEqual(seenInHandler?.type, "mesh");
+    });
+
+    it("negative: no principal header -> Unauthenticated, handler not reached", async () => {
+        const { internalAuth, protoAuthz } = chain([{ principal: PRINCIPAL, roles: ["worker"] }]);
+        const next = mock.fn(async () => ({ message: {} }));
+        const handler = buildChainedHandler(internalAuth, protoAuthz, next);
+
+        const req = createProtoMockRequest(service, internalMethod); // no headers
+        await assert.rejects(
+            () => handler(req),
+            (err: unknown) => {
+                assertConnectError(err, Code.Unauthenticated);
+                return true;
+            },
+        );
+        assert.strictEqual(next.mock.calls.length, 0);
+    });
+
+    it("inclusive roles (real chain): internal + requires{worker}, caller has worker -> allowed", async () => {
+        const { internalAuth, protoAuthz } = chain([{ principal: PRINCIPAL, roles: ["worker"] }]);
+        const next = mock.fn(async () => ({ message: {} }));
+        const handler = buildChainedHandler(internalAuth, protoAuthz, next);
+
+        const req = createProtoMockRequest(service, internalGatedMethod, new Headers({ [PRINCIPAL_HEADER]: PRINCIPAL }));
+        await handler(req);
+
+        assert.strictEqual(next.mock.calls.length, 1);
+    });
+
+    it("inclusive roles (real chain): internal + requires{worker}, caller lacks worker -> PermissionDenied", async () => {
+        // Allow-listed (so identity is established) but WITHOUT the required role.
+        const { internalAuth, protoAuthz } = chain([{ principal: PRINCIPAL, roles: ["viewer"] }]);
+        const next = mock.fn(async () => ({ message: {} }));
+        const handler = buildChainedHandler(internalAuth, protoAuthz, next);
+
+        const req = createProtoMockRequest(service, internalGatedMethod, new Headers({ [PRINCIPAL_HEADER]: PRINCIPAL }));
+        await assert.rejects(
+            () => handler(req),
+            (err: unknown) => {
+                assert.ok(err instanceof Error);
+                assert.strictEqual((err as Error).name, "AuthzDeniedError");
+                assert.strictEqual((err as { code?: unknown }).code, Code.PermissionDenied);
+                return true;
+            },
+        );
+        assert.strictEqual(next.mock.calls.length, 0);
+    });
+});

--- a/packages/auth/tests/unit/internal-auth-interceptor.test.ts
+++ b/packages/auth/tests/unit/internal-auth-interceptor.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for the internal (service-to-service) auth interceptor (ADR-029).
+ *
+ * Covers:
+ * - per-service containment: an A-signed token claiming `iss: B` is REJECTED
+ *   (the empirical issuer-bound JWKS finding from ADR-029 §2);
+ * - meshIdentityTrust allow-list (allow / deny + header stripping);
+ * - signedTokenTrust happy path and identity binding;
+ * - sharedSecretTrust constant-time compare;
+ * - no-marker -> Unauthenticated; non-internal method -> no-op pass-through.
+ */
+
+import assert from "node:assert";
+import { after, before, describe, it } from "node:test";
+import { Code } from "@connectrpc/connect";
+import { assertConnectError, createMockNext, createMockRequest } from "@connectum/testing";
+import { getAuthContext } from "../../src/context.ts";
+import { createInternalAuthInterceptor, meshIdentityTrust, sharedSecretTrust, signedTokenTrust } from "../../src/internal-auth-interceptor.ts";
+import { createTestJwtRS256, generateRsaTestKeypair, type RsaTestKeypair, startTestJwksServer, type TestJwksServer } from "../../src/testing/test-jwt-rs256.ts";
+import type { AuthContext } from "../../src/types.ts";
+
+const SERVICE = "trips.v1.TripService";
+const INTERNAL_METHOD = "RecordTrip";
+const INTERNAL_PATTERN = `${SERVICE}/${INTERNAL_METHOD}`;
+
+/** Build a mock request for the internal method, with optional headers. */
+function internalReq(headers?: Headers) {
+    return createMockRequest(headers ? { service: SERVICE, method: INTERNAL_METHOD, headers } : { service: SERVICE, method: INTERNAL_METHOD });
+}
+
+/** Capture the AuthContext seen inside next(). */
+function capturingNext() {
+    let seen: AuthContext | undefined;
+    const next = createMockNext();
+    const wrapped = async (req: unknown) => {
+        seen = getAuthContext();
+        return next(req);
+    };
+    return { next: wrapped, getSeen: () => seen, calls: () => next.mock.calls.length };
+}
+
+describe("internal-auth-interceptor", () => {
+    describe("non-internal methods", () => {
+        it("passes through untouched (no-op) when the method is not in internalMethods", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: () => null, // would reject everything if it ran
+            });
+            const cap = capturingNext();
+            const handler = interceptor(cap.next as never);
+            // A DIFFERENT method, not internal.
+            const req = createMockRequest({ service: SERVICE, method: "PublicProbe" });
+
+            await handler(req);
+
+            assert.strictEqual(cap.calls(), 1, "next() called");
+            assert.strictEqual(cap.getSeen(), undefined, "no AuthContext set for non-internal method");
+        });
+    });
+
+    describe("missing / invalid marker", () => {
+        it("rejects an internal call with no trust marker as Unauthenticated", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: sharedSecretTrust({ secret: "s3cr3t-value-32-bytes-minimum-xx" }),
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            await assert.rejects(
+                () => handler(internalReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+
+        it("maps a throwing trust source to Unauthenticated (never leaks as Internal)", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: () => {
+                    throw new Error("boom from trust source");
+                },
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            await assert.rejects(
+                () => handler(internalReq()),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+    });
+
+    describe("meshIdentityTrust", () => {
+        const PRINCIPAL = "cluster.local/ns/default/sa/trips";
+
+        it("allows an allow-listed principal and sets its roles", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: meshIdentityTrust({
+                    allowlist: [{ principal: PRINCIPAL, roles: ["worker"], scopes: ["trip:write"] }],
+                }),
+            });
+            const cap = capturingNext();
+            const handler = interceptor(cap.next as never);
+
+            const headers = new Headers({ "x-forwarded-client-principal": PRINCIPAL });
+            await handler(internalReq(headers));
+
+            assert.strictEqual(cap.calls(), 1);
+            const ctx = cap.getSeen();
+            assert.ok(ctx, "AuthContext set");
+            assert.strictEqual(ctx?.subject, PRINCIPAL);
+            assert.deepStrictEqual([...(ctx?.roles ?? [])], ["worker"]);
+            assert.deepStrictEqual([...(ctx?.scopes ?? [])], ["trip:write"]);
+            assert.strictEqual(ctx?.type, "mesh");
+            // Identity header stripped (anti-spoofing).
+            assert.strictEqual(headers.get("x-forwarded-client-principal"), null);
+        });
+
+        it("rejects a non-allow-listed principal as Unauthenticated", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: meshIdentityTrust({ allowlist: [{ principal: PRINCIPAL, roles: ["worker"] }] }),
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            const headers = new Headers({ "x-forwarded-client-principal": "cluster.local/ns/default/sa/evil" });
+            await assert.rejects(
+                () => handler(internalReq(headers)),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+            // Header stripped even on rejection.
+            assert.strictEqual(headers.get("x-forwarded-client-principal"), null);
+        });
+    });
+
+    describe("sharedSecretTrust (dev-only)", () => {
+        const SECRET = "dev-only-shared-secret-please-rotate";
+
+        it("allows a matching secret and assigns the configured identity", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: sharedSecretTrust({ secret: SECRET, subject: "internal-dev", roles: ["dev"] }),
+            });
+            const cap = capturingNext();
+            const handler = interceptor(cap.next as never);
+
+            const headers = new Headers({ "x-internal-secret": SECRET });
+            await handler(internalReq(headers));
+
+            assert.strictEqual(cap.calls(), 1);
+            const ctx = cap.getSeen();
+            assert.strictEqual(ctx?.subject, "internal-dev");
+            assert.deepStrictEqual([...(ctx?.roles ?? [])], ["dev"]);
+            assert.strictEqual(headers.get("x-internal-secret"), null, "secret header stripped");
+        });
+
+        it("rejects a mismatched secret (and a length mismatch does not throw a length oracle)", async () => {
+            const interceptor = createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: sharedSecretTrust({ secret: SECRET }),
+            });
+            const next = createMockNext();
+            const handler = interceptor(next);
+
+            for (const bad of ["wrong", `${SECRET}x`, ""]) {
+                const headers = new Headers(bad === "" ? {} : { "x-internal-secret": bad });
+                await assert.rejects(
+                    () => handler(internalReq(headers)),
+                    (err: unknown) => {
+                        assertConnectError(err, Code.Unauthenticated);
+                        return true;
+                    },
+                );
+            }
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+    });
+
+    describe("signedTokenTrust — per-service issuer-bound JWKS", () => {
+        const ISS_A = "service-a";
+        const ISS_B = "service-b";
+        const AUDIENCE = "internal-api";
+
+        let kpA: RsaTestKeypair;
+        let kpB: RsaTestKeypair;
+        let jwksA: TestJwksServer;
+        let jwksB: TestJwksServer;
+
+        before(async () => {
+            // DISTINCT kids per issuer — load-bearing for the containment test:
+            // the forged token carries header kid = kid_A while claiming iss = B.
+            kpA = await generateRsaTestKeypair("kid-service-a");
+            kpB = await generateRsaTestKeypair("kid-service-b");
+            jwksA = await startTestJwksServer(kpA.publicJwk);
+            jwksB = await startTestJwksServer(kpB.publicJwk);
+        });
+
+        after(async () => {
+            await jwksA.close();
+            await jwksB.close();
+        });
+
+        function buildInterceptor() {
+            return createInternalAuthInterceptor({
+                internalMethods: [INTERNAL_PATTERN],
+                trustSource: signedTokenTrust({
+                    issuers: {
+                        [ISS_A]: { jwksUri: jwksA.url, audience: AUDIENCE, algorithms: ["RS256"], claimsMapping: { roles: "roles" } },
+                        [ISS_B]: { jwksUri: jwksB.url, audience: AUDIENCE, algorithms: ["RS256"], claimsMapping: { roles: "roles" } },
+                    },
+                }),
+            });
+        }
+
+        it("accepts a correctly self-signed B token and binds identity to B", async () => {
+            const token = await createTestJwtRS256(kpB.privateKey, { sub: ISS_B, roles: ["worker"] }, { kid: kpB.kid, issuer: ISS_B, audience: AUDIENCE });
+
+            const cap = capturingNext();
+            const handler = buildInterceptor()(cap.next as never);
+            const headers = new Headers({ "x-internal-token": token });
+
+            await handler(internalReq(headers));
+
+            assert.strictEqual(cap.calls(), 1, "self-signed B token accepted");
+            const ctx = cap.getSeen();
+            assert.strictEqual(ctx?.subject, ISS_B, "identity bound to B");
+            assert.strictEqual(ctx?.claims.iss, ISS_B);
+            assert.deepStrictEqual([...(ctx?.roles ?? [])], ["worker"]);
+            assert.strictEqual(headers.get("x-internal-token"), null, "token header stripped");
+        });
+
+        // ====================================================================
+        // HEADLINE CONTAINMENT TEST (ADR-029 §2 empirical finding):
+        // A token claiming iss:B but signed with A's private key (header kid_A)
+        // MUST be rejected as Unauthenticated. With issuer-bound JWKS, the iss:B
+        // claim selects B's keyset (kid_B only) -> ERR_JWKS_NO_MATCHING_KEY.
+        // ====================================================================
+        it("REJECTS an A-signed token forged to claim iss:B (per-service containment)", async () => {
+            // Signed with A's PRIVATE key, header kid = kid_A, but claims iss = B.
+            const forged = await createTestJwtRS256(
+                kpA.privateKey,
+                { sub: ISS_B, roles: ["admin"] },
+                { kid: kpA.kid, issuer: ISS_B, audience: AUDIENCE },
+            );
+
+            const next = createMockNext();
+            const handler = buildInterceptor()(next);
+            const headers = new Headers({ "x-internal-token": forged });
+
+            await assert.rejects(
+                () => handler(internalReq(headers)),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0, "forged A-as-B token never reaches the handler");
+        });
+
+        it("also rejects the reverse forge (B-signed token claiming iss:A)", async () => {
+            const forged = await createTestJwtRS256(kpB.privateKey, { sub: ISS_A, roles: ["admin"] }, { kid: kpB.kid, issuer: ISS_A, audience: AUDIENCE });
+
+            const next = createMockNext();
+            const handler = buildInterceptor()(next);
+            const headers = new Headers({ "x-internal-token": forged });
+
+            await assert.rejects(
+                () => handler(internalReq(headers)),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+
+        it("rejects a token from an unconfigured issuer", async () => {
+            const token = await createTestJwtRS256(kpA.privateKey, { sub: "service-c" }, { kid: kpA.kid, issuer: "service-c", audience: AUDIENCE });
+
+            const next = createMockNext();
+            const handler = buildInterceptor()(next);
+            const headers = new Headers({ "x-internal-token": token });
+
+            await assert.rejects(
+                () => handler(internalReq(headers)),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+
+        it("accepts a Bearer-prefixed token value", async () => {
+            const token = await createTestJwtRS256(kpA.privateKey, { sub: ISS_A }, { kid: kpA.kid, issuer: ISS_A, audience: AUDIENCE });
+
+            const cap = capturingNext();
+            const handler = buildInterceptor()(cap.next as never);
+            const headers = new Headers({ "x-internal-token": `Bearer ${token}` });
+
+            await handler(internalReq(headers));
+            assert.strictEqual(cap.calls(), 1);
+            assert.strictEqual(cap.getSeen()?.subject, ISS_A);
+        });
+    });
+
+    describe("construction guards", () => {
+        it("throws when trustSource is missing", () => {
+            assert.throws(
+                // @ts-expect-error intentionally missing trustSource
+                () => createInternalAuthInterceptor({ internalMethods: [INTERNAL_PATTERN] }),
+                /requires a trustSource/,
+            );
+        });
+        it("meshIdentityTrust throws on empty allowlist", () => {
+            assert.throws(() => meshIdentityTrust({ allowlist: [] }), /non-empty allowlist/);
+        });
+        it("signedTokenTrust throws with no issuers", () => {
+            assert.throws(() => signedTokenTrust({ issuers: {} }), /at least one issuer/);
+        });
+        it("sharedSecretTrust throws on empty secret", () => {
+            assert.throws(() => sharedSecretTrust({ secret: "" }), /non-empty secret/);
+        });
+    });
+});

--- a/packages/auth/tests/unit/proto-authz-interceptor.test.ts
+++ b/packages/auth/tests/unit/proto-authz-interceptor.test.ts
@@ -13,7 +13,7 @@ import { assertConnectError, createMockNext } from "@connectum/testing";
 import { authContextStorage } from "../../src/context.ts";
 import { createProtoAuthzInterceptor } from "../../src/proto/proto-authz-interceptor.ts";
 import type { AuthContext, AuthzRule } from "../../src/types.ts";
-import { createFakeMethod, createFakeService, createMethodOptions, createProtoMockRequest } from "../helpers/proto-test-helpers.ts";
+import { createFakeMethod, createFakeService, createMethodOptions, createProtoMockRequest, createServiceOptions } from "../helpers/proto-test-helpers.ts";
 
 const defaultContext: AuthContext = {
     subject: "user-1",
@@ -302,6 +302,103 @@ describe("proto-authz-interceptor", () => {
                     return true;
                 },
             );
+        });
+    });
+
+    // ADR-029: internal (service-to-service) methods compose inclusively with
+    // the existing authz model. The internal identity is populated upstream by
+    // createInternalAuthInterceptor; here we simulate it via authContextStorage.run.
+    describe("internal methods (ADR-029)", () => {
+        const internalContext: AuthContext = {
+            subject: "trips-service",
+            roles: ["worker"],
+            scopes: [],
+            claims: {},
+            type: "service",
+        };
+
+        it("allows an internal method with no requires when identity is present", async () => {
+            const service = createFakeService();
+            const method = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true }));
+
+            const interceptor = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+            const req = createProtoMockRequest(service, method);
+
+            await authContextStorage.run(internalContext, () => handler(req));
+
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("rejects an internal method with no identity as Unauthenticated", async () => {
+            const service = createFakeService();
+            const method = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true }));
+
+            const interceptor = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+            const req = createProtoMockRequest(service, method);
+
+            // No authContextStorage.run -> no identity.
+            await assert.rejects(
+                () => handler(req),
+                (err: unknown) => {
+                    assertConnectError(err, Code.Unauthenticated);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+
+        it("inclusive roles: internal + requires{roles} ALLOWS a caller with the role (existing requires path)", async () => {
+            const service = createFakeService();
+            const method = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true, requires: { roles: ["worker"] } }));
+
+            const interceptor = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+            const req = createProtoMockRequest(service, method);
+
+            await authContextStorage.run(internalContext, () => handler(req));
+
+            assert.strictEqual(next.mock.calls.length, 1);
+        });
+
+        it("inclusive roles: internal + requires{roles} DENIES a caller without the role (PermissionDenied)", async () => {
+            const service = createFakeService();
+            const method = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true, requires: { roles: ["admin"] } }));
+
+            const interceptor = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+            const req = createProtoMockRequest(service, method);
+
+            // internalContext has role "worker", not "admin".
+            await assert.rejects(
+                () => authContextStorage.run(internalContext, () => handler(req)),
+                (err: unknown) => {
+                    assert.ok(err instanceof Error);
+                    assert.strictEqual((err as Error).name, "AuthzDeniedError");
+                    assert.strictEqual((err as any).code, Code.PermissionDenied);
+                    return true;
+                },
+            );
+            assert.strictEqual(next.mock.calls.length, 0);
+        });
+
+        it("internal resolved from service-level default (method inherits service internal)", async () => {
+            const service = createFakeService({ serviceOptions: createServiceOptions({ internal: true }) });
+            const method = createFakeMethod(service, "RecordTrip");
+
+            const interceptor = createProtoAuthzInterceptor({ defaultPolicy: "deny" });
+            const next = createMockNext();
+            const handler = interceptor(next);
+            const req = createProtoMockRequest(service, method);
+
+            await authContextStorage.run(internalContext, () => handler(req));
+
+            assert.strictEqual(next.mock.calls.length, 1);
         });
     });
 });

--- a/packages/auth/tests/unit/proto-reader.test.ts
+++ b/packages/auth/tests/unit/proto-reader.test.ts
@@ -7,7 +7,7 @@
 
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { getPublicMethods, resolveMethodAuth } from "../../src/proto/reader.ts";
+import { getInternalMethods, getPublicMethods, resolveMethodAuth } from "../../src/proto/reader.ts";
 import { createFakeMethod, createFakeService, createMethodOptions, createServiceOptions } from "../helpers/proto-test-helpers.ts";
 
 describe("proto-reader", () => {
@@ -19,8 +19,39 @@ describe("proto-reader", () => {
             const resolved = resolveMethodAuth(method);
 
             assert.strictEqual(resolved.public, false);
+            assert.strictEqual(resolved.internal, false);
             assert.strictEqual(resolved.policy, undefined);
             assert.strictEqual(resolved.requires, undefined);
+        });
+
+        it("should resolve method with internal: true (ADR-029)", () => {
+            const service = createFakeService();
+            const method = createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true }), { register: true });
+
+            const resolved = resolveMethodAuth(method);
+
+            assert.strictEqual(resolved.internal, true);
+            assert.strictEqual(resolved.public, false);
+        });
+
+        it("should inherit service-level internal: true", () => {
+            const svcOpts = createServiceOptions({ internal: true });
+            const service = createFakeService({ serviceOptions: svcOpts });
+            const method = createFakeMethod(service, "AnyMethod", undefined, { register: true });
+
+            const resolved = resolveMethodAuth(method);
+
+            assert.strictEqual(resolved.internal, true);
+        });
+
+        it("should respect method internal: false override on service internal: true", () => {
+            const svcOpts = createServiceOptions({ internal: true });
+            const service = createFakeService({ serviceOptions: svcOpts });
+            const method = createFakeMethod(service, "PublicProbe", createMethodOptions({ internal: false }), { register: true });
+
+            const resolved = resolveMethodAuth(method);
+
+            assert.strictEqual(resolved.internal, false, "method-level internal=false should override service-level internal=true");
         });
 
         it("should resolve method with public: true", () => {
@@ -216,6 +247,47 @@ describe("proto-reader", () => {
             const result = getPublicMethods([svc1, svc2]);
 
             assert.deepStrictEqual(result, ["svc1.v1.Svc1/Public1", "svc2.v1.Svc2/AllPublic"]);
+        });
+    });
+
+    describe("getInternalMethods() (ADR-029)", () => {
+        it("should return patterns for internal methods only", () => {
+            const service = createFakeService({ typeName: "trips.v1.TripService" });
+            createFakeMethod(service, "RecordTrip", createMethodOptions({ internal: true }), { register: true });
+            createFakeMethod(service, "EndTrip", createMethodOptions({ internal: true }), { register: true });
+            createFakeMethod(service, "PublicProbe", createMethodOptions({ public: true }), { register: true });
+            createFakeMethod(service, "GatedMethod", createMethodOptions({ requires: { roles: ["admin"] } }), { register: true });
+
+            const result = getInternalMethods([service]);
+
+            assert.deepStrictEqual(result, ["trips.v1.TripService/RecordTrip", "trips.v1.TripService/EndTrip"]);
+        });
+
+        it("should not overlap with getPublicMethods for the same services", () => {
+            const service = createFakeService({ typeName: "mix.v1.MixService" });
+            createFakeMethod(service, "Internal1", createMethodOptions({ internal: true }), { register: true });
+            createFakeMethod(service, "Public1", createMethodOptions({ public: true }), { register: true });
+
+            assert.deepStrictEqual(getInternalMethods([service]), ["mix.v1.MixService/Internal1"]);
+            assert.deepStrictEqual(getPublicMethods([service]), ["mix.v1.MixService/Public1"]);
+        });
+
+        it("should handle service-level internal flag", () => {
+            const svcOpts = createServiceOptions({ internal: true });
+            const service = createFakeService({ typeName: "int.v1.IntService", serviceOptions: svcOpts });
+            createFakeMethod(service, "MethodA", undefined, { register: true });
+            createFakeMethod(service, "MethodB", undefined, { register: true });
+
+            const result = getInternalMethods([service]);
+
+            assert.deepStrictEqual(result, ["int.v1.IntService/MethodA", "int.v1.IntService/MethodB"]);
+        });
+
+        it("should return empty array when no internal methods exist", () => {
+            const service = createFakeService();
+            createFakeMethod(service, "PublicMethod", createMethodOptions({ public: true }), { register: true });
+
+            assert.deepStrictEqual(getInternalMethods([service]), []);
         });
     });
 });


### PR DESCRIPTION
Closes #171. Implements [ADR-029](https://github.com/Connectum-Framework/docs/blob/main/en/contributing/adr/029-internal-service-to-service-auth.md).

## What

A first-class **`internal`** marker so service-to-service / worker calls (no end-user JWT, trusted by the mesh) stop being modeled as world-open `public`.

- **proto:** additive `internal` on `ServiceAuth` + `MethodAuth`.
- **`createInternalAuthInterceptor`** + three trust-source factories:
  - **`meshIdentityTrust`** — allow-listed mesh-forwarded SA / SPIFFE principal (production default; per-service by construction).
  - **`signedTokenTrust`** — per-service JWT verified via **issuer-bound JWKS**. The claimed `iss` only *selects* the keyset (read via `decodeJwt`, never trusted); `jwtVerify` runs against **only** that issuer's keyset, pinned to that issuer. **No `jwtVerify` ever sees a multi-issuer keyset** — so a token signed with service A's key but claiming `iss: B` is **rejected** (`ERR_JWKS_NO_MATCHING_KEY`). A shared multi-key JWKS would *not* contain compromise (jose resolves by `kid` independent of `iss`), so it is explicitly avoided.
  - **`sharedSecretTrust`** — documented **dev-only** fallback (not per-service).
- **`getInternalMethods`** (mirrors `getPublicMethods`); `resolveMethodAuth` surfaces `internal`; **`createProtoAuthzInterceptor`** gains one inclusive rule (no parallel `requires_identity`): `internal` + no `requires` → allow; `internal` + `requires` → the **existing** roles/scopes check; `internal` + no identity → `Unauthenticated`.
- Chain order `errorHandler → (jwtAuth | internalAuth) → protoAuthz` documented.

## Validation

- **Per-service containment (headline):** an A-signed token forged to claim `iss: B` is rejected (and the reverse forge, and an unconfigured issuer) — verified with two keypairs + two issuer JWKS endpoints via `@connectum/auth/testing`.
- Inclusive roles (allow with role / `PermissionDenied` without) through the existing proto-authz path; `internal`+no-identity → `Unauthenticated`; mesh allow-list accept/reject.
- `public`/gated unchanged. **`pnpm test` 345/345**; build/typecheck/biome clean; changeset `@connectum/auth` minor.

Deferred per ADR-029: example migration (`public → internal`) and app-level mTLS-SAN reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-to-service authentication support with three configurable trust mechanisms: mesh identity extraction with role allowlists, per-service token verification with issuer-bound key selection, and dev-only shared secret validation.

* **Tests**
  * Added comprehensive integration and unit test coverage for internal authentication and trust validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->