### PR TITLE
docs(release): trim RELEASE_HIGHLIGHTS for 1.1.0 (concise, no duplication)

### DIFF
--- a/.github/RELEASE_HIGHLIGHTS.md
+++ b/.github/RELEASE_HIGHLIGHTS.md
@@ -2,8 +2,11 @@
   Curated release highlights for the NEXT release. Maintainer-edited.
   `scripts/build-release-notes.mjs` prepends this verbatim as the "## Highlights"
   section of both the GitHub Release notes and the Version Packages PR body.
-  Keep it to the few most important user-facing changes (newest release).
-  Update (or clear) this file when cutting a new release.
+  Keep it SHORT: the few most important user-facing changes, ONE concise line
+  each. The per-package sections below already carry the full detail — do NOT
+  duplicate it here. Update (or clear) this file when cutting a new release.
 -->
-- **`EventBus.publishes` — correct topic for publisher-only processes** — a process that publishes an event without subscribing to it has no `routes`, so `publish()` previously fell back to the message `typeName` and silently emitted to the wrong topic whenever the event declared a custom `(connectum.events.v1.event).topic`. List the event service descriptors in the new `EventBusOptions.publishes` and the declared topic is resolved from the proto option end-to-end — no hand-maintained raw topic strings. ([#166](https://github.com/Connectum-Framework/connectum/pull/166))
-- **`connectum --version` reports the real published version** — the CLI now reads its version from `package.json` instead of a hand-maintained string that had drifted from the actual release. ([#164](https://github.com/Connectum-Framework/connectum/pull/164))
+- **Internal (service-to-service) auth** — a first-class `internal` marker and `createInternalAuthInterceptor` with pluggable per-service trust (mesh identity, issuer-bound JWKS, or a dev shared-secret), so `public → internal` removes world-open exposure rather than just renaming it (ADR-029). ([#179](https://github.com/Connectum-Framework/connectum/pull/179))
+- **`createCatalogClient`** — the catalog-typed `call`/`stream` ergonomics outside a `Server`, for out-of-process callers like a Temporal worker, scheduler, or CLI. ([#178](https://github.com/Connectum-Framework/connectum/pull/178))
+- **EventBus broadcast & publisher topics** — `createBroadcastSubscribers` for 1→N fan-out, plus `EventBusOptions.publishes` so a publisher-only process resolves the declared topic instead of silently using the message `typeName`. ([#176](https://github.com/Connectum-Framework/connectum/pull/176), [#166](https://github.com/Connectum-Framework/connectum/pull/166))
+- **`connectum --version`** now reports the real published version, read from `package.json`. ([#164](https://github.com/Connectum-Framework/connectum/pull/164))


### PR DESCRIPTION
## What

Trim the curated **1.1.0 highlights** down to the few most important user-facing changes, **one concise line each**. The highlights had grown to repeat the per-package CHANGELOG detail verbatim (the `EventBus.publishes` bullet was the full #166 changelog paragraph); the **Package changes** sections below already carry that detail, so the headline list should not duplicate it.

New highlights (4 concise bullets):

- **Internal (service-to-service) auth** (#179)
- **`createCatalogClient`** (#178)
- **EventBus broadcast & publisher topics** — `createBroadcastSubscribers` + `publishes` (#176, #166)
- **`connectum --version`** (#164)

`strictTopics` (#177) and the RS256 test helpers (#175) intentionally stay in the per-package detail rather than the headline list.

## Effect

`.github/RELEASE_HIGHLIGHTS.md` only (same single-file shape as #168). Merging this to `main` regenerates the open **Version Packages PR (#165)** body via the release workflow's "Update Version Packages PR body" step — it **does not publish** (publishing only happens when #165 itself is merged). Verified the rendered Highlights section locally with `scripts/build-release-notes.mjs 1.1.0` (HTML maintainer-comment stripped, bullets render, `## Package changes` follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release highlights documentation and internal guidance to provide clearer direction on creating concise, user-focused feature descriptions.
  * Refined the upcoming release highlights list to better showcase key capabilities and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->