### PR TITLE
docs(events,events-amqp): recovery backoff tuning + publisher shutdown guidance

### DIFF
--- a/.changeset/gentle-clouds-repeat.md
+++ b/.changeset/gentle-clouds-repeat.md
@@ -1,0 +1,9 @@
+---
+"@connectum/events": patch
+"@connectum/events-amqp": patch
+---
+
+docs: recovery backoff tuning and publisher shutdown guidance
+
+- **events-amqp**: accurate reconnect-delay semantics in README and `AmqpRecoveryOptions` JSDoc — the amqplib v2 strategy is symmetric jitter around the exponential base (not equal-jitter), with the cap applied before jitter (hence the overshoot above `maxDelay`). Documented the exact full-jitter workaround (`jitter: 1` + halved `initialDelay`/`maxDelay` → delay uniform in `[0, intended cap]`, verified against amqplib 2.0.1) with a fragility caveat and upstream tracking links (amqp-node/amqplib#855, amqp-node/amqplib#856).
+- **events**: new "Publishers and Shutdown" README section — `stop()` drains consumer handlers only; await-before-stop recipe for at-least-once producers; the stopping-gate limitation for publishes from draining handlers (#212); the planned opt-in `drainPublishTimeout` (#196).

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -214,9 +214,9 @@ queueOverrides: {
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `initialDelay` | `number` | `100` | First reconnect delay in ms |
-| `maxDelay` | `number` | `30000` | Base delay cap in ms. The effective wait adds equal-jitter on top, so it can exceed this (~20% at the default jitter, up to ~2x at `jitter: 1`) |
+| `maxDelay` | `number` | `30000` | Base delay cap in ms. Jitter is applied on top of the capped base, so the effective wait can exceed this (~20% at the default jitter, up to ~2x at `jitter: 1`) |
 | `factor` | `number` | `2` | Exponential backoff factor |
-| `jitter` | `number` | `0.2` | Equal-jitter randomization factor (0..1) applied around the base delay |
+| `jitter` | `number` | `0.2` | Symmetric jitter factor (0..1): the delay is drawn uniformly from `[base × (1 − jitter), base × (1 + jitter)]` |
 | `maxRetries` | `number` | `Infinity` | Attempts per series before giving up. Governs **both** the initial connect and each later recovery series; the counter resets on every success |
 
 ### AmqpLifecycleCallbacks
@@ -295,8 +295,27 @@ Connection behavior:
 
 - **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering. Under the default `maxRetries: Infinity`, `connect()` blocks rather than failing fast, and a **permanent** setup/topology error on the first connect would otherwise loop indefinitely. Set `failFastOnInitialSetupError: true` to reject `connect()` with the typed `AmqpTopologyError` on such a deterministic startup misconfiguration while still recovering from transient broker outages; use `onSetupFailed` for observability without changing behavior.
 - **`maxRetries` scope.** The retry budget governs **both** the initial connect and every later recovery series, with the counter reset on each success. A finite value chosen only to bound startup therefore makes the adapter brittle in steady state: a normal transient blip of that many consecutive failures in any single series permanently stops recovery. The default `Infinity` blocks at startup but never self-destructs on a transient outage.
-- **Reconnect delay.** The effective delay is amqplib equal-jitter around the exponential base (`initialDelay` × `factor`ⁿ, capped at `maxDelay`) and is **not** clamped from above by `maxDelay`, so it can overshoot (~20% at the default `jitter: 0.2`, up to ~2x at `jitter: 1`).
+- **Reconnect delay.** The effective delay is symmetric jitter around the exponential base — uniform in `[base × (1 − jitter), base × (1 + jitter)]` with `base = min(maxDelay, initialDelay × factor^(attempt − 1))`. The cap applies to the base **before** jitter, so the wait can overshoot `maxDelay` (~20% at the default `jitter: 0.2`, up to ~2x at `jitter: 1`). See [Tuning the reconnect backoff](#tuning-the-reconnect-backoff).
 - **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable or topology setup fails, and a lost connection is not restored.
+
+#### Tuning the reconnect backoff
+
+The delay strategy is fixed inside amqplib — a pluggable backoff hook and an independent initial-connect budget are proposed upstream ([amqp-node/amqplib#855](https://github.com/amqp-node/amqplib/issues/855), [amqp-node/amqplib#856](https://github.com/amqp-node/amqplib/issues/856); tracked here as [#199](https://github.com/Connectum-Framework/connectum/issues/199) and [#198](https://github.com/Connectum-Framework/connectum/issues/198)).
+
+One shape that **is** expressible exactly with the current knobs is AWS-style **full jitter** with a hard cap — the delay drawn uniformly from `[0, min(cap, schedule step)]`, never above the cap. Set `jitter: 1` and halve both `initialDelay` and `maxDelay`:
+
+```typescript
+// Full jitter over an intended 500ms → 30s exponential schedule, hard-capped at 30s:
+recovery: {
+  jitter: 1,          // delay becomes uniform in [0, 2 × base]
+  initialDelay: 250,  // half of the intended 500ms first step
+  maxDelay: 15_000,   // half of the intended 30s cap
+}
+```
+
+With `jitter: 1` the delay is uniform in `[0, 2 × base]`; halving the knobs makes `2 × base` trace the intended schedule, so the effective delay never exceeds the intended cap.
+
+> **Caveat**: this leans on the exact internal delay formula of amqplib v2 (verified against 2.0.1: `base = min(maxDelay, initialDelay × factor^(attempt − 1))`, then a uniform offset of `± base × jitter`). It is precise today but is not a documented amqplib contract — re-verify after amqplib upgrades.
 
 ### Error Taxonomy
 

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -250,24 +250,31 @@ export interface AmqpQueueOverride {
  * series, with the counter reset on each success — so a finite value chosen only
  * to bound startup also caps steady-state recovery and makes the adapter brittle
  * (N consecutive transient failures in any single series stop it permanently).
- * The effective reconnect delay is amqplib equal-jitter around the exponential
- * base and is NOT clamped to `maxDelay` from above, so it can overshoot (~20% at
- * the default jitter, up to ~2x at `jitter: 1`).
+ * The effective reconnect delay is symmetric jitter around the exponential
+ * base — uniform in `[base × (1 − jitter), base × (1 + jitter)]` with
+ * `base = min(maxDelay, initialDelay × factor^(attempt − 1))`. The cap applies
+ * BEFORE jitter, so the wait can overshoot `maxDelay` (~20% at the default
+ * jitter, up to ~2x at `jitter: 1`).
+ *
+ * Full jitter with a hard cap is expressible today: set `jitter: 1` and halve
+ * `initialDelay`/`maxDelay` — the delay becomes uniform in `[0, intended cap]`
+ * (verified against amqplib 2.0.1's internal formula; re-verify on upgrades).
  *
  * Bounding the initial connect independently from steady-state recovery, and a
- * backoff hook that owns (and can clamp) the final delay, are tracked as future
- * options — see
+ * pluggable backoff hook, are tracked as future options — see
  * {@link https://github.com/Connectum-Framework/connectum/issues/198} and
- * {@link https://github.com/Connectum-Framework/connectum/issues/199}.
+ * {@link https://github.com/Connectum-Framework/connectum/issues/199}
+ * (upstream: {@link https://github.com/amqp-node/amqplib/issues/856} and
+ * {@link https://github.com/amqp-node/amqplib/issues/855}).
  */
 export interface AmqpRecoveryOptions {
     /** @default 100 */
     readonly initialDelay?: number;
-    /** Base delay cap in ms; jitter is added on top, so the effective wait can exceed it. @default 30000 */
+    /** Base delay cap in ms; jitter is applied on top of the capped base, so the effective wait can exceed it. @default 30000 */
     readonly maxDelay?: number;
     /** @default 2 */
     readonly factor?: number;
-    /** Equal-jitter factor (0..1) around the base delay. @default 0.2 */
+    /** Symmetric jitter factor (0..1): the delay is uniform in `[base × (1 − jitter), base × (1 + jitter)]`. @default 0.2 */
     readonly jitter?: number;
     /** Attempts per series (initial connect and each recovery series); resets on success. @default Infinity */
     readonly maxRetries?: number;

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -406,6 +406,28 @@ await bus.stop();
 
 Set `drainTimeout: 0` for immediate abort (skip drain).
 
+### Publishers and Shutdown
+
+`stop()` drains **consumer handlers** only — in-flight `publish()` promises are not tracked by the bus, and `drainTimeout` does not cover them. An at-least-once producer must settle its publishes **before** stopping:
+
+```typescript
+// Track publishes you must not lose:
+const pending = new Set<Promise<void>>();
+
+const p = bus.publish(OrderCreatedSchema, order);
+pending.add(p);
+p.catch(() => {}).finally(() => pending.delete(p));
+
+// On shutdown — settle them BEFORE stop():
+await Promise.allSettled([...pending]);
+await bus.stop();
+```
+
+Two related boundaries:
+
+- **Publishing from a draining handler is rejected.** Once `stop()` begins, `publish()` throws — including from handlers that are still draining. Relay topologies (consume → transform → publish) therefore lose the in-flight tail at shutdown; the design discussion is tracked in [#212](https://github.com/Connectum-Framework/connectum/issues/212).
+- **An opt-in symmetric publish drain** (`drainPublishTimeout`) is planned — tracked in [#196](https://github.com/Connectum-Framework/connectum/issues/196).
+
 ## Exports Summary
 
 | Export | Kind | Description |


### PR DESCRIPTION
## Summary

Docs-first slice of the 1.3.0 events cluster (design pass on #195–#204): accurate reconnect-delay semantics with an exact full-jitter workaround for `@connectum/events-amqp`, and a "Publishers and Shutdown" guide for `@connectum/events`. Ships ahead of the code PRs because both guides help operators today and nothing depends on them.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (documented in migration guide)
- [x] Documentation / chore / internal

## What changed

**events-amqp** (README + `AmqpRecoveryOptions` JSDoc):

- Fixed the delay-strategy terminology: amqplib v2 applies **symmetric jitter** around the exponential base (`delay` uniform in `[base × (1 − jitter), base × (1 + jitter)]`, `base = min(maxDelay, initialDelay × factor^(attempt − 1))`), not equal-jitter as previously stated. The overshoot claims (~20% at default, up to ~2× at `jitter: 1`) were already correct and are kept.
- New **"Tuning the reconnect backoff"** section: the exact full-jitter-with-hard-cap recipe (`jitter: 1` + halved `initialDelay`/`maxDelay` → delay uniform in `[0, intended cap]`), verified against amqplib 2.0.1 `lib/recovery.js` (`calculateDelay`), with a fragility caveat and upstream tracking links (amqp-node/amqplib#855, amqp-node/amqplib#856).

**events** (README):

- New **"Publishers and Shutdown"** section: `stop()` drains consumer handlers only; in-flight `publish()` promises are not tracked and `drainTimeout` does not cover them; await-before-stop recipe (`Promise.allSettled`) for at-least-once producers; the stopping-gate limitation for publishes from draining handlers (#212); the planned opt-in `drainPublishTimeout` (#196).

Changeset: patch for both packages.

## Test plan

- [x] `pnpm build && pnpm turbo run typecheck && pnpm test` pass locally (33/33 turbo tasks)
- [x] `pnpm lint` passes locally (15/15; the single pre-existing warning in `events/src/broadcast.ts` is unrelated)
- [x] Full-jitter math re-verified against `amqplib@2.0.1` `lib/recovery.js` before writing (`calculateDelay`: `base = min(maxDelay, initialDelay × factor^(attempt−1))`, uniform offset `± base × jitter`)
- [ ] Relevant examples in `examples/` exercised — N/A (docs/JSDoc only)

## Parity coverage

- [x] Parity N/A: this PR does not change observable RPC behaviour — documentation and JSDoc only; no runtime code touched.

## Related issues / changes

- Design pass: #196 (docs half — the recipe; the option itself is a follow-up PR), #199 (docs-only resolution: workaround + upstream), #198 (upstream link), #212 (relay-drain limitation)
- Upstream: amqp-node/amqplib#855, amqp-node/amqplib#856
- Companion docs-site PR in Connectum-Framework/docs (recovery table + tuning section + `onSetupFailed` currency)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified reconnect delay behavior and tuning guidance for AMQP connections, including how jitter and delay caps interact.
  * Added shutdown guidance for publishers, explaining what is and isn’t drained during graceful stop and how in-flight publishes may behave.
  * Included examples and caveats to help users configure retries and shutdowns more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->