### PR TITLE
ci(release): auto-publish the versioned BSR contract label on release

### DIFF
--- a/.github/workflows/bsr-publish.yml
+++ b/.github/workflows/bsr-publish.yml
@@ -1,5 +1,12 @@
 name: Publish Proto to BSR
 
+# Manual BACKFILL / FALLBACK for BSR contract publishing.
+#
+# The normal path is automatic: release.yml pushes the contracts to BSR on every
+# release that changed `proto/connectum/...`, labelling them with both `main` and
+# the released version (`vX.Y.Z`). Use this workflow only to re-publish or
+# backfill a label out-of-band (e.g. a missed/older version, or a dry-run check).
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,3 +215,13 @@ jobs:
             --label "${{ github.ref_name }}" \
             --source-control-url "https://github.com/Connectum-Framework/connectum/commit/${{ github.sha }}"
 
+          # Also publish the immutable versioned label (vX.Y.Z) for this release,
+          # so consumers can pin the exact contract that ships with the npm
+          # version. The version comes from a fixed-group package's package.json
+          # (already bumped on main by the merged Version Packages PR). This
+          # removes the previously-manual bsr-publish.yml step for version labels.
+          VERSION=$(node -p "require('./packages/core/package.json').version")
+          buf push .bsr \
+            --label "v${VERSION}" \
+            --source-control-url "https://github.com/Connectum-Framework/connectum/commit/${{ github.sha }}"
+


### PR DESCRIPTION
## Summary

`release.yml` already pushes the proto contracts to BSR (labelled `main`) on any release that changed `proto/connectum/...`. This adds a second `buf push` in the same step that **also labels them with the released version** (`vX.Y.Z`, read from a fixed-group `package.json` — already bumped on `main` by the merged Version Packages PR). Removes the previously-manual `bsr-publish.yml` step for versioned labels and closes the "forgot the contract v-label" gap (which nearly happened for 1.1.0, whose `connectum.auth.v1` options proto changed — the ADR-029 `internal` marker). `bsr-publish.yml` stays as a manual backfill/fallback; its header now says so.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented in migration guide)
- [x] Documentation / chore / internal — CI/release-workflow only. **No changeset** (no published runtime code).

## Test plan

- [x] `release.yml` + `bsr-publish.yml` validated as well-formed YAML locally
- [x] Version source verified: `node -p "require('./packages/core/package.json').version"` → the fixed-group version (1.1.0 on `main` after the Version Packages PR)
- [x] Gating unchanged: the new push reuses the existing `proto-changes.changed == 'true'` + `changesets.published == 'true'` conditions and the already-built `.bsr` module + Buf auth
- [ ] Full path exercised on the next real release (by design — workflow runs only on release)

## Parity coverage

- [ ] Parity coverage added
- [x] **Parity N/A** — CI/release-workflow change only; no service-observable RPC behaviour is added or changed.

## Related issues / changes

- Precedes the **1.1.0 release** (#165): with this merged first, 1.1.0 auto-publishes the BSR `v1.1.0` label (its `connectum.auth.v1` proto changed via ADR-029 / #179).
- Complements the existing BSR auto-push + the `bsr-publish.yml` manual fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release publishing now adds a versioned label for each published BSR release, making releases easier to identify and trace by version.
* **Chores**
  * Clarified the manual publishing workflow with additional notes; no behavior changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->