### PR TITLE
docs(events-amqp): republish-safety matrix + recovery semantics (#191 #192 #193)

### DIFF
--- a/.changeset/amqp-recovery-republish-docs.md
+++ b/.changeset/amqp-recovery-republish-docs.md
@@ -1,0 +1,9 @@
+---
+"@connectum/events-amqp": patch
+---
+
+docs(events-amqp): document republish-safety and recovery semantics
+
+- The Error Taxonomy now publishes an authoritative **Message state** / **Republish (at-least-once)** matrix (README + the errors `@module` JSDoc) so at-least-once producers no longer infer retry-safety from class names. Connection loss is classified structurally and is never misreported as a nack; `AmqpSerializationError`/`AmqpUnroutableError`/`AmqpTopologyError` are documented as deterministic (do-not-republish).
+- Recovery docs clarify that `maxRetries` governs **both** the initial connect and every steady-state recovery series (counter reset on success), with the brittleness of a finite value, and that the effective reconnect delay can overshoot `maxDelay` because of equal-jitter.
+- `topologyMode: "check"` and the recovery JSDoc are finalized: fail-fast applies only with `recovery: false` or `failFastOnInitialSetupError: true`; under the default recovery a permanent setup error is surfaced via `onSetupFailed` / `onReconnecting`.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -214,10 +214,10 @@ queueOverrides: {
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `initialDelay` | `number` | `100` | First reconnect delay in ms |
-| `maxDelay` | `number` | `30000` | Delay cap in ms |
+| `maxDelay` | `number` | `30000` | Base delay cap in ms. The effective wait adds equal-jitter on top, so it can exceed this (~20% at the default jitter, up to ~2x at `jitter: 1`) |
 | `factor` | `number` | `2` | Exponential backoff factor |
-| `jitter` | `number` | `0.2` | Randomization factor (0..1) |
-| `maxRetries` | `number` | `Infinity` | Give up after this many attempts |
+| `jitter` | `number` | `0.2` | Equal-jitter randomization factor (0..1) applied around the base delay |
+| `maxRetries` | `number` | `Infinity` | Attempts per series before giving up. Governs **both** the initial connect and each later recovery series; the counter resets on every success |
 
 ### AmqpLifecycleCallbacks
 
@@ -294,21 +294,27 @@ Recovery is delegated to amqplib v2 native opt-in recovery and is **enabled by d
 Connection behavior:
 
 - **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering. Under the default `maxRetries: Infinity`, `connect()` blocks rather than failing fast, and a **permanent** setup/topology error on the first connect would otherwise loop indefinitely. Set `failFastOnInitialSetupError: true` to reject `connect()` with the typed `AmqpTopologyError` on such a deterministic startup misconfiguration while still recovering from transient broker outages; use `onSetupFailed` for observability without changing behavior.
+- **`maxRetries` scope.** The retry budget governs **both** the initial connect and every later recovery series, with the counter reset on each success. A finite value chosen only to bound startup therefore makes the adapter brittle in steady state: a normal transient blip of that many consecutive failures in any single series permanently stops recovery. The default `Infinity` blocks at startup but never self-destructs on a transient outage.
+- **Reconnect delay.** The effective delay is amqplib equal-jitter around the exponential base (`initialDelay` × `factor`ⁿ, capped at `maxDelay`) and is **not** clamped from above by `maxDelay`, so it can overshoot (~20% at the default `jitter: 0.2`, up to ~2x at `jitter: 1`).
 - **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable or topology setup fails, and a lost connection is not restored.
 
 ### Error Taxonomy
 
-Every terminal publish/topology outcome is distinguishable by error class -- what an at-least-once producer needs for an "advance cursor after confirm" pattern:
+Every terminal publish/topology outcome is distinguishable by error class -- what an at-least-once producer needs for an "advance cursor after confirm" pattern. The **Message state** and **Republish** columns are the published, authoritative retry-safety policy:
 
-| Error | Meaning |
-|-------|---------|
-| `AmqpAdapterError` | Base class for all adapter errors |
-| `AmqpConnectionError` | Connection absent, lost, or recovery in progress / exhausted |
-| `AmqpUnroutableError` | Broker returned a `mandatory` message as unroutable (`basic.return`); has `.routingKey` |
-| `AmqpPublishNackError` | Broker negatively acknowledged (nacked) a published message |
-| `AmqpPublishTimeoutError` | No broker outcome within `publishTimeoutMs`; message state UNKNOWN |
-| `AmqpTopologyError` | Topology declaration or verification failed (missing object in `check` mode, conflicting redeclare in `assert` mode) |
-| `AmqpSerializationError` | Payload encoding failed in a custom `serialization.encode` hook |
+| Error | Meaning | Message state | Republish (at-least-once) |
+|-------|---------|---------------|---------------------------|
+| `AmqpAdapterError` | Base class for all adapter errors | -- | -- |
+| `AmqpConnectionError` | Connection absent, lost, or recovery in progress / exhausted | Not sent (pre-send) or UNKNOWN (in-flight)\* | **Yes** |
+| `AmqpPublishTimeoutError` | No broker outcome within `publishTimeoutMs` | UNKNOWN | **Yes** |
+| `AmqpPublishNackError` | Broker negatively acknowledged (nacked) a published message | Sent, refused | **Yes** -- policy: treated as retriable |
+| `AmqpUnroutableError` | Broker returned a `mandatory` message as unroutable (`basic.return`); has `.routingKey` | Sent, dropped | **No** -- deterministic; fix topology/routing |
+| `AmqpSerializationError` | Payload encoding failed in a custom `serialization.encode` hook | Never sent | **No** -- deterministic |
+| `AmqpTopologyError` | Topology declaration or verification failed (missing object in `check` mode, conflicting redeclare in `assert` mode) | N/A (not a publish) | **No** -- fix config/topology |
+
+> **Do not infer republish-safety from class names -- this matrix is the policy.** In particular the **Nack** row is a maintainer decision: a `basic.nack` is treated as a retriable, deliverable-on-retry outcome (e.g. a queue at capacity with `x-overflow: reject-publish`), so an at-least-once producer should republish. Connection loss is classified *structurally* (the confirm channel emitted `close`, was swapped by recovery, or the publish is closing) rather than by amqplib's error text, so an in-flight connection drop is never misreported as a nack.
+>
+> \* `AmqpConnectionError` covers both a **pre-send** failure (publishing while disconnected, or a synchronous publish failure -- the message is never sent) and an **in-flight** loss (the connection drops while awaiting the confirm -- state genuinely UNKNOWN). Both are republish-safe; UNKNOWN is the conservative label.
 
 ## External AMQP Contract
 

--- a/packages/events-amqp/src/errors.ts
+++ b/packages/events-amqp/src/errors.ts
@@ -6,6 +6,23 @@
  * "advance cursor after confirm" pattern: a non-advanced message corresponds
  * to exactly one typed error explaining why.
  *
+ * Authoritative republish policy (do not infer it from class names):
+ *
+ * | Error                     | Message state      | Republish (at-least-once) |
+ * | ------------------------- | ------------------ | ------------------------- |
+ * | `AmqpConnectionError`     | not sent / UNKNOWN | Yes                       |
+ * | `AmqpPublishTimeoutError` | UNKNOWN            | Yes                       |
+ * | `AmqpPublishNackError`    | sent, refused      | Yes (policy: retriable)   |
+ * | `AmqpUnroutableError`     | sent, dropped      | No (deterministic)        |
+ * | `AmqpSerializationError`  | never sent         | No (deterministic)        |
+ * | `AmqpTopologyError`       | N/A                | No (fix config)           |
+ *
+ * `AmqpConnectionError` is thrown pre-send (never sent) or on an in-flight
+ * confirm loss (UNKNOWN); both are republish-safe. The `AmqpSerializationError`
+ * row is the publish-side encode failure; the same class is also thrown on the
+ * consumer side for a decode failure (nack without requeue), which is outside
+ * republish semantics.
+ *
  * @module errors
  */
 

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -110,6 +110,13 @@ export interface AmqpAdapterOptions {
      * In-flight publishes at the moment of a connection loss reject with
      * `AmqpConnectionError`.
      *
+     * `maxRetries` governs BOTH the initial connect and steady-state recovery
+     * (counter reset on success); under the default `Infinity`, `connect()`
+     * blocks until the broker is reachable rather than failing fast (see
+     * {@link AmqpAdapterOptions.failFastOnInitialSetupError} to fail fast on a
+     * deterministic startup misconfiguration). See {@link AmqpRecoveryOptions}
+     * for the retry-budget scope and jitter/`maxDelay` overshoot.
+     *
      * @default true (amqplib defaults: 100ms initial, ×2, 30s cap, jitter 0.2, infinite retries)
      */
     readonly recovery?: boolean | AmqpRecoveryOptions;
@@ -236,17 +243,33 @@ export interface AmqpQueueOverride {
     readonly durable?: boolean;
 }
 
-/** Recovery knobs (passed through to amqplib's opt-in recovery). */
+/**
+ * Recovery knobs (passed through to amqplib's opt-in recovery).
+ *
+ * `maxRetries` governs BOTH the initial connect and every subsequent recovery
+ * series, with the counter reset on each success — so a finite value chosen only
+ * to bound startup also caps steady-state recovery and makes the adapter brittle
+ * (N consecutive transient failures in any single series stop it permanently).
+ * The effective reconnect delay is amqplib equal-jitter around the exponential
+ * base and is NOT clamped to `maxDelay` from above, so it can overshoot (~20% at
+ * the default jitter, up to ~2x at `jitter: 1`).
+ *
+ * Bounding the initial connect independently from steady-state recovery, and a
+ * backoff hook that owns (and can clamp) the final delay, are tracked as future
+ * options — see
+ * {@link https://github.com/Connectum-Framework/connectum/issues/198} and
+ * {@link https://github.com/Connectum-Framework/connectum/issues/199}.
+ */
 export interface AmqpRecoveryOptions {
     /** @default 100 */
     readonly initialDelay?: number;
-    /** @default 30000 */
+    /** Base delay cap in ms; jitter is added on top, so the effective wait can exceed it. @default 30000 */
     readonly maxDelay?: number;
     /** @default 2 */
     readonly factor?: number;
-    /** 0..1 @default 0.2 */
+    /** Equal-jitter factor (0..1) around the base delay. @default 0.2 */
     readonly jitter?: number;
-    /** @default Infinity */
+    /** Attempts per series (initial connect and each recovery series); resets on success. @default Infinity */
     readonly maxRetries?: number;
 }
 


### PR DESCRIPTION
## Summary

Closes the `@connectum/events-amqp` documentation for the behaviour the 1.2.0 resilience release (#205) changes — one docs-only PR covering the remaining trio. No API or behaviour change; changeset is `patch` and folds into the open 1.2.0 (#206).

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented in migration guide)
- [x] Documentation / chore / internal

## Test plan

- [x] `pnpm build && pnpm typecheck && pnpm test` pass locally (events-amqp build ✓, monorepo typecheck ✓, unit 37/37 node)
- [x] `pnpm lint` passes locally (Biome — events-amqp 4/4, no fixes)
- [x] Cross-runtime: `test:bun` ✓, `test:esbuild` ✓
- [x] Markdown MD028 / MD058 / table-column-count checked manually (no local markdownlint)
- [ ] Relevant examples in `examples/` exercised — N/A (docs-only)

## Parity coverage

- [x] Parity N/A: this PR does not change observable RPC behaviour. **Docs-only** — README prose, JSDoc comments, and a changeset; no runtime code path is added or altered.

## Related issues / changes

Closes #191
Closes #192
Closes #193

Related: #205 (the resilience fix these docs describe); #198 / #199 (recovery follow-up options cross-linked from the JSDoc).

---

### Detail per issue

#### #192 — Error Taxonomy republish / message-state matrix
- README Error Taxonomy gains **Message state** and **Republish (at-least-once)** columns + a policy blockquote + the `AmqpConnectionError` pre-send-vs-in-flight footnote.
- Mirrored into the `errors.ts` `@module` JSDoc (IDE hover), with the encode (publish) vs decode (consumer-side) split called out for `AmqpSerializationError`.
- **Re-derived from the current confirm-callback classifier** (`AmqpAdapter.ts`), not the v1.1.0 issue draft: #194/#205 made connection-loss-vs-nack classification *structural*, so an in-flight drop is never misreported as a nack. Every row's republish policy is unchanged — now sourced from code.

#### #193 — recovery semantics
- `maxRetries` governs **both** the initial connect and every steady-state recovery series (reset on success), with the brittleness of a finite value — README recovery section + `AmqpRecoveryOptions` JSDoc.
- The effective reconnect delay is equal-jitter around the base and is **not** clamped to `maxDelay` from above (~20% at the default jitter, up to ~2x at `jitter: 1`); corrected the misleading "Delay cap" wording.
- Cross-links to `initialMaxRetries` (#198) and the backoff hook (#199) placed in the JSDoc (developer-facing roadmap) to keep forward-refs out of user-facing README prose.

#### #191 — `topologyMode: "check"` / silent-hang docs
- Most shipped in #205 (JSDoc + README "Fail-fast vs. recovery" blockquote + recovery section); this PR finalizes the remaining "`maxRetries` governs both" statement (shared with #193).
- **AC overtaken by events:** the criterion "the behavioural fail-fast fix is tracked separately and cannot ship in a patch" is now obsolete — `failFastOnInitialSetupError` + `onSetupFailed` shipped in 1.2.0 via #205, and the docs already point to it as the remedy. Intentionally not implemented because it no longer applies.

## Validation
- build ✓, typecheck (events-amqp + monorepo) ✓, Biome lint ✓ (events-amqp 4/4, no fixes)
- unit 37/37 (node) ✓, bun ✓, esbuild ✓
- CI on this PR: all 16 checks green (AMQP integration/recovery, Bun, Node 22/25, Typecheck/Lint/Test, esbuild, HTTP↔in-process parity, Release Gate, CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139CrPKNuk4RmuPnSXEoqn2
