### PR TITLE
feat(events-amqp): fail-fast initial setup + lifecycle & confirm hardening

### DIFF
--- a/.changeset/amqp-confirm-classification.md
+++ b/.changeset/amqp-confirm-classification.md
@@ -1,0 +1,5 @@
+---
+"@connectum/events-amqp": patch
+---
+
+Harden the connection-loss-vs-nack classification of in-flight publishes. A per-confirm-channel `close` flag (set via `prependListener`, before amqplib drains outstanding confirms) is now the primary structural signal for classifying a failed publish confirm as `AmqpConnectionError` vs `AmqpPublishNackError`; the amqplib error-text match is retained only as a defense-in-depth fallback. This makes the at-least-once republish decision robust to upstream error-text drift. No public API change, and genuine broker nacks on a live channel still classify as `AmqpPublishNackError`.

--- a/.changeset/amqp-failfast-initial-setup.md
+++ b/.changeset/amqp-failfast-initial-setup.md
@@ -1,0 +1,7 @@
+---
+"@connectum/events-amqp": minor
+---
+
+Add opt-in `failFastOnInitialSetupError` and an `onSetupFailed` lifecycle callback.
+
+When recovery is enabled, a deterministic setup/topology error on the **first** connect can now reject `connect()` with the typed `AmqpTopologyError` instead of hanging forever in amqplib's infinite recovery loop (under the default `maxRetries: Infinity`, amqplib never rejects the initial connect, so a permanent topology error previously hung `connect()`/`bus.start()` silently). A transient broker-unreachable at startup still blocks-and-retries. `onSetupFailed(error, { initial, attempt })` surfaces setup/topology failures on the initial validation probe and on every reconnect — distinct from a mere broker outage. Default behavior is unchanged (both are opt-in). Also corrects the `topologyMode: "check"` documentation, which previously promised unconditional "fail fast".

--- a/.changeset/amqp-onreconnecting-double-fire.md
+++ b/.changeset/amqp-onreconnecting-double-fire.md
@@ -1,0 +1,5 @@
+---
+"@connectum/events-amqp": patch
+---
+
+Fix `onReconnecting` firing twice per failed reconnect cycle. amqplib emits both `connect-failed` and `reconnect-scheduled` for a single failed attempt; the adapter now derives `onReconnecting` solely from `reconnect-scheduled`, so it fires exactly once per scheduled retry. The terminal, retries-exhausted case remains `onReconnectFailed`. Removes the undocumented `{ attempt: -1 }` sentinel that double-counted reconnect metrics.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -190,7 +190,7 @@ Queues declared in `topology.queues` are asserted once (with their full argument
 | `'skip'` | No topology operations; the application owns topology |
 
 > **`check` limitations**: AMQP has no passive introspection. `check` mode verifies only that exchanges and queues *exist* -- argument equivalence and binding presence are NOT verifiable. A conflicting redeclare elsewhere still fails with `PRECONDITION_FAILED` (406).
-
+>
 > **Fail-fast vs. recovery**: a topology `AmqpTopologyError` rejects `connect()` immediately **only** with `recovery: false` or `failFastOnInitialSetupError: true`. Under the default recovery (`maxRetries: Infinity`), a permanent topology error on the first connect otherwise enters the infinite recovery loop -- `connect()` does not reject; the failure is surfaced via `onSetupFailed` / `onReconnecting`. Set `failFastOnInitialSetupError: true` to reject a deterministic startup misconfiguration instead. See [Connection Recovery](#connection-recovery).
 
 ### AmqpQueueOverride

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -124,6 +124,7 @@ function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter
 | `topologyMode` | `'assert' \| 'check' \| 'skip'` | `'assert'` | How topology is established |
 | `queueOverrides` | `Record<string, AmqpQueueOverride>` | `undefined` | Map a consumer group to an externally named queue |
 | `recovery` | `boolean \| AmqpRecoveryOptions` | `true` | Automatic connection recovery (amqplib native); `false` disables |
+| `failFastOnInitialSetupError` | `boolean` | `false` | Reject `connect()` with the typed `AmqpTopologyError` on a deterministic setup/topology error at the **first** connect, instead of hanging in infinite recovery. Transient broker-unreachable still blocks-and-retries. |
 | `lifecycle` | `AmqpLifecycleCallbacks` | `undefined` | Connection lifecycle callbacks |
 | `publishTimeoutMs` | `number` | `30000` | Per-publish broker-outcome deadline |
 
@@ -185,10 +186,12 @@ Queues declared in `topology.queues` are asserted once (with their full argument
 | Mode | Behavior |
 |------|----------|
 | `'assert'` (default) | Declare topology idempotently (`assertExchange` / `assertQueue` / bind) |
-| `'check'` | Existence-only verification (`checkExchange` / `checkQueue`); fails fast with `AmqpTopologyError` on missing objects |
+| `'check'` | Existence-only verification (`checkExchange` / `checkQueue`); a missing object raises `AmqpTopologyError` |
 | `'skip'` | No topology operations; the application owns topology |
 
 > **`check` limitations**: AMQP has no passive introspection. `check` mode verifies only that exchanges and queues *exist* -- argument equivalence and binding presence are NOT verifiable. A conflicting redeclare elsewhere still fails with `PRECONDITION_FAILED` (406).
+
+> **Fail-fast vs. recovery**: a topology `AmqpTopologyError` rejects `connect()` immediately **only** with `recovery: false` or `failFastOnInitialSetupError: true`. Under the default recovery (`maxRetries: Infinity`), a permanent topology error on the first connect otherwise enters the infinite recovery loop -- `connect()` does not reject; the failure is surfaced via `onSetupFailed` / `onReconnecting`. Set `failFastOnInitialSetupError: true` to reject a deterministic startup misconfiguration instead. See [Connection Recovery](#connection-recovery).
 
 ### AmqpQueueOverride
 
@@ -222,8 +225,9 @@ queueOverrides: {
 |----------|-----------|------------|
 | `onConnected` | `() => void` | Connection established (initial and after recovery) |
 | `onDisconnected` | `(cause: Error) => void` | Connection lost |
-| `onReconnecting` | `(info: { attempt, delay, error }) => void` | A reconnect attempt is scheduled |
+| `onReconnecting` | `(info: { attempt, delay, error }) => void` | A reconnect attempt is scheduled (fires exactly once per scheduled retry) |
 | `onReconnectFailed` | `(cause: Error) => void` | Recovery exhausted (`maxRetries` reached) |
+| `onSetupFailed` | `(error, { initial, attempt }) => void` | Topology/setup failed on the initial validation probe (`initial: true`) or a reconnect re-assert (`initial: false`). Surfaces deterministic config drift distinctly from a broker outage; the initial-connect call requires the startup probe (runs when this callback or `failFastOnInitialSetupError` is set). |
 
 Connection errors are surfaced through these callbacks -- never console-only.
 
@@ -289,8 +293,8 @@ Recovery is delegated to amqplib v2 native opt-in recovery and is **enabled by d
 
 Connection behavior:
 
-- **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering.
-- **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable, and a lost connection is not restored.
+- **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering. Under the default `maxRetries: Infinity`, `connect()` blocks rather than failing fast, and a **permanent** setup/topology error on the first connect would otherwise loop indefinitely. Set `failFastOnInitialSetupError: true` to reject `connect()` with the typed `AmqpTopologyError` on such a deterministic startup misconfiguration while still recovering from transient broker outages; use `onSetupFailed` for observability without changing behavior.
+- **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable or topology setup fails, and a lost connection is not restored.
 
 ### Error Taxonomy
 

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -14,7 +14,7 @@ import { randomUUID } from "node:crypto";
 import type { AdapterContext, EventAdapter, EventSubscription, PublishOptions, RawEvent, RawEventHandler, RawSubscribeOptions } from "@connectum/events";
 import type amqp from "amqplib";
 import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
-import type { AmqpAdapterOptions, AmqpQueueOverride } from "./types.ts";
+import type { AmqpAdapterOptions, AmqpLifecycleCallbacks, AmqpQueueOverride } from "./types.ts";
 import { AmqpTopologyMode } from "./types.ts";
 
 /** Default exchange name when none is provided. */
@@ -65,9 +65,110 @@ export function toAmqpPattern(pattern: string): string {
  * must reject the publish with `AmqpConnectionError`, matching the documented
  * contract ("in-flight publishes reject with AmqpConnectionError on
  * connection loss").
+ *
+ * NOTE: this is a text-based FALLBACK. amqplib provides no `.code` at the
+ * confirm callback to distinguish a nacked from a closed channel, so the
+ * primary signal is the structural per-channel close flag tracked by
+ * {@link trackChannelClose} and consumed by {@link classifyConfirmError}; this
+ * regex only catches the residual case where the channel reference still
+ * matches but the error text indicates a close.
  */
 export function isConnectionLostError(err: unknown): boolean {
     return err instanceof Error && /channel closed|connection closed|closed unexpectedly/i.test(err.message);
+}
+
+/**
+ * Classify a publisher-confirm failure into a typed error.
+ *
+ * A connection/channel loss MUST reject with {@link AmqpConnectionError} (the
+ * message state is unknown → republish-safe); a genuine broker nack is
+ * {@link AmqpPublishNackError}. The decision is driven by STRUCTURAL signals the
+ * adapter owns — the publish is closing, the confirm channel emitted `close`, or
+ * it was swapped by recovery — with {@link isConnectionLostError} kept only as a
+ * defense-in-depth fallback for the error text.
+ */
+export function classifyConfirmError(params: {
+    readonly err: unknown;
+    readonly closing: boolean;
+    readonly channelClosed: boolean;
+    readonly channelSwapped: boolean;
+    readonly routingKey: string;
+}): AmqpConnectionError | AmqpPublishNackError {
+    const { err, closing, channelClosed, channelSwapped, routingKey } = params;
+    if (closing || channelClosed || channelSwapped || isConnectionLostError(err)) {
+        return new AmqpConnectionError("Connection lost while awaiting publish confirm", { cause: err });
+    }
+    return new AmqpPublishNackError(`Broker nacked message for routing key '${routingKey}'`, { cause: err });
+}
+
+/** Minimal channel surface needed to record a `close` before amqplib's drain. */
+interface AmqpChannelCloseSource {
+    prependListener(event: "close", listener: () => void): unknown;
+}
+
+/**
+ * Record a confirm channel as closed BEFORE amqplib drains its unconfirmed
+ * publishes.
+ *
+ * amqplib registers a `close` listener in the `Channel` constructor that fails
+ * every outstanding confirm with `Error("channel closed")` (amqplib
+ * `lib/channel.js`). Listeners run in registration order, so we MUST
+ * `prependListener` to set the flag first — otherwise the confirm callback would
+ * observe it unset. Consumed by {@link classifyConfirmError}.
+ */
+export function trackChannelClose<C extends AmqpChannelCloseSource>(ch: C, closed: WeakSet<C>): void {
+    ch.prependListener("close", () => {
+        closed.add(ch);
+    });
+}
+
+/** Side effects the recovery-lifecycle wiring needs from the adapter closure. */
+interface RecoveryLifecycleHooks {
+    readonly clearPublishChannel: () => void;
+    readonly failPendingReturns: () => void;
+    readonly nextReconnectAttempt: () => number;
+    readonly resetReconnectAttempt: () => void;
+}
+
+/** Structural subset of an amqplib recovering connection (or a Node EventEmitter). */
+interface AmqpRecoveryEmitter {
+    // biome-ignore lint/suspicious/noExplicitAny: matches Node's EventEmitter.on listener signature
+    on(event: string, listener: (...args: any[]) => void): unknown;
+}
+
+/**
+ * Wire the amqplib recovery lifecycle events to the public lifecycle callbacks.
+ *
+ * `onReconnecting` is driven SOLELY by `reconnect-scheduled` (it fires once per
+ * scheduled retry). amqplib emits `connect-failed` AND `reconnect-scheduled` for
+ * the same failed attempt, so also mapping `connect-failed` to `onReconnecting`
+ * would double-count; `connect-failed` only clears the half-open publish channel
+ * and (for a topology error) reports `onSetupFailed`. The terminal,
+ * retries-exhausted case is `reconnect-failed` → `onReconnectFailed`.
+ */
+export function wireRecoveryLifecycle(conn: AmqpRecoveryEmitter, lifecycle: AmqpLifecycleCallbacks | undefined, hooks: RecoveryLifecycleHooks): void {
+    conn.on("connect", () => {
+        hooks.resetReconnectAttempt();
+        lifecycle?.onConnected?.();
+    });
+    conn.on("disconnect", (err: Error) => {
+        hooks.failPendingReturns();
+        lifecycle?.onDisconnected?.(err);
+    });
+    conn.on("reconnect-scheduled", (info: { attempt: number; delay: number; error: Error }) => {
+        lifecycle?.onReconnecting?.(info);
+    });
+    conn.on("connect-failed", (err: Error) => {
+        hooks.clearPublishChannel();
+        const attempt = hooks.nextReconnectAttempt();
+        if (err instanceof AmqpTopologyError) {
+            lifecycle?.onSetupFailed?.(err, { initial: false, attempt });
+        }
+    });
+    conn.on("reconnect-failed", (err: Error) => {
+        hooks.clearPublishChannel();
+        lifecycle?.onReconnectFailed?.(err);
+    });
 }
 
 /**
@@ -169,6 +270,16 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
     let publishChannel: amqp.ConfirmChannel | null = null;
     let closing = false;
 
+    /** Reconnect attempt counter (own; never read from amqplib internals). */
+    let reconnectAttempt = 0;
+
+    /**
+     * Confirm channels observed closed, recorded BEFORE amqplib drains their
+     * unconfirmed publishes — the structural signal {@link classifyConfirmError}
+     * uses to tell a connection loss from a broker nack.
+     */
+    const closedPublishChannels = new WeakSet<amqp.ConfirmChannel>();
+
     /** Pending mandatory publishes awaiting confirm (publish-id → return flag). */
     const pendingReturns = new Map<string, PendingReturn>();
 
@@ -269,6 +380,10 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
      */
     async function setupPublishChannel(model: amqp.ChannelModel): Promise<void> {
         const ch = await model.createConfirmChannel();
+
+        // Mark the channel closed BEFORE amqplib drains outstanding confirms, so
+        // a connection loss is classified structurally (see classifyConfirmError).
+        trackChannelClose(ch, closedPublishChannels);
 
         ch.on("return", (msg: amqp.ConsumeMessage) => {
             const id = (msg.properties.headers as Record<string, unknown> | undefined)?.[PUBLISH_ID_HEADER];
@@ -508,6 +623,54 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 };
             }
 
+            // Optional fail-fast / observability probe: validate topology against
+            // a throwaway NON-recovering connection BEFORE entering amqplib's
+            // recovery loop, which never rejects connect() under the default
+            // maxRetries=Infinity (so a permanent topology error would otherwise
+            // hang connect() forever, silently). Runs only when opted in. A broker
+            // that is merely unreachable here is transient (fall through to
+            // recovery); only a deterministic AmqpTopologyError fails fast.
+            if (recoveryEnabled && (options.failFastOnInitialSetupError || lifecycle?.onSetupFailed)) {
+                const probeOptions: Record<string, unknown> = { ...options.socketOptions };
+                if (Object.keys(clientProperties).length > 0) {
+                    probeOptions.clientProperties = clientProperties;
+                }
+
+                let probe: amqp.ChannelModel | null = null;
+                try {
+                    probe = (await amqplib.connect(options.url, probeOptions)) as amqp.ChannelModel;
+                } catch {
+                    // Broker unreachable at startup — not a deterministic setup error.
+                    probe = null;
+                }
+
+                if (probe) {
+                    try {
+                        await onSetup(probe);
+                    } catch (err) {
+                        await probe.close().catch(() => undefined);
+                        publishChannel = null;
+                        if (err instanceof AmqpTopologyError) {
+                            lifecycle?.onSetupFailed?.(err, { initial: true, attempt: 0 });
+                            if (options.failFastOnInitialSetupError) {
+                                throw err;
+                            }
+                        }
+                        // Non-topology error, or fail-fast disabled: fall through
+                        // to the real recovering connect below.
+                        probe = null;
+                    }
+
+                    if (probe) {
+                        // Topology validated; discard the probe. The real recovering
+                        // connection re-runs onSetup (re-creating publishChannel)
+                        // before connect() returns.
+                        await probe.close().catch(() => undefined);
+                        publishChannel = null;
+                    }
+                }
+            }
+
             const conn = (await amqplib.connect(options.url, connectOptions)) as amqp.ChannelModel;
 
             // Surface connection lifecycle; never console-only.
@@ -516,28 +679,18 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             });
 
             if (recoveryEnabled) {
-                conn.on("connect", () => {
-                    lifecycle?.onConnected?.();
-                });
-                conn.on("disconnect", (err: Error) => {
-                    failPendingReturns();
-                    lifecycle?.onDisconnected?.(err);
-                });
-                conn.on("reconnect-scheduled", (info: { attempt: number; delay: number; error: Error }) => {
-                    lifecycle?.onReconnecting?.(info);
-                });
-                // A failed reconnect attempt (e.g. onSetup throws on a 406 topology
-                // re-assert) emits "connect-failed", NOT "reconnect-failed".
-                // Without this, a recurring setup failure under the default
-                // maxRetries=Infinity would loop silently. Surface it as a
-                // reconnecting signal carrying the failure so it is observable.
-                conn.on("connect-failed", (err: Error) => {
-                    publishChannel = null;
-                    lifecycle?.onReconnecting?.({ attempt: -1, delay: 0, error: err });
-                });
-                conn.on("reconnect-failed", (err: Error) => {
-                    publishChannel = null;
-                    lifecycle?.onReconnectFailed?.(err);
+                wireRecoveryLifecycle(conn, lifecycle, {
+                    clearPublishChannel: () => {
+                        publishChannel = null;
+                    },
+                    failPendingReturns,
+                    nextReconnectAttempt: () => {
+                        reconnectAttempt += 1;
+                        return reconnectAttempt;
+                    },
+                    resetReconnectAttempt: () => {
+                        reconnectAttempt = 0;
+                    },
                 });
 
                 // With recovery, the wrapper already ran onSetup before resolving.
@@ -695,11 +848,16 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                                     if (err) {
                                         // A dropped channel/connection (recovery may not yet
                                         // have swapped publishChannel) is a connection loss,
-                                        // not a broker nack — classify by the close signal.
+                                        // not a broker nack — classify by the structural
+                                        // close signal, with the text regex as a fallback.
                                         reject(
-                                            closing || publishChannel !== ch || isConnectionLostError(err)
-                                                ? new AmqpConnectionError("Connection lost while awaiting publish confirm", { cause: err })
-                                                : new AmqpPublishNackError(`Broker nacked message for routing key '${routingKey}'`, { cause: err }),
+                                            classifyConfirmError({
+                                                err,
+                                                closing,
+                                                channelClosed: closedPublishChannels.has(ch),
+                                                channelSwapped: publishChannel !== ch,
+                                                routingKey,
+                                            }),
                                         );
                                     } else if (pending.returned) {
                                         reject(new AmqpUnroutableError(`Message unroutable (mandatory): no queue bound for routing key '${routingKey}'`, routingKey));

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -76,8 +76,12 @@ export interface AmqpAdapterOptions {
     /**
      * How topology is established:
      * - `"assert"` (default) — declare idempotently (assertExchange/assertQueue/bind);
-     * - `"check"` — existence-only verification (checkExchange/checkQueue), fail
-     *   fast with AmqpTopologyError on missing objects. AMQP offers no passive
+     * - `"check"` — existence-only verification (checkExchange/checkQueue). A
+     *   missing object raises AmqpTopologyError, which fails `connect()` fast
+     *   ONLY with `recovery: false` or `failFastOnInitialSetupError: true`; under
+     *   the default recovery a first-connect check failure otherwise enters the
+     *   (infinite) recovery loop and is surfaced via `onSetupFailed` /
+     *   `onReconnecting` rather than rejecting `connect()`. AMQP offers no passive
      *   introspection: argument equivalence and binding presence are NOT
      *   verifiable in this mode (a conflicting redeclare elsewhere is
      *   PRECONDITION_FAILED 406);
@@ -109,6 +113,33 @@ export interface AmqpAdapterOptions {
      * @default true (amqplib defaults: 100ms initial, ×2, 30s cap, jitter 0.2, infinite retries)
      */
     readonly recovery?: boolean | AmqpRecoveryOptions;
+
+    /**
+     * Fail fast on a DETERMINISTIC setup/topology error on the FIRST connect,
+     * instead of entering amqplib's infinite recovery loop.
+     *
+     * amqplib's opt-in recovery resolves `connect()` only after its setup hook
+     * succeeds, and rejects only once `maxRetries` is exhausted (default
+     * `Infinity`). A permanent topology error on the first connect under the
+     * default recovery therefore HANGS `connect()` forever, with no thrown error
+     * and — because the lifecycle listeners attach only after that never-returning
+     * await — no callback. When this flag is `true` (and recovery is enabled), the
+     * adapter first validates topology against a throwaway non-recovering
+     * connection; a topology error rejects `connect()` with the typed
+     * `AmqpTopologyError` / `AmqpConnectionError`.
+     *
+     * Only deterministic setup/topology errors fail fast. A transient
+     * broker-unreachable at startup is NOT a fail-fast condition — it falls
+     * through to normal recovery (block-until-broker). SUBSEQUENT reconnects
+     * always keep infinite-recovery behavior.
+     *
+     * No-op with `recovery: false` (that path already fails fast on setup).
+     * Enabling this (or supplying {@link AmqpLifecycleCallbacks.onSetupFailed})
+     * adds one extra short-lived connection at startup for the validation probe.
+     *
+     * @default false
+     */
+    readonly failFastOnInitialSetupError?: boolean;
 
     /**
      * Connection lifecycle callbacks. Connection errors are surfaced here —
@@ -223,8 +254,27 @@ export interface AmqpRecoveryOptions {
 export interface AmqpLifecycleCallbacks {
     readonly onConnected?: () => void;
     readonly onDisconnected?: (cause: Error) => void;
+    /**
+     * A reconnect attempt has been scheduled. Fires exactly ONCE per scheduled
+     * retry (amqplib's `reconnect-scheduled`). A failed attempt that also emits
+     * `connect-failed` does NOT double-invoke this; the terminal, retries-exhausted
+     * case is reported via {@link onReconnectFailed}, not here.
+     */
     readonly onReconnecting?: (info: { attempt: number; delay: number; error: Error }) => void;
     readonly onReconnectFailed?: (cause: Error) => void;
+    /**
+     * A setup/topology failure occurred while (re)applying the declarative
+     * topology — on the initial connect's validation probe (`ctx.initial: true`,
+     * `ctx.attempt: 0`) and/or on a reconnect whose topology re-assert fails
+     * (`ctx.initial: false`, `ctx.attempt` ≥ 1).
+     *
+     * This surfaces deterministic configuration drift (e.g. a missing queue in
+     * `check` mode, or a `PRECONDITION_FAILED` redeclare) distinctly from a mere
+     * broker outage, even when fail-fast is off. The initial-connect invocation
+     * requires a startup validation probe, which runs when either this callback or
+     * {@link AmqpAdapterOptions.failFastOnInitialSetupError} is set.
+     */
+    readonly onSetupFailed?: (error: Error, ctx: { readonly initial: boolean; readonly attempt: number }) => void;
 }
 
 /**

--- a/packages/events-amqp/tests/integration/amqp-recovery.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-recovery.test.ts
@@ -21,12 +21,13 @@
 
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { after, before, describe, it } from "node:test";
 import { promisify } from "node:util";
 import { type CreatedProxy, type StartedToxiProxyContainer, ToxiProxyContainer } from "@testcontainers/toxiproxy";
 import { connect } from "amqplib";
 import { GenericContainer, Network, type StartedNetwork, type StartedTestContainer } from "testcontainers";
-import { AmqpAdapter } from "../../src/AmqpAdapter.ts";
+import { AmqpAdapter, isConnectionLostError } from "../../src/AmqpAdapter.ts";
 import { AmqpConnectionError, AmqpPublishTimeoutError, AmqpTopologyError } from "../../src/errors.ts";
 
 const execFileAsync = promisify(execFile);
@@ -412,6 +413,114 @@ describe("AMQP connection recovery (testcontainers)", { skip: RUN ? false : "RUN
             }
         } finally {
             await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("failFastOnInitialSetupError: a permanent topology error rejects connect() instead of hanging", { timeout: 20_000 }, async () => {
+        // Pre-declare a queue with one argument via a throwaway connection.
+        const pre = await connect(url);
+        const pch = await pre.createChannel();
+        await pch.assertQueue("rec.ff.q", { durable: true, arguments: { "x-max-length": 100 } });
+        await pch.close();
+        await pre.close();
+
+        const setupFailures: Array<{ initial: boolean; attempt: number }> = [];
+        // recovery ENABLED (default) + flag: must reject FAST via the typed error,
+        // not hang forever in amqplib's infinite recovery loop.
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.ff",
+            exchangeType: "direct",
+            failFastOnInitialSetupError: true,
+            topology: { queues: [{ name: "rec.ff.q", durable: true, arguments: { "x-max-length": 999 } }] },
+            lifecycle: { onSetupFailed: (_e, ctx) => setupFailures.push({ ...ctx }) },
+        });
+
+        await assert.rejects(
+            () => adapter.connect(),
+            (err: unknown) => err instanceof AmqpTopologyError,
+        );
+        assert.deepEqual(setupFailures, [{ initial: true, attempt: 0 }]);
+        await adapter.disconnect().catch(() => undefined);
+    });
+
+    it("failFastOnInitialSetupError: valid topology still connects and publishes (probe does not break the happy path)", { timeout: 20_000 }, async () => {
+        const setupFailures: unknown[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.ff.ok",
+            exchangeType: "topic",
+            failFastOnInitialSetupError: true,
+            lifecycle: { onSetupFailed: (e) => setupFailures.push(e) },
+        });
+        await adapter.connect();
+        try {
+            // The probe nulled publishChannel; the real recovering connect must
+            // have re-created it, so publish works end-to-end.
+            await adapter.publish("rec.ff.ok.evt", new TextEncoder().encode("hello"));
+            assert.equal(setupFailures.length, 0);
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("amqplib pin: an outstanding confirm is rejected with 'channel closed' on connection loss", { timeout: 20_000 }, async () => {
+        // A5: the classifier's text fallback depends on this exact amqplib wording.
+        const raw = await connect(url);
+        // Swallow the socket-loss error we deliberately induce (raw + underlying connection).
+        (raw as unknown as EventEmitter).on("error", () => undefined);
+        const conn = (raw as unknown as { connection: EventEmitter & { stream: { destroy: (err?: Error) => void } } }).connection;
+        conn.on("error", () => undefined);
+        try {
+            const ch = await raw.createConfirmChannel();
+            ch.on("error", () => undefined);
+            await ch.assertQueue("rec.pin.drop", { durable: true });
+
+            const confirmErr = new Promise<Error | null>((resolve) => {
+                ch.sendToQueue("rec.pin.drop", Buffer.from("x"), { persistent: true }, (err) => resolve(err ?? null));
+            });
+            // Destroy the socket in the SAME tick as the publish: the broker confirm
+            // cannot have round-tripped yet, so the confirm is outstanding and amqplib
+            // drains it with Error("channel closed") — deterministic, with no race
+            // against a fast localhost broker. (wrapStream returns the raw Duplex
+            // socket; destroy(err) emits 'error', which amqplib's onSocketError
+            // handler — stream.on('error') at connection.js:214 — reacts to, unlike a
+            // bare destroy() that only emits 'close'.)
+            conn.stream.destroy(new Error("test: forced socket loss"));
+
+            const err = await confirmErr;
+            assert.ok(err instanceof Error, "the outstanding confirm must be rejected on socket loss");
+            assert.ok(isConnectionLostError(err), `amqplib drop wording changed (classifier fallback would miss it): ${err.message}`);
+        } finally {
+            await raw.close().catch(() => undefined);
+        }
+    });
+
+    it("amqplib pin: an over-capacity queue nacks the publish with 'message nacked' (NOT a connection loss)", { timeout: 20_000 }, async () => {
+        // A5: a genuine nack must NOT match the connection-lost fallback regex.
+        const raw = await connect(url);
+        (raw as unknown as EventEmitter).on("error", () => undefined);
+        try {
+            const ch = await raw.createConfirmChannel();
+            // Exclusive (not transient non-exclusive, which RabbitMQ 4 deprecates →
+            // 541 INTERNAL_ERROR): auto-removed when this connection closes.
+            const q = "rec.pin.nack";
+            await ch.assertQueue(q, { exclusive: true, arguments: { "x-max-length": 1, "x-overflow": "reject-publish" } });
+
+            // First message fills the queue (length 1, no consumer).
+            await new Promise<void>((resolve, reject) => {
+                ch.sendToQueue(q, Buffer.from("1"), {}, (err) => (err ? reject(err) : resolve()));
+            });
+            // Second exceeds max-length with reject-publish → broker nacks it.
+            const nackErr = await new Promise<Error | null>((resolve) => {
+                ch.sendToQueue(q, Buffer.from("2"), {}, (err) => resolve(err ?? null));
+            });
+
+            assert.ok(nackErr instanceof Error, "over-capacity publish must be nacked");
+            assert.match(nackErr.message, /message nacked/i, "amqplib nack wording changed");
+            assert.equal(isConnectionLostError(nackErr), false, "a nack must not be misclassified as a connection loss");
+        } finally {
+            await raw.close().catch(() => undefined);
         }
     });
 });

--- a/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
-import { AmqpAdapter, isConnectionLostError, toAmqpPattern } from "../../src/AmqpAdapter.ts";
+import { AmqpAdapter, classifyConfirmError, isConnectionLostError, toAmqpPattern, trackChannelClose, wireRecoveryLifecycle } from "../../src/AmqpAdapter.ts";
+import { AmqpConnectionError, AmqpPublishNackError, AmqpTopologyError } from "../../src/errors.ts";
+import type { AmqpLifecycleCallbacks } from "../../src/types.ts";
 
 describe("isConnectionLostError", () => {
     it("classifies amqplib channel/connection-close errors as connection loss", () => {
@@ -239,5 +242,153 @@ describe("toAmqpPattern", () => {
 
     it("should handle pattern with only >", () => {
         assert.equal(toAmqpPattern(">"), "#");
+    });
+});
+
+describe("classifyConfirmError", () => {
+    const base = { closing: false, channelClosed: false, channelSwapped: false, routingKey: "rk" };
+
+    it("classifies a genuine broker nack on a live channel as AmqpPublishNackError", () => {
+        const out = classifyConfirmError({ ...base, err: new Error("message nacked") });
+        assert.ok(out instanceof AmqpPublishNackError);
+    });
+
+    it("classifies via the structural close flag even when the error text does NOT match the regex", () => {
+        // This is the discriminating case: a regex-only classifier would call
+        // this a nack; the structural channelClosed flag correctly says connection loss.
+        const out = classifyConfirmError({ ...base, channelClosed: true, err: new Error("some-future-amqplib-close-phrasing") });
+        assert.ok(out instanceof AmqpConnectionError);
+    });
+
+    it("classifies via closing and channelSwapped structurally", () => {
+        assert.ok(classifyConfirmError({ ...base, closing: true, err: new Error("message nacked") }) instanceof AmqpConnectionError);
+        assert.ok(classifyConfirmError({ ...base, channelSwapped: true, err: new Error("message nacked") }) instanceof AmqpConnectionError);
+    });
+
+    it("still classifies the legacy text fallback as connection loss", () => {
+        assert.ok(classifyConfirmError({ ...base, err: new Error("channel closed") }) instanceof AmqpConnectionError);
+    });
+});
+
+describe("trackChannelClose", () => {
+    it("sets the closed flag BEFORE amqplib's own close drain runs (prependListener)", () => {
+        const ee = new EventEmitter();
+        const closed = new WeakSet<EventEmitter>();
+
+        // Simulate amqplib's constructor-registered close drain: registered FIRST,
+        // it records what the flag looked like when it ran.
+        let flagWhenDrainRan: boolean | undefined;
+        ee.on("close", () => {
+            flagWhenDrainRan = closed.has(ee);
+        });
+
+        // trackChannelClose registers AFTER the drain but must prepend, so its
+        // flag-setter runs first.
+        trackChannelClose(ee, closed);
+
+        ee.emit("close");
+
+        assert.equal(flagWhenDrainRan, true, "the close flag must be set before the drain listener runs (use prependListener, not on)");
+        assert.equal(closed.has(ee), true);
+    });
+});
+
+describe("wireRecoveryLifecycle", () => {
+    function setup(lifecycle: AmqpLifecycleCallbacks) {
+        const ee = new EventEmitter();
+        let attempt = 0;
+        const calls = { clearPublishChannel: 0, failPendingReturns: 0, reset: 0 };
+        wireRecoveryLifecycle(ee, lifecycle, {
+            clearPublishChannel: () => {
+                calls.clearPublishChannel += 1;
+            },
+            failPendingReturns: () => {
+                calls.failPendingReturns += 1;
+            },
+            nextReconnectAttempt: () => {
+                attempt += 1;
+                return attempt;
+            },
+            resetReconnectAttempt: () => {
+                calls.reset += 1;
+                attempt = 0;
+            },
+        });
+        return { ee, calls };
+    }
+
+    it("fires onReconnecting exactly once per failed attempt (connect-failed + reconnect-scheduled pair)", () => {
+        const reconnecting: Array<{ attempt: number; delay: number }> = [];
+        const { ee } = setup({ onReconnecting: (info) => reconnecting.push({ attempt: info.attempt, delay: info.delay }) });
+
+        // amqplib emits BOTH connect-failed and reconnect-scheduled for one failed attempt.
+        ee.emit("connect-failed", new Error("attempt failed"));
+        ee.emit("reconnect-scheduled", { attempt: 1, delay: 100, error: new Error("attempt failed") });
+
+        assert.equal(reconnecting.length, 1, "onReconnecting must fire once per scheduled retry, not also on connect-failed");
+        assert.deepEqual(reconnecting[0], { attempt: 1, delay: 100 });
+    });
+
+    it("reports the terminal exhausted case via onReconnectFailed, not onReconnecting", () => {
+        let reconnecting = 0;
+        let reconnectFailed = 0;
+        const { ee, calls } = setup({
+            onReconnecting: () => {
+                reconnecting += 1;
+            },
+            onReconnectFailed: () => {
+                reconnectFailed += 1;
+            },
+        });
+
+        ee.emit("connect-failed", new Error("attempt failed"));
+        ee.emit("reconnect-failed", new Error("recovery exhausted"));
+
+        assert.equal(reconnecting, 0);
+        assert.equal(reconnectFailed, 1);
+        assert.equal(calls.clearPublishChannel, 2, "both connect-failed and reconnect-failed clear the publish channel");
+    });
+
+    it("reports a topology setup failure on a reconnect via onSetupFailed with attempt context", () => {
+        const setupFailures: Array<{ initial: boolean; attempt: number }> = [];
+        const { ee } = setup({ onSetupFailed: (_err, ctx) => setupFailures.push({ ...ctx }) });
+
+        ee.emit("connect-failed", new AmqpTopologyError("Topology declaration failed: 406"));
+        ee.emit("connect-failed", new AmqpTopologyError("Topology declaration failed: 406"));
+
+        assert.deepEqual(setupFailures, [
+            { initial: false, attempt: 1 },
+            { initial: false, attempt: 2 },
+        ]);
+    });
+
+    it("does NOT call onSetupFailed for a non-topology connect-failed", () => {
+        let setupFailed = 0;
+        const { ee } = setup({ onSetupFailed: () => {
+            setupFailed += 1;
+        } });
+
+        ee.emit("connect-failed", new Error("ECONNRESET"));
+        assert.equal(setupFailed, 0);
+    });
+
+    it("resets the attempt counter and fires onConnected on connect; drains pending on disconnect", () => {
+        let connected = 0;
+        const disconnects: Error[] = [];
+        const { ee, calls } = setup({
+            onConnected: () => {
+                connected += 1;
+            },
+            onDisconnected: (cause) => disconnects.push(cause),
+        });
+
+        ee.emit("connect-failed", new Error("x")); // attempt -> 1
+        ee.emit("connect"); // resets attempt
+        ee.emit("disconnect", new Error("dropped"));
+
+        assert.equal(connected, 1);
+        assert.equal(calls.reset, 1);
+        assert.equal(calls.failPendingReturns, 1);
+        assert.deepEqual(disconnects.map((e) => e.message), ["dropped"]);
     });
 });


### PR DESCRIPTION
## Summary

Resolves a v1.1.0 `@connectum/events-amqp` blocker: a **permanent topology error on the initial connect hangs `connect()` / `bus.start()` forever, silently**, under the default recovery — `maxRetries: Infinity` never rejects the initial connect, and the lifecycle listeners attach only after that never-returning `await`. Rolling back to hand-rolled connection management was evaluated and rejected (no reliability gain); this fixes the framework at the source so every consumer benefits.

Three changes land together (they touch the same recovery / confirm paths).

### #200 — fail-fast on initial setup error (minor)
- New opt-in `failFastOnInitialSetupError` (default `false`): on the **first** connect, a deterministic setup/topology error rejects `connect()` with the typed `AmqpTopologyError` instead of entering infinite recovery. A transient broker-unreachable at startup still blocks-and-retries; subsequent reconnects keep infinite recovery.
- New `onSetupFailed(error, { initial, attempt })` lifecycle callback for observability on the initial probe and on reconnects.
- Implementation: *probe-then-recover* — validate topology against a throwaway non-recovering connection before entering amqplib recovery. No public-API or default-behavior change when neither the option nor the callback is set.
- Corrects the `topologyMode: "check"` JSDoc + README, which previously promised an unconditional "fail fast".

### #190 — `onReconnecting` double-fire (patch)
amqplib emits both `connect-failed` **and** `reconnect-scheduled` for a single failed attempt. `onReconnecting` is now driven solely by `reconnect-scheduled` (fires exactly once per scheduled retry); the terminal exhausted case remains `onReconnectFailed`. Removes the undocumented `{ attempt: -1 }` sentinel that double-counted reconnect metrics.

### #194 — confirm-classification hardening (patch)
A per-confirm-channel `close` flag (set via `prependListener`, before amqplib drains outstanding confirms) is now the primary **structural** signal for classifying an in-flight publish failure as `AmqpConnectionError` vs `AmqpPublishNackError`; the amqplib error-text match is retained only as a defense-in-depth fallback. This makes the at-least-once republish decision robust to upstream error-text drift.

> Scope note: this went beyond the originally filed "pin the error texts" scope — it is a classifier **code** change, not just a test. Patch-safe: a genuine broker nack on a live channel still classifies as `AmqpPublishNackError`; only previously-misclassified connection losses change.

## Verification
- **Unit** (node + bun + esbuild): 37/37, incl. 11 new tests — lifecycle once-per-retry, structural classification (with a discriminating case a regex-only impl would fail), and a `prependListener` ordering pin.
- **Recovery integration** (`RUN_RECOVERY_TESTS=1`, testcontainers): 14/14, incl. fail-fast reject, post-probe happy-path publish, and amqplib error-text pins (`channel closed` / `message nacked`).
- **Full monorepo** `build` + `typecheck` + `lint` + `test`: green.

## Release
Deferred to the maintainer. The `#200` minor changeset bumps the fixed `@connectum/*` family to **1.2.0** via the Version Packages PR.

Closes #200
Closes #190
Closes #194

The `topologyMode: "check"` docs correction from #191 is folded in here (it documents the behavior #200 introduces); the remaining recovery-semantics doc gaps (blocking `connect()` under `Infinity`, jitter overshoot, `maxRetries` scope) stay in #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional fail-fast setting for initial AMQP setup errors, so some configuration issues now fail immediately instead of waiting in recovery.
  * Added a new setup-failure callback to surface topology/setup problems during connection attempts and reconnects.

* **Bug Fixes**
  * Improved publish confirmation handling so connection loss and broker nacks are classified more reliably.
  * Fixed reconnect notifications so they no longer fire twice during a failed reconnect cycle.

* **Documentation**
  * Updated AMQP connection, recovery, and topology-mode docs to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->