### PR TITLE
docs(readme): document the 1.1.0 APIs in auth/core/events READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Enhancement ideas are welcome:
 ### Prerequisites
 
 - **Node.js**: ≥25.2.0 (for stable type stripping)
-- **pnpm**: ≥10.0.0
+- **pnpm**: ≥11.0.0
 - **Git**: Latest version
 - **protoc**: Latest version (for proto generation)
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish",
     "generate:keys": "mkdir -p keys && openssl req -nodes -x509 -newkey rsa:2048 -days 3650 -subj \"/CN=localhost\" -keyout keys/server.key -out keys/server.crt -addext \"subjectAltName=DNS:localhost,IP:127.0.0.1\"",
-    "docs:api": "typedoc",
+    "docs:api": "typedoc && node scripts/stabilize-api-source-links.mjs",
     "prepare": "husky"
   },
   "keywords": [

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -14,6 +14,7 @@ Authentication and authorization interceptors for Connectum.
 - **Proto authorization interceptor** -- authorization driven by `connectum.auth.v1` proto custom options, with `getPublicMethods`/`resolveMethodAuth` reader utilities
 - **Client Bearer interceptor** -- client-side `Authorization: Bearer <token>` injection with static tokens or async refresh factories
 - **Client gateway interceptor** -- client-side service-to-service auth headers (gateway secret + subject + roles) for calls behind an API gateway
+- **Internal (service-to-service) auth interceptor** -- authorize proto-`internal` methods via a pluggable per-service trust source (mesh identity, per-service signed tokens, or a dev-only shared secret)
 - **AsyncLocalStorage context** -- zero-boilerplate access to auth context from any handler
 - **Header propagation** -- cross-service auth context forwarding (Envoy-style `x-auth-*` headers)
 - **LRU cache** -- in-memory credential verification caching with TTL expiration
@@ -234,6 +235,181 @@ const sessionAuth = createSessionAuthInterceptor({
 | `skipMethods` | `string[]` | `[]` | Methods to skip authentication for |
 | `propagateHeaders` | `boolean` | `false` | Propagate auth context as `x-auth-*` headers for downstream services |
 | `propagatedClaims` | `string[]` | - | Filter which claim keys are propagated in `x-auth-claims` header. When not set, all claims are propagated. |
+
+### createInternalAuthInterceptor(options)
+
+> Available since 1.1.0.
+
+Internal (service-to-service) authentication interceptor (ADR-029). For methods marked `internal` in proto options, it authorizes the call from a configurable per-service **trust source** instead of an end-user token, and rejects a missing/invalid marker as `Code.Unauthenticated`. Non-internal methods are a **no-op pass-through**.
+
+Internal methods skip end-user (JWT) authentication, so feed `getInternalMethods(services)` into the JWT interceptor's `skipMethods` (alongside `getPublicMethods(services)`); this interceptor then enforces the internal trust marker on those same methods.
+
+```typescript
+import {
+  createInternalAuthInterceptor,
+  meshIdentityTrust,
+  createJwtAuthInterceptor,
+  getInternalMethods,
+  getPublicMethods,
+} from '@connectum/auth';
+import services from '#gen/services.js';
+
+// JWT skips both public and internal methods; the internal interceptor
+// then enforces the trust marker on the internal ones.
+const jwtAuth = createJwtAuthInterceptor({
+  jwksUri: 'https://auth.example.com/.well-known/jwks.json',
+  skipMethods: [...getPublicMethods(services), ...getInternalMethods(services)],
+});
+
+const internalAuth = createInternalAuthInterceptor({
+  internalMethods: getInternalMethods(services),
+  trustSource: meshIdentityTrust({
+    allowlist: [
+      { principal: 'cluster.local/ns/default/sa/trips', roles: ['worker'] },
+    ],
+  }),
+});
+```
+
+**Options (`InternalAuthInterceptorOptions`)**:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `trustSource` | `InternalTrustSource` | **required** | Pluggable trust source that authorizes an internal call -- use `meshIdentityTrust`, `signedTokenTrust`, `sharedSecretTrust`, or a custom function. Returning `null` (or throwing) rejects the call as `Unauthenticated`. |
+| `internalMethods` | `readonly string[]` | **required** | Method patterns enforced as internal (`"Service/Method"`, `"Service/*"`, or `"*"`). Typically `getInternalMethods(services)`. All other methods pass through unchanged. |
+
+**Chain order (load-bearing).** This interceptor MUST run **before** `createProtoAuthzInterceptor`: it populates the `AuthContext` that proto-authz's `internal` rule consumes.
+
+```text
+errorHandler -> (jwtAuth | internalAuth) -> protoAuthz
+```
+
+For an `internal` method, `createProtoAuthzInterceptor` composes the marker inclusively with the existing roles/scopes model:
+
+- `internal` + no identity (no `AuthContext`) -> `Unauthenticated`
+- `internal` + no `requires` -> allow (any trusted internal caller)
+- `internal` + `requires { roles | scopes }` -> the existing roles/scopes check against the same `AuthContext`
+
+> **Proto contract (additive).** `optional bool internal` was added to both `ServiceAuth` and `MethodAuth` in `connectum.auth.v1`. Marking a method `internal` instead of `public` removes world-open exposure while keeping it reachable by trusted callers (ADR-029).
+
+`InternalTrustSource` is `(req: { header: Headers }) => AuthContext | null | Promise<AuthContext | null>`. Each shipped trust source strips its own trust header after extraction on the internal path (accept and reject) to prevent a spoofed marker from being propagated downstream.
+
+### meshIdentityTrust(options)
+
+> Available since 1.1.0.
+
+Production-default trust source. Verifies a mesh-forwarded peer principal (an Istio short-form ServiceAccount principal `cluster.local/ns/<ns>/sa/<name>`, or a SPIFFE id) against an allow-list. Because the mesh issues each workload its own mTLS identity, matching the forwarded principal against the allow-list is **per-service by construction** -- compromising one workload cannot forge another's identity. The identity header is stripped after extraction (anti-spoofing).
+
+```typescript
+import { createInternalAuthInterceptor, meshIdentityTrust, getInternalMethods } from '@connectum/auth';
+import services from '#gen/services.js';
+
+const internalAuth = createInternalAuthInterceptor({
+  internalMethods: getInternalMethods(services),
+  trustSource: meshIdentityTrust({
+    allowlist: [
+      { principal: 'cluster.local/ns/default/sa/trips', roles: ['worker'], name: 'trips-service' },
+      { principal: 'cluster.local/ns/default/sa/billing', scopes: ['charge'] },
+    ],
+  }),
+});
+```
+
+**Options (`MeshIdentityTrustOptions`)**:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `allowlist` | `readonly MeshIdentityEntry[]` | **required** | Permitted mesh identities. A non-empty list is enforced at construction (throws otherwise). A request whose principal is not on the list is rejected. |
+| `header` | `string` | `"x-forwarded-client-principal"` | Header carrying the mesh-forwarded peer identity |
+| `type` | `string` | `"mesh"` | Credential type set on the resulting `AuthContext` |
+
+**`MeshIdentityEntry`**:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `principal` | `string` | Yes | Forwarded peer identity to match (Istio ServiceAccount principal or SPIFFE id) |
+| `roles` | `readonly string[]` | No | Roles granted to this caller (compose via `requires { roles }`) |
+| `scopes` | `readonly string[]` | No | Scopes granted to this caller (compose via `requires { scopes }`) |
+| `name` | `string` | No | Human-readable name for the calling service |
+
+### signedTokenTrust(options)
+
+> Available since 1.1.0.
+
+Non-mesh, per-service trust source. Each caller signs a short-lived JWT with its **own** private key; this trust source verifies it against that service's published JWKS, so compromising service A's key forges only A.
+
+**Issuer-bound key selection (hard security requirement).** The keyset is selected by the token's claimed `iss` (`issuers[iss].jwksUri`), and verification is **pinned** to that same issuer -- each issuer gets its own `createRemoteJWKSet`, so no verification call ever receives a keyset spanning more than one issuer. A token claiming `iss: "B"` but signed with A's key is **rejected**. (A single shared JWKS holding multiple services' keys does NOT contain compromise, because `jose` resolves the signing key by `kid` independently of `iss`.)
+
+The framework ships only the verification primitive; key issuance/rotation/JWKS publication belong to the deployment (SPIRE / the IdP / the mesh).
+
+```typescript
+import { createInternalAuthInterceptor, signedTokenTrust, getInternalMethods } from '@connectum/auth';
+import services from '#gen/services.js';
+
+const internalAuth = createInternalAuthInterceptor({
+  internalMethods: getInternalMethods(services),
+  trustSource: signedTokenTrust({
+    issuers: {
+      'trips-service': {
+        jwksUri: 'https://trips/.well-known/jwks.json',
+        claimsMapping: { roles: 'roles' },
+      },
+      'billing-service': { jwksUri: 'https://billing/.well-known/jwks.json' },
+    },
+  }),
+});
+```
+
+**Options (`SignedTokenTrustOptions`)**:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `issuers` | `Readonly<Record<string, SignedTokenIssuer>>` | **required** | Per-issuer JWKS config keyed by the token's `iss` value. At least one issuer is enforced at construction (throws otherwise). |
+| `header` | `string` | `"x-internal-token"` | Header carrying the service token (bare token or `Bearer <token>`) |
+| `type` | `string` | `"service"` | Credential type set on the resulting `AuthContext` |
+
+**`SignedTokenIssuer`**:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `jwksUri` | `string` | **required** | The issuer's JWKS endpoint URL (its own keyset only) |
+| `audience` | `string \| string[]` | - | Expected audience(s) for tokens from this issuer |
+| `algorithms` | `string[]` | `["RS256"]` | Allowed signing algorithms |
+| `maxTokenAge` | `number \| string` | - | Maximum token age (seconds or string like `"2h"`) |
+| `claimsMapping` | `{ subject?, name?, roles?, scopes? }` | `{}` | Map token claims to `AuthContext` (dot-notation). Subject defaults to the `sub` claim, else the issuer. |
+
+### sharedSecretTrust(options)
+
+> Available since 1.1.0.
+
+> **DEV-ONLY.** A single shared secret is **not** per-service: every legitimate caller holds the same secret, so one compromise forges **all** internal identities. Use `meshIdentityTrust` (mesh) or `signedTokenTrust` (non-mesh per-service JWT) in production. This factory exists only for local development and single-tenant low-trust-boundary setups.
+
+Constant-time compares a single shared secret against the trust header. The header is stripped after extraction (anti-spoofing).
+
+```typescript
+import { createInternalAuthInterceptor, sharedSecretTrust, getInternalMethods } from '@connectum/auth';
+import services from '#gen/services.js';
+
+const internalAuth = createInternalAuthInterceptor({
+  internalMethods: getInternalMethods(services),
+  trustSource: sharedSecretTrust({
+    secret: process.env.INTERNAL_SECRET ?? '',
+    subject: 'internal-batch',
+    roles: ['worker'],
+  }),
+});
+```
+
+**Options (`SharedSecretTrustOptions`)**:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `secret` | `string` | **required** | Shared secret, constant-time compared against the header value. A non-empty secret is enforced at construction (throws otherwise). |
+| `header` | `string` | `"x-internal-secret"` | Header carrying the shared secret |
+| `subject` | `string` | `"internal"` | Subject identity assigned to a trusted call |
+| `roles` | `readonly string[]` | `[]` | Roles granted to a trusted caller |
+| `scopes` | `readonly string[]` | `[]` | Scopes granted to a trusted caller |
+| `type` | `string` | `"internal"` | Credential type set on the resulting `AuthContext` |
 
 ### createAuthzInterceptor(options)
 
@@ -482,6 +658,109 @@ await withAuthContext(createMockAuthContext({ subject: 'user-1' }), async () => 
 
 Deterministic HMAC secret for test JWTs: `"connectum-test-secret-do-not-use-in-production"`.
 
+### generateRsaTestKeypair(kid?)
+
+> Available since 1.1.0.
+
+Generate an RSA (RS256) test keypair plus the matching public JWK for the production-realistic JWKS path (`createJwtAuthInterceptor({ jwksUri })`). Unlike `createTestJwt` (HS256-only), this exercises the asymmetric `jose.createRemoteJWKSet` branch. The returned `publicJwk` carries the `kid`/`alg`/`use` a JWKS endpoint publishes, and the same `kid` must be stamped on every token minted for it (otherwise key selection fails). Defaults the `kid` to `TEST_JWT_KID`.
+
+```typescript
+import { generateRsaTestKeypair } from '@connectum/auth/testing';
+
+const keypair = await generateRsaTestKeypair();
+// { privateKey, publicKey, publicJwk, kid }
+```
+
+**Returns (`RsaTestKeypair`)**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `privateKey` | `CryptoKey` | Private signing key -- pass to `createTestJwtRS256` |
+| `publicKey` | `CryptoKey` | Public verification key |
+| `publicJwk` | `jose.JWK` | Public JWK (`kid`, `alg: "RS256"`, `use: "sig"`) -- serve at the JWKS endpoint |
+| `kid` | `string` | Key id shared by `publicJwk` and the token header |
+
+### startTestJwksServer(jwks)
+
+> Available since 1.1.0.
+
+Start an ephemeral in-process JWKS server publishing the given public JWK(s) at `/.well-known/jwks.json` on a random loopback port. Pass `server.url` as `jwksUri` to `createJwtAuthInterceptor`. Call `close()` after the test.
+
+```typescript
+import { generateRsaTestKeypair, startTestJwksServer } from '@connectum/auth/testing';
+import { createJwtAuthInterceptor } from '@connectum/auth';
+
+const keypair = await generateRsaTestKeypair();
+const jwks = await startTestJwksServer(keypair.publicJwk); // or an array of JWKs
+
+const auth = createJwtAuthInterceptor({
+  jwksUri: jwks.url,
+  issuer: 'https://issuer.example',
+  audience: 'my-api',
+  algorithms: ['RS256'],
+});
+
+// ...exercise the interceptor...
+await jwks.close();
+```
+
+**Returns (`TestJwksServer`)**:
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `url` | `string` | The JWKS URL -- pass as `jwksUri` to `createJwtAuthInterceptor` |
+| `origin` | `string` | Origin without path, e.g. `http://127.0.0.1:<port>` |
+| `close` | `() => Promise<void>` | Stop the server (e.g. in `after`) |
+
+### createTestJwtRS256(privateKey, payload, options)
+
+> Available since 1.1.0.
+
+Mint an RS256 test token signed by the private key from `generateRsaTestKeypair`, with a `kid` header matching the published JWK. Verified through the same `createRemoteJWKSet` branch production uses, so an RS256 round-trip test exercises the real `jwksUri` code path. The `options` argument and its `kid` field are **required** (the `kid` must match the published JWK). NOT for production use.
+
+```typescript
+import {
+  generateRsaTestKeypair,
+  startTestJwksServer,
+  createTestJwtRS256,
+} from '@connectum/auth/testing';
+
+const keypair = await generateRsaTestKeypair();
+const jwks = await startTestJwksServer(keypair.publicJwk);
+
+const token = await createTestJwtRS256(
+  keypair.privateKey,
+  { sub: 'user-123', roles: ['admin'], scope: 'read write' },
+  { kid: keypair.kid, issuer: 'https://issuer.example', audience: 'my-api' },
+);
+
+// ...use `Authorization: Bearer ${token}`...
+await jwks.close();
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `privateKey` | `CryptoKey` | Private key from `generateRsaTestKeypair` |
+| `payload` | `Record<string, unknown>` | JWT claims (e.g. `sub`, `roles`, `scope`) |
+| `options` | `{ kid: string; issuer?: string; audience?: string; expiresIn?: string }` | **required**; `kid` is required and must match the published JWK |
+
+**`options` fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `kid` | `string` | **required** | Key id header (must match the published JWK) |
+| `issuer` | `string` | - | Token issuer |
+| `audience` | `string` | - | Token audience |
+| `expiresIn` | `string` | `'1h'` | Expiration (jose duration format) |
+
+### TEST_JWT_KID
+
+> Available since 1.1.0.
+
+Default `kid` shared by `generateRsaTestKeypair` and the tokens minted for it: `"connectum-test-key"`.
+
 ## Integration with better-auth
 
 [better-auth](https://www.better-auth.com/) is a modern authentication framework for TypeScript. It supports programmatic session verification and works directly with `createSessionAuthInterceptor`.
@@ -528,10 +807,16 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `createJwtAuthInterceptor` -- JWT convenience with jose
 - `createGatewayAuthInterceptor` -- gateway-injected headers
 - `createSessionAuthInterceptor` -- session-based auth
+- `createInternalAuthInterceptor` -- internal (service-to-service) auth via a pluggable trust source
 - `createAuthzInterceptor` -- declarative rules-based authorization
 - `createProtoAuthzInterceptor` -- proto-option-driven authorization (`connectum.auth.v1`)
 - `createClientBearerInterceptor` -- client-side Bearer token injection
 - `createClientGatewayInterceptor` -- client-side gateway service-to-service auth
+
+**Internal trust sources** (for `createInternalAuthInterceptor`):
+- `meshIdentityTrust` -- production default; verify a mesh-forwarded peer principal against an allow-list
+- `signedTokenTrust` -- non-mesh per-service signed JWT with issuer-bound JWKS
+- `sharedSecretTrust` -- dev-only single shared secret (not per-service)
 
 **Context management**:
 - `getAuthContext` -- get current AuthContext (or undefined)
@@ -551,6 +836,7 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `AuthzDeniedError` -- authorization denied error class
 - `matchesMethodPattern` -- method pattern matching utility
 - `getPublicMethods` -- collect `skipMethods` patterns for proto-`public` methods from service descriptors
+- `getInternalMethods` -- collect patterns for proto-`internal` methods (feed into both the JWT interceptor's `skipMethods` and `createInternalAuthInterceptor`)
 - `resolveMethodAuth` -- resolve effective per-method auth config from proto options (cached)
 
 **Types** (TypeScript only):
@@ -560,6 +846,13 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 - `GatewayAuthInterceptorOptions`
 - `GatewayHeaderMapping`
 - `SessionAuthInterceptorOptions`
+- `InternalAuthInterceptorOptions`
+- `InternalTrustSource`
+- `MeshIdentityTrustOptions`
+- `MeshIdentityEntry`
+- `SignedTokenTrustOptions`
+- `SignedTokenIssuer`
+- `SharedSecretTrustOptions`
 - `AuthzInterceptorOptions`
 - `ProtoAuthzInterceptorOptions`
 - `ClientBearerInterceptorOptions`
@@ -574,8 +867,13 @@ const betterAuthInterceptor = createSessionAuthInterceptor({
 
 - `createMockAuthContext` -- create AuthContext with defaults
 - `createTestJwt` -- create signed HS256 test JWT
+- `createTestJwtRS256` -- mint an RS256 test JWT verified through the production JWKS branch
+- `generateRsaTestKeypair` -- generate an RSA (RS256) test keypair + public JWK
+- `startTestJwksServer` -- start an in-process JWKS server publishing the public JWK(s)
 - `withAuthContext` -- run code with injected AuthContext
-- `TEST_JWT_SECRET` -- deterministic test secret
+- `TEST_JWT_SECRET` -- deterministic HS256 test secret
+- `TEST_JWT_KID` -- default `kid` for the RS256 helpers
+- `RsaTestKeypair`, `TestJwksServer` -- types for the RS256 helpers (TypeScript only)
 
 ## Dependencies
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -381,7 +381,7 @@ const internalAuth = createInternalAuthInterceptor({
 ### sharedSecretTrust(options)
 
 > Available since 1.1.0.
-
+>
 > **DEV-ONLY.** A single shared secret is **not** per-service: every legitimate caller holds the same secret, so one compromise forges **all** internal identities. Use `meshIdentityTrust` (mesh) or `signedTokenTrust` (non-mesh per-service JWT) in production. This factory exists only for local development and single-tenant low-trust-boundary setups.
 
 Constant-time compares a single shared secret against the trust header. The header is stripped after extraction (anti-spoofing).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,6 +12,7 @@ Main Server factory with protocol plugin system for Connectum.
 - **TLS Configuration**: Utilities for configuring TLS certificates
 - **Graceful Shutdown**: Built-in graceful shutdown support with automatic signal handling
 - **Explicit Interceptors**: User passes interceptors explicitly (zero internal deps)
+- **Standalone Catalog Client** _(since 1.1.0)_: `createCatalogClient()` — the catalog-typed `call`/`stream` surface usable OUTSIDE a `Server` (a Temporal worker, scheduler, or CLI)
 
 ### Protocol Packages (installed separately)
 
@@ -350,6 +351,49 @@ class PaymentError extends Error implements SanitizableError {
 throw new PaymentError('Stripe declined', { stripeCode: 'card_declined', amount: 4999 });
 ```
 
+### createCatalogClient()
+
+_Available since 1.1.0._
+
+A standalone, catalog-typed client that exposes the **same** typed `call` (unary) and `stream` (server/client/bidi) surface as the in-handler `ctx.call` / `ctx.stream`, but usable **outside** a `Server` — in a Temporal worker, a scheduler, or a CLI — without constructing a server:
+
+```typescript
+import { createCatalogClient, type CreateCatalogClientOptions } from '@connectum/core';
+
+function createCatalogClient(options: CreateCatalogClientOptions): CatalogClient
+```
+
+**Parameters (`CreateCatalogClientOptions`):**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `catalog` | `ServiceCatalog` | required | The service catalog backing typed dispatch — the same object passed to `createServer({ catalog })` |
+| `resolver` | `RemoteResolver` | required | Resolves every target's transport (`singleTransportResolver` / `mapResolver` / `dnsResolver` / `perServiceEnvResolver`) |
+
+**Returns:** `CatalogClient` — `{ call, stream }`, keyed off the generated `ConnectumCallMap` / `ConnectumStreamMap`.
+
+The dispatch is typed off the generated catalog, so calls are statically checked exactly as on the handler `ctx`:
+
+```typescript
+import { createCatalogClient, mapResolver } from '@connectum/core';
+import { createGrpcTransport } from '@connectrpc/connect-node';
+import { serviceCatalog } from '#gen/catalog.js'; // from @connectum/protoc-gen-catalog
+
+const client = createCatalogClient({
+  catalog: serviceCatalog,
+  resolver: mapResolver({
+    'trip.v1.TripService': createGrpcTransport({ baseUrl: process.env.TRIP_ADDR ?? 'http://localhost:8080' }),
+  }),
+});
+
+// Fully typed off the generated catalog — same surface as ctx.call:
+const trip = await client.call('trip.v1.TripService/StartTrip', { vehicleId: 'veh-42' });
+```
+
+**Resolution & caching:** every target is routed through the supplied `RemoteResolver`, and the resolved transport is cached per `(typeName, endpoint)`. There is **no** in-process/local path: a service the resolver cannot resolve fails with `Code.Unavailable`. The rest of the error model mirrors `ctx.call` — unknown service/method (or wrong method kind) fails with `Code.Unimplemented`, and a resolver that throws surfaces as `Code.Internal` (cause preserved).
+
+**Difference from `ctx.call`:** there is no inbound request to cascade from, so `CallOptions` are applied **verbatim** — the `signal` / `timeoutMs` are **not** cascaded or clamped, no inbound headers are propagated, and no `ContextValues` are forwarded.
+
 ## Exports Summary
 
 | Export | Kind | Description |
@@ -390,6 +434,9 @@ throw new PaymentError('Stripe declined', { stripeCode: 'card_declined', amount:
 | `defineCatalog` | function | Build a typed `ServiceCatalog` for cross-service calls |
 | `mergeCatalogs` | function | Merge multiple catalogs into one |
 | `CatalogConfigError` | class | Error thrown for invalid catalog configuration |
+| `createCatalogClient` | function | Standalone, catalog-typed `call` / `stream` client usable outside a `Server` (since 1.1.0) |
+| `CreateCatalogClientOptions` | type | Options for `createCatalogClient()` (`catalog` + `resolver`) |
+| `CatalogClient` | type | The standalone catalog client returned by `createCatalogClient()` (`call` + `stream`) |
 | `createLocalTransport` | function | Create an in-process transport for same-process service calls |
 | `CreateLocalTransportOptions` | type | Options for `createLocalTransport()` (client-side interceptors) |
 | `defaultPropagateHeaders` | const | Ready-made opt-in allow-list of W3C trace-context headers for `createServer({ propagateHeaders })` (nothing propagates by default) |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -693,7 +693,7 @@ None — `@connectum/core` is Layer 0 with zero internal dependencies.
 ## Requirements
 
 - **Node.js**: >=22.13.0
-- **pnpm**: >=10.0.0
+- **pnpm**: >=11.0.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ### Alternative Runtimes

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -234,7 +234,7 @@ function createEventBus(options: EventBusOptions): EventBus
 > await bus.start();
 > await bus.publish(OrderPlacedSchema, order); // → declared topic, not "order.v1.OrderPlaced"
 > ```
-
+>
 > **`strictTopics` (opt-in, default `false`):** the same silent fallback also happens for any event covered by neither `routes` nor `publishes` and published without an explicit `PublishOptions.topic` — `publish()` emits to the raw `schema.typeName`. Set `strictTopics: true` to make that unresolved-topic case **throw** at the call site instead of silently misconfiguring. Backward-compatible; available since 1.1.0.
 
 ### createBroadcastSubscribers()

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -9,6 +9,7 @@ Universal event adapter layer for Connectum: proto-first pub/sub with pluggable 
 ## Features
 
 - **createEventBus()** -- factory with explicit lifecycle (`start()` / `stop()`)
+- **createBroadcastSubscribers()** -- 1->N fan-out wiring: one event delivered to N independent reactors, each on its own bus + consumer group
 - **Proto-first** -- publish and subscribe using `@bufbuild/protobuf` message schemas
 - **Pluggable Adapters** -- swap NATS, Kafka, Redis Streams, or in-memory without code changes
 - **EventRouter** -- type-safe handler registration mirroring ConnectRouter pattern
@@ -217,6 +218,7 @@ function createEventBus(options: EventBusOptions): EventBus
 | `adapter` | `EventAdapter` | required | Broker adapter (NATS, Kafka, Redis, Memory) |
 | `routes` | `EventRoute[]` | `[]` | Event route handlers (subscriber side) |
 | `publishes` | `DescService[]` | `[]` | Event service descriptors this process publishes to (publisher side, no subscription) |
+| `strictTopics` | `boolean` | `false` | Throw on an unresolved publish topic instead of silently falling back to the message `typeName` |
 | `middleware` | `MiddlewareConfig` | `{}` | Middleware configuration |
 | `group` | `string` | `undefined` | Consumer group name |
 | `signal` | `AbortSignal` | `undefined` | External abort signal |
@@ -232,6 +234,83 @@ function createEventBus(options: EventBusOptions): EventBus
 > await bus.start();
 > await bus.publish(OrderPlacedSchema, order); // → declared topic, not "order.v1.OrderPlaced"
 > ```
+
+> **`strictTopics` (opt-in, default `false`):** the same silent fallback also happens for any event covered by neither `routes` nor `publishes` and published without an explicit `PublishOptions.topic` — `publish()` emits to the raw `schema.typeName`. Set `strictTopics: true` to make that unresolved-topic case **throw** at the call site instead of silently misconfiguring. Backward-compatible; available since 1.1.0.
+
+### createBroadcastSubscribers()
+
+```typescript
+import { createBroadcastSubscribers } from '@connectum/events';
+
+function createBroadcastSubscribers(
+  options: BroadcastSubscribersOptions,
+): Array<EventBus & EventBusLike>
+```
+
+Available since 1.1.0.
+
+First-class 1->N fan-out wiring. Delivering ONE published event to N **independent** reactors (each reacting on its own) requires one `EventBus` **per reactor**, each with its own consumer group:
+
+- the per-bus duplicate-topic guard rejects two routes resolving to the same topic on one bus (it throws `Duplicate event topic "..." on one EventBus`), and
+- on a real broker, a **shared** group load-balances (one reactor "steals" each event) while **distinct** groups give each reactor its own durable consumer.
+
+`createBroadcastSubscribers()` builds that one-bus-per-reactor wiring from a list of reactors, so callers do not hand-roll N `createEventBus` calls. It **throws** if two reactors share a consumer group.
+
+The returned buses are **not started** -- start (and later stop) them yourself.
+
+```typescript
+import { createBroadcastSubscribers } from '@connectum/events';
+import { NatsAdapter } from '@connectum/events-nats';
+
+// Per-bus adapter factory: each reactor bus gets its own connection / durable consumer
+const buses = createBroadcastSubscribers({
+  adapter: () => NatsAdapter({ servers: 'nats://localhost:4222' }),
+  reactors: [
+    { group: 'pricing', routes: [pricingRoutes] },
+    { group: 'audit', routes: [auditRoutes] },
+    { group: 'notify', routes: [notifyRoutes] },
+  ],
+});
+
+await Promise.all(buses.map((bus) => bus.start()));
+
+// On shutdown:
+await Promise.all(buses.map((bus) => bus.stop()));
+```
+
+For in-process tests, pass a single shared `MemoryAdapter()` instance instead of a factory (all buses share the in-memory registry):
+
+```typescript
+import { createBroadcastSubscribers, MemoryAdapter } from '@connectum/events';
+
+const buses = createBroadcastSubscribers({
+  adapter: MemoryAdapter(), // one shared instance
+  reactors: [
+    { group: 'pricing', routes: [pricingRoutes] },
+    { group: 'audit', routes: [auditRoutes] },
+  ],
+});
+
+await Promise.all(buses.map((bus) => bus.start()));
+```
+
+**Parameters (`BroadcastSubscribersOptions`):**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `adapter` | `EventAdapter \| (() => EventAdapter)` | required | One shared adapter instance (fine for `MemoryAdapter` in tests) OR a factory invoked once per reactor (use for real brokers so each bus gets its own connection / durable consumer) |
+| `reactors` | `BroadcastReactor[]` | required | The independent reactors -- each becomes its own EventBus with its own group |
+| `handlerTimeout` | `number` | `30000` | Shared per-bus handler timeout in ms |
+| `drainTimeout` | `number` | `30000` | Shared per-bus drain timeout in ms |
+| `signal` | `AbortSignal` | `undefined` | Shared abort signal for graceful shutdown |
+
+**`BroadcastReactor`:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `group` | `string` | required | Consumer group -- MUST be distinct per reactor for true fan-out (a shared group load-balances) |
+| `routes` | `EventRoute[]` | required | The event routes (handlers) this reactor subscribes with |
+| `middleware` | `MiddlewareConfig` | `undefined` | Optional per-reactor middleware (retry / DLQ / custom) |
 
 ### EventBus Interface
 
@@ -332,6 +411,7 @@ Set `drainTimeout: 0` for immediate abort (skip drain).
 | Export | Kind | Description |
 |--------|------|-------------|
 | `createEventBus` | function | Factory for creating an EventBus |
+| `createBroadcastSubscribers` | function | Builds one-bus-per-reactor 1->N fan-out wiring from a list of reactors |
 | `deriveServiceName` | function | Derives a consumer identity (`package@hostname`) from proto service names |
 | `NonRetryableError` | class | Error that skips retry middleware |
 | `RetryableError` | class | Error that forces retry |
@@ -346,6 +426,8 @@ Set `drainTimeout: 0` for immediate abort (skip drain).
 | `EventAdapter` | type | Adapter interface |
 | `EventBus` | type | EventBus interface |
 | `EventBusOptions` | type | Options for `createEventBus()` |
+| `BroadcastSubscribersOptions` | type | Options for `createBroadcastSubscribers()` |
+| `BroadcastReactor` | type | One independent broadcast reactor (group + routes + optional middleware) |
 | `EventContext` | type | Handler context interface |
 | `EventRouter` | type | Router interface |
 | `PublishOptions` | type | Publish options |

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -454,7 +454,7 @@ For the complete, always-current list of exported symbols and types, see the [AP
 ## Requirements
 
 - **Node.js**: >=22.13.0
-- **pnpm**: >=10.0.0
+- **pnpm**: >=11.0.0
 - **TypeScript**: >=5.7.2 (for type checking)
 
 ## Documentation

--- a/packages/healthcheck/README.md
+++ b/packages/healthcheck/README.md
@@ -339,7 +339,7 @@ describe('health check', () => {
 ## Requirements
 
 - **Node.js**: >=22.13.0
-- **pnpm**: >=10.0.0
+- **pnpm**: >=11.0.0
 
 ## Documentation
 

--- a/packages/reflection/README.md
+++ b/packages/reflection/README.md
@@ -159,7 +159,7 @@ await server.start();
 ## Requirements
 
 - **Node.js**: >=22.13.0
-- **pnpm**: >=10.0.0
+- **pnpm**: >=11.0.0
 
 ## License
 

--- a/scripts/stabilize-api-source-links.mjs
+++ b/scripts/stabilize-api-source-links.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Stabilize the generated API-reference source links.
+ *
+ * TypeDoc embeds the current git HEAD commit SHA in every "Defined in:" source
+ * link. That makes each regen rewrite all ~900 files (SHA churn), and a regen on
+ * a feature branch pins links to a commit that squash-merge later orphans
+ * (eventual 404s). Configuring TypeDoc's `disableGit` + `sourceLinkTemplate` to
+ * avoid this also restructures the per-package output (it shifts `{path}`
+ * rooting), so instead we post-process: replace the volatile
+ * `/blob/<40-hex-sha>/` with the stable `/blob/main/`.
+ *
+ * Run automatically by `pnpm docs:api` (after `typedoc`).
+ *
+ * @module scripts/stabilize-api-source-links
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const API_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "docs", "en", "api");
+
+/** Volatile source-link revision: `/blob/<40 hex>/` → stable `/blob/main/`. */
+const SHA_LINK = /\/blob\/[0-9a-f]{40}\//g;
+const STABLE = "/blob/main/";
+
+/** Recursively yield every `.md` file under `dir`. */
+function* markdownFiles(dir) {
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            yield* markdownFiles(full);
+        } else if (entry.endsWith(".md")) {
+            yield full;
+        }
+    }
+}
+
+let scanned = 0;
+let rewritten = 0;
+for (const file of markdownFiles(API_DIR)) {
+    scanned += 1;
+    const before = readFileSync(file, "utf8");
+    const after = before.replace(SHA_LINK, STABLE);
+    if (after !== before) {
+        writeFileSync(file, after);
+        rewritten += 1;
+    }
+}
+
+console.log(`stabilize-api-source-links: pinned source links to ${STABLE} in ${rewritten}/${scanned} files`);


### PR DESCRIPTION
## What

Bring the package READMEs current with the **1.1.0** API additions (the prior doc pass predated them). Every new API is marked **"since 1.1.0"** and was **adversarially verified against the real exports** in `src/index.ts` (signatures, option names, export path):

- **`@connectum/auth`** — internal (service-to-service) auth: `createInternalAuthInterceptor` + the `meshIdentityTrust` / `signedTokenTrust` / `sharedSecretTrust` trust sources + `getInternalMethods` (ADR-029); and the RS256 + JWKS test helpers (`generateRsaTestKeypair` / `startTestJwksServer` / `createTestJwtRS256`) under the `@connectum/auth/testing` subpath.
- **`@connectum/core`** — `createCatalogClient({ catalog, resolver })`: the catalog-typed `call`/`stream` surface usable outside a `Server`.
- **`@connectum/events`** — `createBroadcastSubscribers` for 1→N fan-out, and the opt-in `EventBusOptions.strictTopics` (`publishes` was already documented).

## Scope

`cli` / root / the other 11 package READMEs had **no 1.1.0 changeset** — confirmed no drift (grep). Additions are **README-only**; existing content is unchanged (no rewrite/reorder).

## Verification

Every new claim was checked against the actual exported API (e.g. `createBroadcastSubscribers(options: BroadcastSubscribersOptions): Array<EventBus & EventBusLike>` matches `broadcast.ts` exactly; RS256 helpers are under `/testing`). No code changed, so the build/typecheck/test matrix is a regression confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal service-to-service authentication interceptor with configurable trust sources.
  * Added standalone catalog client API for use outside server contexts.
  * Added broadcast subscribers for 1-to-N event distribution patterns.
  * Added strict topic validation option for event bus.
  * Added RS256 JWT and JWKS testing utilities.

* **Documentation**
  * Updated API documentation across auth, core, and events packages with new features and types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->