### PR TITLE
fix(ci): authenticate buf push to BSR via BUF_TOKEN env

### DIFF
--- a/.github/workflows/bsr-publish.yml
+++ b/.github/workflows/bsr-publish.yml
@@ -80,6 +80,10 @@ jobs:
 
       - name: Push to BSR
         if: inputs.dry_run == false
+        env:
+          # buf push reads the token from env; the buf-action `setup_only` login
+          # does not reliably persist auth into this run step.
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: |
           buf push .bsr \
             --label "${{ inputs.label }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,11 @@ jobs:
 
       - name: Push proto to BSR
         if: steps.proto-changes.outputs.changed == 'true'
+        env:
+          # buf push reads the token from env; the buf-action `setup_only` login
+          # does NOT reliably persist auth into this run step (it failed on the
+          # 1.1.0 release with "not authenticated for buf.build").
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: |
           mkdir -p .bsr/connectum
           for proto_root in packages/*/proto/connectum/*/; do


### PR DESCRIPTION
## Summary

The 1.1.0 release's **Push proto to BSR** step failed with `you are not authenticated for buf.build`. The `bufbuild/buf-action` `setup_only` login does not reliably persist auth into the subsequent `run: buf push` step, so the push ran with no token. Pass it explicitly via `env: BUF_TOKEN: ${{ secrets.BUF_TOKEN }}` on the push steps (buf reads `BUF_TOKEN` from env) — in both `release.yml` and the manual `bsr-publish.yml`.

The `BUF_TOKEN` secret exists (updated 2026-03-22) — this is a wiring gap, not a missing/expired token. The auto-push had been latent since v1.0.0 (no `proto/connectum/...` changed in between), so it first surfaced on 1.1.0, which changed the auth options proto (the ADR-029 `internal` marker).

**npm 1.1.0 itself published fine** (all 15 packages) and the draft GitHub Release was created — only the BSR contract-label push failed.

## Type of change

- [x] Bug fix (non-breaking) — CI/release-workflow. **No changeset** (no published runtime code).
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented in migration guide)
- [ ] Documentation / chore / internal

## Test plan

- [x] Both workflows validated as well-formed YAML
- [ ] Verified end-to-end by running `bsr-publish.yml` (dry_run=false, label `v1.1.0`) from this branch — confirms the token now authenticates and backfills the 1.1.0 contract label

## Parity coverage

- [ ] Parity coverage added
- [x] **Parity N/A** — CI/release-workflow only; no service-observable RPC behaviour changed.

## Related issues / changes

- Recovers the BSR step of the 1.1.0 release (#165). Complements the versioned-label automation (#188), which sat on top of this latent auth gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)