### PR TITLE
feat(events-amqp): external-contract publish mode without the EventBus envelope (#161)

### DIFF
--- a/.changeset/events-amqp-external-contract-publish.md
+++ b/.changeset/events-amqp-external-contract-publish.md
@@ -1,0 +1,7 @@
+---
+"@connectum/events-amqp": minor
+---
+
+Add `publisherOptions.externalContract` for publishing against an external (non-EventBus) AMQP/AsyncAPI contract. When set, the adapter suppresses the EventBus envelope so the wire frame carries only contract-specified properties — no `x-event-id` / `x-published-at` headers, no auto-populated `messageId` / `timestamp`, and (for `mandatory` publishes) single-flight correlation so no `x-connectum-publish-id` header reaches the wire (`correlationHeader` is ignored in this mode). The frame then carries only `contentType`, `persistent`/deliveryMode, `mandatory`, and the headers supplied via `PublishOptions.metadata`.
+
+This closes the gap where `correlationHeader: false` was documented as yielding a "clean wire" but the envelope still shipped (#161). Default (EventBus) behavior is unchanged: the envelope is stamped on publish and stripped on delivery. Verified with a raw amqplib consumer against a real broker. A caller-controlled `messageId` / `timestamp` (needs a cross-package `PublishOptions` field) remains a documented follow-up.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -158,6 +158,7 @@ function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter
 | `persistent` | `boolean` | `true` | Persist messages (deliveryMode=2) |
 | `mandatory` | `boolean` | `false` | Reject the publish with `AmqpUnroutableError` if the broker cannot route the message |
 | `correlationHeader` | `boolean` | `true` | Correlate `basic.return` frames via a private `x-connectum-publish-id` header on mandatory publishes; `false` switches to single-flight serialization |
+| `externalContract` | `boolean` | `false` | Publish against an external (non-EventBus) contract: suppress the EventBus envelope so the wire carries only contract-specified properties (no `x-event-id` / `x-published-at` / auto `messageId` / `timestamp` / publish-id). Forces single-flight for `mandatory`. See [External AMQP Contract](#external-amqp-contract) |
 
 ### AmqpSerializationOptions
 
@@ -260,7 +261,7 @@ Example: "order.>"  →  "order.#"
 
 ### Metadata
 
-Event metadata is transmitted as AMQP message headers. Internal headers (`x-event-id`, `x-published-at`, `x-connectum-publish-id`) are set on publish and stripped from metadata on delivery.
+Event metadata is transmitted as AMQP message headers. Internal headers (`x-event-id`, `x-published-at`, `x-connectum-publish-id`) are set on publish and stripped from metadata on delivery. For an external contract that must not carry these, set `publisherOptions.externalContract: true` — see [External AMQP Contract](#external-amqp-contract).
 
 ### Reliable Publishing (Per-Message Confirms)
 
@@ -338,7 +339,9 @@ const adapter = AmqpAdapter({
   queueOverrides: {
     partner: { queue: 'partner.inbound.v1' },
   },
-  publisherOptions: { persistent: true, mandatory: true },
+  // externalContract: emit only contract-specified properties — no EventBus
+  // envelope (no x-event-id / x-published-at / auto messageId / publish-id).
+  publisherOptions: { persistent: true, mandatory: true, externalContract: true },
 });
 
 await adapter.connect();
@@ -360,7 +363,7 @@ const body = new TextEncoder().encode(JSON.stringify({ code: '0104603...' }));
 await adapter.publish('inbound', body);
 ```
 
-> **Wire-visible header**: with `mandatory: true` and the default `correlationHeader: true`, every mandatory publish carries a private `x-connectum-publish-id` header that external consumers will see. Either document it in the contract, or set `publisherOptions.correlationHeader: false` for a clean wire (single-flight throughput trade-off).
+> **Clean wire for external contracts.** By default the adapter stamps EventBus *envelope* metadata on every frame: the `x-event-id` and `x-published-at` headers, an auto-generated `messageId`, an auto `timestamp`, and — on mandatory publishes with the default `correlationHeader: true` — a private `x-connectum-publish-id` header. A consumer validating an external contract would see fields it never defined. Set **`publisherOptions.externalContract: true`** (as above) to suppress the whole envelope: the frame then carries only `contentType`, `persistent`/deliveryMode, `mandatory`, and exactly the headers you pass via `PublishOptions.metadata`. In this mode mandatory publishes use single-flight correlation, so no `x-connectum-publish-id` reaches the wire (`correlationHeader` is ignored). Note: `correlationHeader: false` alone removes only the publish-id header — the rest of the envelope still ships, so it is **not** a clean wire on its own. Setting a caller-controlled `messageId`/`timestamp` is a planned follow-up.
 
 ## Dependencies
 

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -155,7 +155,12 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
     const topologyMode = options.topologyMode ?? AmqpTopologyMode.ASSERT;
     const contentType = options.serialization?.contentType ?? DEFAULT_CONTENT_TYPE;
     const publishTimeoutMs = options.publishTimeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS;
-    const correlationHeader = options.publisherOptions?.correlationHeader ?? true;
+    // External-contract publishing suppresses the EventBus envelope (see
+    // AmqpPublisherOptions.externalContract). It also forces single-flight
+    // mandatory correlation so no `x-connectum-publish-id` header reaches the
+    // wire — `correlationHeader` is ignored in this mode.
+    const externalContract = options.publisherOptions?.externalContract ?? false;
+    const correlationHeader = externalContract ? false : (options.publisherOptions?.correlationHeader ?? true);
     const lifecycle = options.lifecycle;
 
     /** The recovering connection wrapper (amqplib opt-in recovery) or a plain connection. */
@@ -612,8 +617,13 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 }
             }
 
-            headers["x-event-id"] = eventId;
-            headers["x-published-at"] = new Date().toISOString();
+            // External-contract mode emits no EventBus envelope: the wire carries
+            // only the caller's contract-specified headers. Otherwise stamp the
+            // envelope (stripped again on delivery in subscribe()).
+            if (!externalContract) {
+                headers["x-event-id"] = eventId;
+                headers["x-published-at"] = new Date().toISOString();
+            }
 
             const persistent = options.publisherOptions?.persistent ?? true;
             const mandatory = options.publisherOptions?.mandatory ?? false;
@@ -665,14 +675,12 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                                 exchange,
                                 routingKey,
                                 body,
-                                {
-                                    persistent,
-                                    mandatory,
-                                    headers,
-                                    contentType,
-                                    messageId: eventId,
-                                    timestamp: Math.trunc(Date.now() / 1000),
-                                },
+                                // External-contract mode auto-populates neither messageId
+                                // nor timestamp (the contract owns them); the keys are
+                                // omitted entirely, not set to undefined.
+                                externalContract
+                                    ? { persistent, mandatory, headers, contentType }
+                                    : { persistent, mandatory, headers, contentType, messageId: eventId, timestamp: Math.trunc(Date.now() / 1000) },
                                 (err) => {
                                     // Per-message confirm callback (ack/nack). The broker
                                     // guarantees basic.return arrives BEFORE the confirm of

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -331,4 +331,32 @@ export interface AmqpPublisherOptions {
      * @default true
      */
     readonly correlationHeader?: boolean;
+
+    /**
+     * Publish against an EXTERNAL (non-EventBus) message contract: suppress the
+     * EventBus envelope so the wire frame carries ONLY contract-specified
+     * properties. For an external AsyncAPI/AMQP contract the oracle is the
+     * published spec, not this serializer — a third-party consumer validates the
+     * exact header/property set, which must not include adapter-internal fields.
+     *
+     * When `true`, `publish()`:
+     * - does NOT stamp the `x-event-id` / `x-published-at` headers;
+     * - does NOT auto-populate the `messageId` or `timestamp` properties;
+     * - uses single-flight correlation for `mandatory` publishes (so no
+     *   `x-connectum-publish-id` header reaches the wire) — `correlationHeader`
+     *   is ignored in this mode.
+     *
+     * The frame then carries only `contentType`, `persistent`/deliveryMode,
+     * `mandatory`, and exactly the headers passed via `PublishOptions.metadata`.
+     * Per-message confirms, `mandatory` → `AmqpUnroutableError`, the typed error
+     * taxonomy, and connection recovery are unchanged.
+     *
+     * Leave unset (default) for normal EventBus use, where the envelope is
+     * stamped on publish and stripped on delivery. Setting a caller-controlled
+     * `messageId` / `timestamp` is not yet supported (it needs a cross-package
+     * `PublishOptions` field — tracked as a follow-up).
+     *
+     * @default false
+     */
+    readonly externalContract?: boolean;
 }

--- a/packages/events-amqp/tests/integration/amqp-broker.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-broker.test.ts
@@ -17,6 +17,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type amqp from "amqplib";
 import { AmqpAdapter } from "../../src/AmqpAdapter.ts";
 import { AmqpTopologyError, AmqpUnroutableError } from "../../src/errors.ts";
 
@@ -306,6 +307,103 @@ describe("AMQP broker integration", { skip: AMQP_URL === undefined ? "AMQP_TEST_
             () => missing.connect(),
             (err: unknown) => err instanceof AmqpTopologyError,
         );
+    });
+
+    // ── External-contract publish mode (#161) ──────────────────────────────
+    // The oracle here is the RAW wire frame consumed via a plain amqplib channel
+    // — NOT adapter.subscribe(), which strips the envelope on delivery and would
+    // hide a dirty wire (tautological). We assert msg.properties directly.
+
+    it("external contract: the wire frame carries ONLY contract headers, no EventBus envelope (raw amqplib oracle)", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.external",
+            exchangeType: "topic",
+            recovery: false,
+            serialization: { contentType: "application/json" },
+            publisherOptions: { externalContract: true },
+        });
+        await adapter.connect(); // asserts the exchange so the raw consumer can bind
+        const amqplib = await import("amqplib");
+        const conn = await amqplib.connect(url);
+        try {
+            const ch = await conn.createChannel();
+            const q = await ch.assertQueue("", { exclusive: true });
+            await ch.bindQueue(q.queue, "it.external", "ext.clean");
+            const received: amqp.ConsumeMessage[] = [];
+            await ch.consume(q.queue, (m) => { if (m) received.push(m); }, { noAck: true });
+
+            await adapter.publish("ext.clean", new Uint8Array([1, 2, 3]), { metadata: { "x-trace-id": "trace-1" } });
+            await waitFor(() => received.length > 0);
+
+            const msg = received[0];
+            assert.ok(msg);
+            const headers = (msg.properties.headers ?? {}) as Record<string, unknown>;
+            // The caller's contract header passes through unchanged...
+            assert.equal(headers["x-trace-id"], "trace-1");
+            // ...and NONE of the EventBus envelope reaches the wire.
+            assert.equal(headers["x-event-id"], undefined, "x-event-id must not be on the wire");
+            assert.equal(headers["x-published-at"], undefined, "x-published-at must not be on the wire");
+            assert.equal(headers["x-connectum-publish-id"], undefined, "publish-id header must not be on the wire");
+            assert.equal(msg.properties.messageId, undefined, "messageId must not be auto-populated");
+            assert.equal(msg.properties.timestamp, undefined, "timestamp must not be auto-populated");
+            // Only contract-specified properties remain.
+            assert.equal(msg.properties.contentType, "application/json");
+            assert.deepEqual(new Uint8Array(msg.content), new Uint8Array([1, 2, 3]));
+        } finally {
+            await conn.close();
+            await adapter.disconnect();
+        }
+    });
+
+    it("default mode still stamps the EventBus envelope on the wire (raw amqplib oracle, regression)", async () => {
+        const adapter = AmqpAdapter({ url, exchange: "it.envelope", exchangeType: "topic", recovery: false });
+        await adapter.connect();
+        const amqplib = await import("amqplib");
+        const conn = await amqplib.connect(url);
+        try {
+            const ch = await conn.createChannel();
+            const q = await ch.assertQueue("", { exclusive: true });
+            await ch.bindQueue(q.queue, "it.envelope", "env.rk");
+            const received: amqp.ConsumeMessage[] = [];
+            await ch.consume(q.queue, (m) => { if (m) received.push(m); }, { noAck: true });
+
+            await adapter.publish("env.rk", new Uint8Array([9]));
+            await waitFor(() => received.length > 0);
+
+            const msg = received[0];
+            assert.ok(msg);
+            const headers = (msg.properties.headers ?? {}) as Record<string, unknown>;
+            assert.equal(typeof headers["x-event-id"], "string", "x-event-id stamped by default");
+            assert.equal(typeof headers["x-published-at"], "string", "x-published-at stamped by default");
+            assert.equal(typeof msg.properties.messageId, "string", "messageId auto-populated by default");
+            assert.equal(typeof msg.properties.timestamp, "number", "timestamp auto-populated by default");
+        } finally {
+            await conn.close();
+            await adapter.disconnect();
+        }
+    });
+
+    it("external contract + mandatory: unroutable rejects via single-flight, no publish-id header on the wire", async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "it.external.mandatory",
+            exchangeType: "topic",
+            recovery: false,
+            publisherOptions: { externalContract: true, mandatory: true },
+        });
+        await adapter.connect();
+        try {
+            // No queue bound for this key → the mandatory publish is returned and,
+            // even though no x-connectum-publish-id header is on the wire, the
+            // forced single-flight correlation still detects it as unroutable.
+            await assert.rejects(
+                adapter.publish("ext.unbound", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpUnroutableError,
+            );
+        } finally {
+            await adapter.disconnect();
+        }
     });
 
     // Connection-recovery scenarios (broker drop/restart mid-test) are in


### PR DESCRIPTION
Closes #161.

## Problem

`AmqpAdapter.publish()` unconditionally stamps EventBus *envelope* metadata onto every frame — `x-event-id` / `x-published-at` headers, an auto `messageId`, an auto `timestamp`, and (on mandatory publishes) the private `x-connectum-publish-id` header — and the caller cannot suppress them. For an external AsyncAPI/AMQP contract the oracle is the published spec, not our serializer: a third-party consumer validates the exact header/property set, so the adapter could not produce a contract-clean frame. The README's "clean wire via `correlationHeader: false`" note was inaccurate (it removes only the publish-id header).

## Change

Add **`publisherOptions.externalContract`** (Option A from the issue — adapter-level, no cross-package `PublishOptions` change). When `true`, `publish()`:

- does **not** stamp `x-event-id` / `x-published-at`;
- does **not** auto-populate `messageId` / `timestamp`;
- forces **single-flight** correlation for `mandatory` publishes → no `x-connectum-publish-id` on the wire (`correlationHeader` ignored).

The frame then carries only `contentType`, `persistent`/deliveryMode, `mandatory`, and the headers passed via `PublishOptions.metadata`. **Default (EventBus) behavior is unchanged** — envelope stamped on publish, stripped on delivery.

## Verification (real broker, raw oracle)

The new integration tests consume via a **raw amqplib channel** (not `adapter.subscribe`, which strips the envelope and would hide a dirty wire) and assert `msg.properties` directly:

- external-contract publish → only `x-trace-id` (caller metadata); no `x-event-id` / `x-published-at` / `x-connectum-publish-id`, no `messageId` / `timestamp`;
- default mode → envelope present (regression);
- external + mandatory unroutable → `AmqpUnroutableError` via single-flight, no publish-id header.

`pnpm test:unit` 27/27 (node/bun/esbuild) · `test:integration` 11/11 (`rabbitmq:4-alpine`) · typecheck + lint green. The existing mandatory/single-flight correlation tests still pass (the shared `correlationHeader` resolution change is covered).

## Notes

- Changeset: **minor** on `@connectum/events-amqp` (folds into the open Version Packages PR).
- A caller-controlled `messageId` / `timestamp` needs a cross-package `PublishOptions` field — documented follow-up on the issue, not in this PR.
- README "External AMQP Contract" recipe + Metadata note + options table updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `publisherOptions.externalContract` option to suppress internal envelope metadata when publishing to external AMQP contracts, enabling clean wire-level messaging without adapter headers

* **Documentation**
  * Updated README with configuration examples and guidance on external contract mode for cleaner message publishing to non-EventBus systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->