### PR TITLE
feat(events-amqp): discriminated onLifecycle connection-lifecycle callback (#197)

### DIFF
--- a/.changeset/lucky-panthers-relax.md
+++ b/.changeset/lucky-panthers-relax.md
@@ -1,0 +1,13 @@
+---
+"@connectum/events-amqp": minor
+---
+
+feat: discriminated `onLifecycle` connection-lifecycle callback (#197)
+
+- New `lifecycle.onLifecycle(event)` — a single discriminated union (`type`: `connected` | `disconnected` | `reconnecting` | `reconnect-failed` | `setup-failed` | `blocked` | `unblocked`) with exactly-once semantics pinned by integration tests. `connected` carries `reconnected: boolean`; `blocked`/`unblocked` surface RabbitMQ flow control (`connection.blocked`) for the first time. Scope: per-retry events of the *initial* connect loop are not yet surfaced (tracked in #198).
+- Setting `onLifecycle` (like `onSetupFailed` / `failFastOnInitialSetupError`) enables the startup validation probe — one extra short-lived connection plus a topology validation pass at `connect()` (recovery enabled required) — so `setup-failed { initial: true }` is delivered for a deterministic misconfiguration at boot.
+- Lifecycle callbacks must not throw: exceptions are now isolated in dispatch (a throwing callback can no longer make amqplib's recovery close a healthy connection or skip reconnect scheduling; the union and flat surfaces cannot starve each other).
+- The flat callbacks (`onConnected`, `onDisconnected`, `onReconnecting`, `onReconnectFailed`, `onSetupFailed`) are now a compatibility shim over the union and are `@deprecated` since 1.3.0 (removal not before 2.0). When both are set, flat callbacks fire after `onLifecycle`.
+- **Behavior fix (documented):** a socket-level connection cut fired `onDisconnected` twice — once via the raw connection `error` re-emit and once via the recovery `disconnect` event; it now fires exactly once per drop on both surfaces. Disconnect-counter metrics of existing consumers will roughly halve. A graceful server close was and remains single-fire.
+- **Behavior fix (documented, `recovery: false` mode):** `disconnected` is now delivered once per connection loss on the connection `close` (with the preceding `error` kept as the cause) — including a server-forced graceful close, which previously surfaced no event at all. The adapter's own `disconnect()` and a failed-setup discard do not emit it.
+- Hardening: the startup probe connection now carries an `error` listener (a broker drop during the probe window could previously crash the process via an unhandled `error` event); a stale reconnect-attempt counter no longer leaks into a later `connect()` incarnation.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -221,13 +221,35 @@ queueOverrides: {
 
 ### AmqpLifecycleCallbacks
 
-| Callback | Signature | Fires when |
-|----------|-----------|------------|
-| `onConnected` | `() => void` | Connection established (initial and after recovery) |
-| `onDisconnected` | `(cause: Error) => void` | Connection lost |
-| `onReconnecting` | `(info: { attempt, delay, error }) => void` | A reconnect attempt is scheduled (fires exactly once per scheduled retry) |
-| `onReconnectFailed` | `(cause: Error) => void` | Recovery exhausted (`maxRetries` reached) |
-| `onSetupFailed` | `(error, { initial, attempt }) => void` | Topology/setup failed on the initial validation probe (`initial: true`) or a reconnect re-assert (`initial: false`). Surfaces deterministic config drift distinctly from a broker outage; the initial-connect call requires the startup probe (runs when this callback or `failFastOnInitialSetupError` is set). |
+The preferred surface is the single discriminated **`onLifecycle`** callback (since 1.3.0); the flat callbacks below are a compatibility shim over the same event stream, `@deprecated` since 1.3.0 (removal not before 2.0). When both are set, flat callbacks fire after `onLifecycle` for the same underlying event.
+
+Callbacks **must not throw** — dispatch runs inside the connection driver's event handlers, so exceptions are isolated (swallowed) to protect the connection. Note: setting `onLifecycle` (like `onSetupFailed` / `failFastOnInitialSetupError`) enables the startup validation probe — one extra short-lived connection plus a topology validation pass at `connect()` (requires recovery enabled).
+
+```typescript
+lifecycle: {
+  onLifecycle: (event) => {
+    if (event.type === 'disconnected') metrics.increment('amqp.disconnects');
+    if (event.type === 'setup-failed' && event.initial) log.fatal(event.error);
+    if (event.type === 'blocked') log.warn(`broker flow control: ${event.reason}`);
+  },
+},
+```
+
+| Event `type` | Payload | Fires when |
+|--------------|---------|------------|
+| `connected` | `reconnected: boolean` | Connection established — exactly once per (re)connect; `false` for the initial connect, `true` after a recovery |
+| `disconnected` | `error: Error` | Connection lost — exactly once per drop |
+| `reconnecting` | `attempt, delay, error` | A reconnect attempt is scheduled (exactly once per scheduled retry) |
+| `reconnect-failed` | `error: Error` | Recovery exhausted (`maxRetries` reached) |
+| `setup-failed` | `initial, attempt, error` | Topology/setup failed on the initial validation probe (`initial: true`) or a reconnect re-assert (`initial: false`). The startup probe runs when `onLifecycle`, `onSetupFailed`, or `failFastOnInitialSetupError` is set — and only with recovery enabled |
+| `blocked` | `reason: string` | Broker flow control (`connection.blocked`, e.g. a memory/disk alarm). Union-only — no flat equivalent |
+| `unblocked` | — | Broker resumed after flow control. Union-only — no flat equivalent |
+
+Deprecated flat callbacks (compatibility shim): `onConnected()`, `onDisconnected(cause)`, `onReconnecting({ attempt, delay, error })`, `onReconnectFailed(cause)`, `onSetupFailed(error, { initial, attempt })`.
+
+**Scope**: the retry loop of the **initial** connect (broker unreachable when `connect()` is called) runs before the lifecycle wiring can attach, so its per-retry events are not surfaced; the startup probe covers the deterministic-misconfiguration case. Full initial-window observability lands with the adapter-owned bounded initial phase ([#198](https://github.com/Connectum-Framework/connectum/issues/198)).
+
+> **Fixed in 1.3.0**: a socket-level connection cut used to fire `onDisconnected` twice (once via the raw connection `error` re-emit, once via the recovery `disconnect` event); it now fires exactly once per drop on both surfaces. If you count disconnects in metrics, expect the count to roughly halve. A graceful server close (e.g. `rabbitmqctl close_all_connections`) was and remains single-fire.
 
 Connection errors are surfaced through these callbacks -- never console-only.
 
@@ -296,7 +318,7 @@ Connection behavior:
 - **With recovery enabled**, `connect()` retries with backoff until the broker becomes reachable -- convenient for `docker-compose` startup ordering. Under the default `maxRetries: Infinity`, `connect()` blocks rather than failing fast, and a **permanent** setup/topology error on the first connect would otherwise loop indefinitely. Set `failFastOnInitialSetupError: true` to reject `connect()` with the typed `AmqpTopologyError` on such a deterministic startup misconfiguration while still recovering from transient broker outages; use `onSetupFailed` for observability without changing behavior.
 - **`maxRetries` scope.** The retry budget governs **both** the initial connect and every later recovery series, with the counter reset on each success. A finite value chosen only to bound startup therefore makes the adapter brittle in steady state: a normal transient blip of that many consecutive failures in any single series permanently stops recovery. The default `Infinity` blocks at startup but never self-destructs on a transient outage.
 - **Reconnect delay.** The effective delay is symmetric jitter around the exponential base — uniform in `[base × (1 − jitter), base × (1 + jitter)]` with `base = min(maxDelay, initialDelay × factor^(attempt − 1))`. The cap applies to the base **before** jitter, so the wait can overshoot `maxDelay` (~20% at the default `jitter: 0.2`, up to ~2x at `jitter: 1`). See [Tuning the reconnect backoff](#tuning-the-reconnect-backoff).
-- **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable or topology setup fails, and a lost connection is not restored.
+- **With `recovery: false`**, `connect()` rejects immediately if the broker is unreachable or topology setup fails, and a lost connection is not restored. A lost connection surfaces as a single `disconnected` on the connection `close` (an abnormal loss keeps its `error` as the cause; since 1.3.0 a server-forced graceful close also counts, matching the exactly-once contract). The startup probe never runs in this mode — setup errors reject `connect()` directly.
 
 #### Tuning the reconnect backoff
 

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -14,7 +14,7 @@ import { randomUUID } from "node:crypto";
 import type { AdapterContext, EventAdapter, EventSubscription, PublishOptions, RawEvent, RawEventHandler, RawSubscribeOptions } from "@connectum/events";
 import type amqp from "amqplib";
 import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
-import type { AmqpAdapterOptions, AmqpLifecycleCallbacks, AmqpQueueOverride } from "./types.ts";
+import type { AmqpAdapterOptions, AmqpLifecycleCallbacks, AmqpLifecycleEvent, AmqpQueueOverride } from "./types.ts";
 import { AmqpTopologyMode } from "./types.ts";
 
 /** Default exchange name when none is provided. */
@@ -128,6 +128,14 @@ interface RecoveryLifecycleHooks {
     readonly failPendingReturns: () => void;
     readonly nextReconnectAttempt: () => number;
     readonly resetReconnectAttempt: () => void;
+    /**
+     * Deliver a `connected` event exactly once per successful (re)connect.
+     * Owned by the adapter so the initial-vs-reconnect flag does not depend on
+     * amqplib's emit-before-resolve ordering: the first delivery (from either
+     * the wrapper's `connect` event or the post-resolve fallback) is
+     * `reconnected: false`, every later one is `reconnected: true`.
+     */
+    readonly deliverConnected: () => void;
 }
 
 /** Structural subset of an amqplib recovering connection (or a Node EventEmitter). */
@@ -137,38 +145,111 @@ interface AmqpRecoveryEmitter {
 }
 
 /**
- * Wire the amqplib recovery lifecycle events to the public lifecycle callbacks.
+ * Deliver one lifecycle event to the union callback and its legacy flat shim.
  *
- * `onReconnecting` is driven SOLELY by `reconnect-scheduled` (it fires once per
+ * `onLifecycle` is the primary surface and receives every event; the flat
+ * callbacks are a compatibility shim over the same stream (deprecated since
+ * 1.3.0). `blocked`/`unblocked` have no flat equivalent. Exported (not via the
+ * package barrel) for direct cross-runtime unit testing.
+ *
+ * User callbacks MUST NOT throw; a thrown exception is isolated here. This is
+ * a hard requirement, not politeness: dispatch runs inside amqplib's recovery
+ * emitter handlers, where a synchronous throw would be caught by
+ * `_connect()`'s try block (closing a just-established healthy connection and
+ * scheduling a pointless reconnect — endless connect/close churn), or would
+ * escape from the model `close` handler BEFORE `_scheduleReconnect` runs
+ * (killing recovery entirely). Isolation also keeps the shim contract: a
+ * throwing `onLifecycle` does not starve the flat callbacks, and vice versa.
+ */
+export function dispatchLifecycle(lifecycle: AmqpLifecycleCallbacks | undefined, event: AmqpLifecycleEvent): void {
+    if (!lifecycle) {
+        return;
+    }
+    try {
+        lifecycle.onLifecycle?.(event);
+    } catch {
+        // Isolated — see the JSDoc contract above.
+    }
+    try {
+        switch (event.type) {
+            case "connected":
+                lifecycle.onConnected?.();
+                break;
+            case "disconnected":
+                lifecycle.onDisconnected?.(event.error);
+                break;
+            case "reconnecting":
+                lifecycle.onReconnecting?.({ attempt: event.attempt, delay: event.delay, error: event.error });
+                break;
+            case "reconnect-failed":
+                lifecycle.onReconnectFailed?.(event.error);
+                break;
+            case "setup-failed":
+                lifecycle.onSetupFailed?.(event.error, { initial: event.initial, attempt: event.attempt });
+                break;
+            default:
+                // blocked / unblocked: union-only observability.
+                break;
+        }
+    } catch {
+        // Isolated — see the JSDoc contract above.
+    }
+}
+
+/** Wire broker flow-control events (`connection.blocked`/`unblocked`) to the lifecycle surface. */
+function wireFlowControlEvents(conn: AmqpRecoveryEmitter, lifecycle: AmqpLifecycleCallbacks | undefined): void {
+    conn.on("blocked", (reason: unknown) => {
+        dispatchLifecycle(lifecycle, { type: "blocked", reason: String(reason ?? "") });
+    });
+    conn.on("unblocked", () => {
+        dispatchLifecycle(lifecycle, { type: "unblocked" });
+    });
+}
+
+/**
+ * Wire the amqplib recovery lifecycle events to the public lifecycle surface.
+ *
+ * `reconnecting` is driven SOLELY by `reconnect-scheduled` (it fires once per
  * scheduled retry). amqplib emits `connect-failed` AND `reconnect-scheduled` for
- * the same failed attempt, so also mapping `connect-failed` to `onReconnecting`
+ * the same failed attempt, so also mapping `connect-failed` to `reconnecting`
  * would double-count; `connect-failed` only clears the half-open publish channel
- * and (for a topology error) reports `onSetupFailed`. The terminal,
- * retries-exhausted case is `reconnect-failed` → `onReconnectFailed`.
+ * and (for a topology error) reports `setup-failed`. The terminal,
+ * retries-exhausted case is `reconnect-failed`.
+ *
+ * `disconnected` is driven SOLELY by the wrapper's `disconnect` event. The raw
+ * connection `error` re-emit is deliberately NOT mapped: a socket-level cut
+ * emits `error` AND `close` (→ `disconnect`), so mapping both would double-fire
+ * (fixed in 1.3.0; pinned by the exactly-once integration tests).
+ *
+ * `connected` delivery goes through {@link RecoveryLifecycleHooks.deliverConnected},
+ * which owns the initial-vs-reconnect flag — exactly-once regardless of
+ * whether amqplib emits the initial `connect` before or after this wiring is
+ * attached (today it is before; pinned by the exactly-once integration test).
  */
 export function wireRecoveryLifecycle(conn: AmqpRecoveryEmitter, lifecycle: AmqpLifecycleCallbacks | undefined, hooks: RecoveryLifecycleHooks): void {
     conn.on("connect", () => {
         hooks.resetReconnectAttempt();
-        lifecycle?.onConnected?.();
+        hooks.deliverConnected();
     });
     conn.on("disconnect", (err: Error) => {
         hooks.failPendingReturns();
-        lifecycle?.onDisconnected?.(err);
+        dispatchLifecycle(lifecycle, { type: "disconnected", error: err });
     });
     conn.on("reconnect-scheduled", (info: { attempt: number; delay: number; error: Error }) => {
-        lifecycle?.onReconnecting?.(info);
+        dispatchLifecycle(lifecycle, { type: "reconnecting", attempt: info.attempt, delay: info.delay, error: info.error });
     });
     conn.on("connect-failed", (err: Error) => {
         hooks.clearPublishChannel();
         const attempt = hooks.nextReconnectAttempt();
         if (err instanceof AmqpTopologyError) {
-            lifecycle?.onSetupFailed?.(err, { initial: false, attempt });
+            dispatchLifecycle(lifecycle, { type: "setup-failed", initial: false, attempt, error: err });
         }
     });
     conn.on("reconnect-failed", (err: Error) => {
         hooks.clearPublishChannel();
-        lifecycle?.onReconnectFailed?.(err);
+        dispatchLifecycle(lifecycle, { type: "reconnect-failed", error: err });
     });
+    wireFlowControlEvents(conn, lifecycle);
 }
 
 /**
@@ -592,6 +673,10 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 throw new AmqpConnectionError("AmqpAdapter: already connected");
             }
             closing = false;
+            // A fresh connect() starts a fresh attempt series — a stale counter
+            // from a previous exhausted-recovery incarnation must not leak into
+            // this incarnation's setup-failed attempt numbers.
+            reconnectAttempt = 0;
 
             // Dynamic import to avoid top-level require issues with ESM
             const amqplib = await import("amqplib");
@@ -630,7 +715,7 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             // hang connect() forever, silently). Runs only when opted in. A broker
             // that is merely unreachable here is transient (fall through to
             // recovery); only a deterministic AmqpTopologyError fails fast.
-            if (recoveryEnabled && (options.failFastOnInitialSetupError || lifecycle?.onSetupFailed)) {
+            if (recoveryEnabled && (options.failFastOnInitialSetupError || lifecycle?.onSetupFailed || lifecycle?.onLifecycle)) {
                 const probeOptions: Record<string, unknown> = { ...options.socketOptions };
                 if (Object.keys(clientProperties).length > 0) {
                     probeOptions.clientProperties = clientProperties;
@@ -639,6 +724,10 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 let probe: amqp.ChannelModel | null = null;
                 try {
                     probe = (await amqplib.connect(options.url, probeOptions)) as amqp.ChannelModel;
+                    // A broker drop while the probe runs its setup pass must
+                    // not crash the process via an unhandled 'error' event —
+                    // the drop surfaces as an onSetup rejection instead.
+                    probe.on("error", () => undefined);
                 } catch {
                     // Broker unreachable at startup — not a deterministic setup error.
                     probe = null;
@@ -651,7 +740,7 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                         await probe.close().catch(() => undefined);
                         publishChannel = null;
                         if (err instanceof AmqpTopologyError) {
-                            lifecycle?.onSetupFailed?.(err, { initial: true, attempt: 0 });
+                            dispatchLifecycle(lifecycle, { type: "setup-failed", initial: true, attempt: 0, error: err });
                             if (options.failFastOnInitialSetupError) {
                                 throw err;
                             }
@@ -673,12 +762,28 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
 
             const conn = (await amqplib.connect(options.url, connectOptions)) as amqp.ChannelModel;
 
-            // Surface connection lifecycle; never console-only.
-            conn.on("error", (err: Error) => {
-                lifecycle?.onDisconnected?.(err);
-            });
-
             if (recoveryEnabled) {
+                // A lost connection is reported SOLELY via the wrapper's
+                // `disconnect` event (see wireRecoveryLifecycle) — mapping the
+                // re-emitted raw `error` too double-fired `disconnected` on a
+                // socket-level cut (fixed in 1.3.0). The no-op listener must
+                // stay: an unhandled EventEmitter `error` crashes the process.
+                conn.on("error", () => undefined);
+
+                // Exactly-once `connected`, ordering-independent: the first
+                // delivery (wherever it comes from) is the initial connect.
+                // Today amqplib emits the initial `connect` before connect()
+                // resolves — i.e. before the wiring below attaches — so the
+                // post-wiring fallback delivers it; if a future amqplib emits
+                // it after attach, the wrapper listener delivers it instead
+                // and the fallback no-ops.
+                let connectedDelivered = false;
+                const deliverConnected = (): void => {
+                    const reconnected = connectedDelivered;
+                    connectedDelivered = true;
+                    dispatchLifecycle(lifecycle, { type: "connected", reconnected });
+                };
+
                 wireRecoveryLifecycle(conn, lifecycle, {
                     clearPublishChannel: () => {
                         publishChannel = null;
@@ -691,26 +796,49 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                     resetReconnectAttempt: () => {
                         reconnectAttempt = 0;
                     },
+                    deliverConnected,
                 });
 
                 // With recovery, the wrapper already ran onSetup before resolving.
                 connection = conn;
-                lifecycle?.onConnected?.();
+                if (!connectedDelivered) {
+                    deliverConnected();
+                }
                 return;
             }
 
-            // recovery: false — legacy single-shot connection.
+            // recovery: false — legacy single-shot connection. Surface
+            // connection lifecycle; never console-only. Without a recovery
+            // wrapper there is no `disconnect` event; `close` is the single
+            // disconnect signal. An `error`, when the loss is abnormal, always
+            // precedes `close` in amqplib and is kept as the cause — while a
+            // server-forced graceful close (e.g. 320 connection-forced) emits
+            // only `close` and must still surface as `disconnected`
+            // (1.3.0 contract fix: exactly once per drop in this mode too).
+            let lastConnError: Error | null = null;
+            let setupFailedClose = false;
+            conn.on("error", (err: Error) => {
+                lastConnError = err;
+            });
+            wireFlowControlEvents(conn, lifecycle);
             conn.on("close", () => {
                 connection = null;
                 publishChannel = null;
                 failPendingReturns();
+                // Not a "loss" when the adapter itself is closing (disconnect())
+                // or discarding a connection whose setup failed (the caller
+                // gets the thrown error instead).
+                if (!closing && !setupFailedClose) {
+                    dispatchLifecycle(lifecycle, { type: "disconnected", error: lastConnError ?? new Error("Connection closed") });
+                }
             });
 
             try {
                 await onSetup(conn);
                 connection = conn;
-                lifecycle?.onConnected?.();
+                dispatchLifecycle(lifecycle, { type: "connected", reconnected: false });
             } catch (err) {
+                setupFailedClose = true;
                 await conn.close().catch(() => undefined);
                 publishChannel = null;
                 throw err;

--- a/packages/events-amqp/src/index.ts
+++ b/packages/events-amqp/src/index.ts
@@ -33,6 +33,7 @@ export type {
     AmqpExchangeDeclaration,
     AmqpExchangeOptions,
     AmqpLifecycleCallbacks,
+    AmqpLifecycleEvent,
     AmqpPublisherOptions,
     AmqpQueueDeclaration,
     AmqpQueueOptions,

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -141,8 +141,11 @@ export interface AmqpAdapterOptions {
      * always keep infinite-recovery behavior.
      *
      * No-op with `recovery: false` (that path already fails fast on setup).
-     * Enabling this (or supplying {@link AmqpLifecycleCallbacks.onSetupFailed})
-     * adds one extra short-lived connection at startup for the validation probe.
+     * Enabling this — or supplying {@link AmqpLifecycleCallbacks.onLifecycle}
+     * or {@link AmqpLifecycleCallbacks.onSetupFailed} — adds one extra
+     * short-lived connection plus a topology validation pass at startup for
+     * the probe (recovery must be enabled; with `recovery: false` no probe
+     * runs and no `setup-failed` event is delivered).
      *
      * @default false
      */
@@ -280,17 +283,84 @@ export interface AmqpRecoveryOptions {
     readonly maxRetries?: number;
 }
 
-/** Connection lifecycle callbacks. */
+/**
+ * Discriminated connection lifecycle event, delivered to
+ * {@link AmqpLifecycleCallbacks.onLifecycle}.
+ *
+ * Exactly-once guarantees (pinned by integration tests):
+ * - `connected` fires once per successful (re)connect; `reconnected` is `false`
+ *   for the initial connect and `true` after a recovery.
+ * - `disconnected` fires once per connection loss (a socket-level cut no longer
+ *   double-fires via the raw `error` event — fixed in 1.3.0).
+ * - `reconnecting` fires once per scheduled retry AFTER the connection has been
+ *   established once; the terminal retries-exhausted case is `reconnect-failed`.
+ * - `setup-failed` reports a topology/setup failure on the initial validation
+ *   probe (`initial: true`, `attempt: 0`) or a reconnect re-assert
+ *   (`initial: false`, `attempt` >= 1).
+ * - `blocked`/`unblocked` surface broker flow control (RabbitMQ
+ *   `connection.blocked`, e.g. under a memory/disk alarm); they have no flat
+ *   callback equivalent.
+ *
+ * Scope: the retry loop of the INITIAL connect (broker unreachable when
+ * `connect()` is called) happens before the lifecycle wiring can attach, so
+ * its per-retry events are not surfaced; the startup probe covers the
+ * deterministic-misconfiguration case (`setup-failed { initial: true }`).
+ * Full initial-window observability lands with the adapter-owned bounded
+ * initial phase — see
+ * {@link https://github.com/Connectum-Framework/connectum/issues/198}.
+ *
+ * The `type` values are deliberately broker-agnostic so a future
+ * cross-adapter generalization stays non-breaking.
+ */
+export type AmqpLifecycleEvent =
+    | { readonly type: "connected"; readonly reconnected: boolean }
+    | { readonly type: "disconnected"; readonly error: Error }
+    | { readonly type: "reconnecting"; readonly attempt: number; readonly delay: number; readonly error: Error }
+    | { readonly type: "reconnect-failed"; readonly error: Error }
+    | { readonly type: "setup-failed"; readonly initial: boolean; readonly attempt: number; readonly error: Error }
+    | { readonly type: "blocked"; readonly reason: string }
+    | { readonly type: "unblocked" };
+
+/**
+ * Connection lifecycle callbacks.
+ *
+ * Prefer the single discriminated {@link onLifecycle} callback; the flat
+ * callbacks are a compatibility shim over the same event stream and are
+ * deprecated since 1.3.0 (removal not before 2.0).
+ */
 export interface AmqpLifecycleCallbacks {
+    /**
+     * Single discriminated-union lifecycle callback — the preferred surface.
+     * Receives every {@link AmqpLifecycleEvent}, including `blocked`/`unblocked`,
+     * which have no flat-callback equivalent. Flat callbacks (if also set) are
+     * invoked after `onLifecycle` for the same underlying event.
+     *
+     * MUST NOT throw: dispatch runs inside the connection driver's event
+     * handlers, so exceptions are isolated (swallowed) to protect the
+     * connection — a throwing callback neither disturbs recovery nor starves
+     * the flat shim.
+     *
+     * Setting this (like `onSetupFailed` / `failFastOnInitialSetupError`)
+     * enables the startup validation probe: one extra short-lived connection
+     * plus a topology validation pass at `connect()` (requires recovery
+     * enabled), so `setup-failed { initial: true }` can be delivered for a
+     * deterministic misconfiguration at boot.
+     */
+    readonly onLifecycle?: (event: AmqpLifecycleEvent) => void;
+    /** @deprecated Since 1.3.0 — use {@link onLifecycle} (`type: "connected"`). Kept until at least 2.0. */
     readonly onConnected?: () => void;
+    /** @deprecated Since 1.3.0 — use {@link onLifecycle} (`type: "disconnected"`). Kept until at least 2.0. */
     readonly onDisconnected?: (cause: Error) => void;
     /**
      * A reconnect attempt has been scheduled. Fires exactly ONCE per scheduled
      * retry (amqplib's `reconnect-scheduled`). A failed attempt that also emits
      * `connect-failed` does NOT double-invoke this; the terminal, retries-exhausted
      * case is reported via {@link onReconnectFailed}, not here.
+     *
+     * @deprecated Since 1.3.0 — use {@link onLifecycle} (`type: "reconnecting"`). Kept until at least 2.0.
      */
     readonly onReconnecting?: (info: { attempt: number; delay: number; error: Error }) => void;
+    /** @deprecated Since 1.3.0 — use {@link onLifecycle} (`type: "reconnect-failed"`). Kept until at least 2.0. */
     readonly onReconnectFailed?: (cause: Error) => void;
     /**
      * A setup/topology failure occurred while (re)applying the declarative
@@ -301,8 +371,10 @@ export interface AmqpLifecycleCallbacks {
      * This surfaces deterministic configuration drift (e.g. a missing queue in
      * `check` mode, or a `PRECONDITION_FAILED` redeclare) distinctly from a mere
      * broker outage, even when fail-fast is off. The initial-connect invocation
-     * requires a startup validation probe, which runs when either this callback or
-     * {@link AmqpAdapterOptions.failFastOnInitialSetupError} is set.
+     * requires a startup validation probe, which runs when either this callback,
+     * {@link onLifecycle}, or {@link AmqpAdapterOptions.failFastOnInitialSetupError} is set.
+     *
+     * @deprecated Since 1.3.0 — use {@link onLifecycle} (`type: "setup-failed"`). Kept until at least 2.0.
      */
     readonly onSetupFailed?: (error: Error, ctx: { readonly initial: boolean; readonly attempt: number }) => void;
 }

--- a/packages/events-amqp/tests/integration/amqp-recovery.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-recovery.test.ts
@@ -118,6 +118,106 @@ describe("AMQP connection recovery (testcontainers)", { skip: RUN ? false : "RUN
         }
     });
 
+    it("lifecycle exactly-once: connected once per (re)connect, disconnected once per drop (#197)", { timeout: 60_000 }, async () => {
+        const events: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.lifecycle197",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            lifecycle: {
+                onConnected: () => events.push("connected"),
+                onDisconnected: () => events.push("disconnected"),
+            },
+        });
+        await adapter.connect();
+        try {
+            assert.equal(events.filter((e) => e === "connected").length, 1, "initial connect fires onConnected exactly once");
+            assert.equal(events.filter((e) => e === "disconnected").length, 0, "no disconnected before any drop");
+
+            await dropConnections();
+            await waitFor(() => events.filter((e) => e === "connected").length >= 2);
+            // Settle window: let any late duplicate disconnected land before counting.
+            await sleep(500);
+
+            assert.equal(events.filter((e) => e === "connected").length, 2, "reconnect fires onConnected exactly once");
+            assert.equal(
+                events.filter((e) => e === "disconnected").length,
+                1,
+                "a single drop fires onDisconnected exactly once (no error+disconnect double-fire)",
+            );
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("onLifecycle union: initial connected{reconnected:false}, then disconnected → reconnecting → connected{reconnected:true} (#197)", { timeout: 60_000 }, async () => {
+        const events: Array<{ type: string; reconnected?: boolean }> = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.union197",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            lifecycle: {
+                onLifecycle: (event) => events.push(event),
+            },
+        });
+        await adapter.connect();
+        try {
+            assert.deepEqual(
+                events.filter((e) => e.type === "connected"),
+                [{ type: "connected", reconnected: false }],
+                "initial connect delivers exactly one connected{reconnected:false}",
+            );
+
+            await dropConnections();
+            await waitFor(() => events.some((e) => e.type === "connected" && e.reconnected === true));
+            await sleep(500);
+
+            const types = events.map((e) => e.type);
+            assert.equal(types.filter((t) => t === "disconnected").length, 1, "one disconnected per drop");
+            assert.ok(types.includes("reconnecting"), "a reconnecting event is delivered before the re-connect");
+            assert.ok(
+                types.indexOf("disconnected") < types.indexOf("reconnecting") && types.indexOf("reconnecting") < types.lastIndexOf("connected"),
+                `order must be disconnected → reconnecting → connected, got: ${types.join(", ")}`,
+            );
+            assert.deepEqual(
+                events.filter((e) => e.type === "connected"),
+                [
+                    { type: "connected", reconnected: false },
+                    { type: "connected", reconnected: true },
+                ],
+                "the recovery re-connect is flagged reconnected:true",
+            );
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("non-recovery mode: a server-forced graceful close surfaces exactly one disconnected; own disconnect() surfaces none (#197)", { timeout: 60_000 }, async () => {
+        const events: Array<{ type: string }> = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.norec197",
+            recovery: false,
+            lifecycle: {
+                onLifecycle: (event) => events.push(event),
+            },
+        });
+        await adapter.connect();
+        try {
+            // A graceful server close (replyCode 320) emits only 'close' — it
+            // must still surface as a single disconnected (1.3.0 contract fix).
+            await dropConnections();
+            await waitFor(() => events.some((e) => e.type === "disconnected"));
+            await sleep(500);
+            assert.equal(events.filter((e) => e.type === "disconnected").length, 1, "a graceful server close fires disconnected exactly once");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+        // The adapter's own disconnect() is not a "loss" — no extra event.
+        await sleep(300);
+        assert.equal(events.filter((e) => e.type === "disconnected").length, 1, "own disconnect() must not emit disconnected");
+    });
+
     it("publish while disconnected fails fast with AmqpConnectionError (recovery disabled)", async () => {
         const adapter = AmqpAdapter({ url, exchange: "rec.failfast", recovery: false });
         await adapter.connect();
@@ -554,6 +654,44 @@ describe("AMQP network partition (Toxiproxy)", { skip: RUN ? false : "RUN_RECOVE
         await toxiproxy?.stop().catch(() => undefined);
         await rabbit?.stop().catch(() => undefined);
         await network?.stop().catch(() => undefined);
+    });
+
+    it("lifecycle exactly-once under a socket-level cut: disconnected once per partition (#197)", { timeout: 90_000 }, async () => {
+        const events: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.partition197",
+            exchangeType: "topic",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            lifecycle: {
+                onConnected: () => events.push("connected"),
+                onDisconnected: () => events.push("disconnected"),
+            },
+        });
+        await adapter.connect();
+        try {
+            assert.equal(events.filter((e) => e === "connected").length, 1, "initial connect fires onConnected exactly once");
+
+            // Sever the link at the socket level: unlike a graceful server
+            // close (close_all_connections → clean connection.close), a killed
+            // socket makes the model emit 'error' AND 'close' — the path where
+            // a double onDisconnected can hide.
+            await proxy.setEnabled(false);
+            await waitFor(() => events.includes("disconnected"), 30_000);
+            await proxy.setEnabled(true);
+            await waitFor(() => events.filter((e) => e === "connected").length >= 2, 30_000);
+            // Settle window: let any late duplicate disconnected land before counting.
+            await sleep(500);
+
+            assert.equal(events.filter((e) => e === "connected").length, 2, "reconnect fires onConnected exactly once");
+            assert.equal(
+                events.filter((e) => e === "disconnected").length,
+                1,
+                "a socket-level cut fires onDisconnected exactly once (no error+disconnect double-fire)",
+            );
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
     });
 
     it("network cut (Toxiproxy proxy disabled) → reconnect when the network heals", async () => {

--- a/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
-import { AmqpAdapter, classifyConfirmError, isConnectionLostError, toAmqpPattern, trackChannelClose, wireRecoveryLifecycle } from "../../src/AmqpAdapter.ts";
+import { AmqpAdapter, classifyConfirmError, dispatchLifecycle, isConnectionLostError, toAmqpPattern, trackChannelClose, wireRecoveryLifecycle } from "../../src/AmqpAdapter.ts";
 import { AmqpConnectionError, AmqpPublishNackError, AmqpTopologyError } from "../../src/errors.ts";
-import type { AmqpLifecycleCallbacks } from "../../src/types.ts";
+import type { AmqpLifecycleCallbacks, AmqpLifecycleEvent } from "../../src/types.ts";
 
 describe("isConnectionLostError", () => {
     it("classifies amqplib channel/connection-close errors as connection loss", () => {
@@ -297,6 +297,7 @@ describe("wireRecoveryLifecycle", () => {
     function setup(lifecycle: AmqpLifecycleCallbacks) {
         const ee = new EventEmitter();
         let attempt = 0;
+        let connectedDelivered = false;
         const calls = { clearPublishChannel: 0, failPendingReturns: 0, reset: 0 };
         wireRecoveryLifecycle(ee, lifecycle, {
             clearPublishChannel: () => {
@@ -312,6 +313,13 @@ describe("wireRecoveryLifecycle", () => {
             resetReconnectAttempt: () => {
                 calls.reset += 1;
                 attempt = 0;
+            },
+            // Mirrors the adapter's ordering-independent exactly-once scheme:
+            // the first delivery is the initial connect, later ones reconnects.
+            deliverConnected: () => {
+                const reconnected = connectedDelivered;
+                connectedDelivered = true;
+                dispatchLifecycle(lifecycle, { type: "connected", reconnected });
             },
         });
         return { ee, calls };
@@ -390,5 +398,125 @@ describe("wireRecoveryLifecycle", () => {
         assert.equal(calls.reset, 1);
         assert.equal(calls.failPendingReturns, 1);
         assert.deepEqual(disconnects.map((e) => e.message), ["dropped"]);
+    });
+
+    it("delivers the full discriminated union to onLifecycle (first connected is initial, later ones reconnected)", () => {
+        const events: AmqpLifecycleEvent[] = [];
+        const { ee } = setup({ onLifecycle: (event) => events.push(event) });
+
+        const topoErr = new AmqpTopologyError("Topology declaration failed: 406");
+        const dropErr = new Error("dropped");
+        const exhaustedErr = new Error("recovery exhausted");
+
+        ee.emit("connect-failed", topoErr); // attempt -> 1
+        ee.emit("reconnect-scheduled", { attempt: 1, delay: 100, error: topoErr });
+        ee.emit("connect"); // first delivery in this harness → initial
+        ee.emit("blocked", "memory alarm");
+        ee.emit("unblocked");
+        ee.emit("disconnect", dropErr);
+        ee.emit("connect"); // second delivery → a recovery re-connect
+        ee.emit("reconnect-failed", exhaustedErr);
+
+        assert.deepEqual(events, [
+            { type: "setup-failed", initial: false, attempt: 1, error: topoErr },
+            { type: "reconnecting", attempt: 1, delay: 100, error: topoErr },
+            { type: "connected", reconnected: false },
+            { type: "blocked", reason: "memory alarm" },
+            { type: "unblocked" },
+            { type: "disconnected", error: dropErr },
+            { type: "connected", reconnected: true },
+            { type: "reconnect-failed", error: exhaustedErr },
+        ]);
+    });
+});
+
+describe("dispatchLifecycle", () => {
+    it("invokes onLifecycle first, then the matching flat shim", () => {
+        const order: string[] = [];
+        const lifecycle: AmqpLifecycleCallbacks = {
+            onLifecycle: (event) => order.push(`union:${event.type}`),
+            onConnected: () => order.push("flat:connected"),
+        };
+
+        dispatchLifecycle(lifecycle, { type: "connected", reconnected: false });
+        assert.deepEqual(order, ["union:connected", "flat:connected"]);
+    });
+
+    it("maps every event type to its flat callback with the legacy payload shape", () => {
+        const flat: Array<[string, unknown]> = [];
+        const err = new Error("boom");
+        const lifecycle: AmqpLifecycleCallbacks = {
+            onConnected: () => flat.push(["connected", undefined]),
+            onDisconnected: (cause) => flat.push(["disconnected", cause]),
+            onReconnecting: (info) => flat.push(["reconnecting", info]),
+            onReconnectFailed: (cause) => flat.push(["reconnect-failed", cause]),
+            onSetupFailed: (error, ctx) => flat.push(["setup-failed", { error, ctx }]),
+        };
+
+        dispatchLifecycle(lifecycle, { type: "connected", reconnected: true });
+        dispatchLifecycle(lifecycle, { type: "disconnected", error: err });
+        dispatchLifecycle(lifecycle, { type: "reconnecting", attempt: 3, delay: 250, error: err });
+        dispatchLifecycle(lifecycle, { type: "reconnect-failed", error: err });
+        dispatchLifecycle(lifecycle, { type: "setup-failed", initial: true, attempt: 0, error: err });
+
+        assert.deepEqual(flat, [
+            ["connected", undefined],
+            ["disconnected", err],
+            ["reconnecting", { attempt: 3, delay: 250, error: err }],
+            ["reconnect-failed", err],
+            ["setup-failed", { error: err, ctx: { initial: true, attempt: 0 } }],
+        ]);
+    });
+
+    it("blocked/unblocked are union-only: no flat callback fires", () => {
+        const union: string[] = [];
+        let flatCalls = 0;
+        const lifecycle: AmqpLifecycleCallbacks = {
+            onLifecycle: (event) => union.push(event.type),
+            onConnected: () => {
+                flatCalls += 1;
+            },
+            onDisconnected: () => {
+                flatCalls += 1;
+            },
+        };
+
+        dispatchLifecycle(lifecycle, { type: "blocked", reason: "disk alarm" });
+        dispatchLifecycle(lifecycle, { type: "unblocked" });
+
+        assert.deepEqual(union, ["blocked", "unblocked"]);
+        assert.equal(flatCalls, 0);
+    });
+
+    it("is a no-op without a lifecycle object", () => {
+        assert.doesNotThrow(() => dispatchLifecycle(undefined, { type: "unblocked" }));
+    });
+
+    it("isolates a throwing onLifecycle: no propagation, flat shim still fires", () => {
+        let flatFired = 0;
+        const lifecycle: AmqpLifecycleCallbacks = {
+            onLifecycle: () => {
+                throw new Error("user metrics bug");
+            },
+            onConnected: () => {
+                flatFired += 1;
+            },
+        };
+
+        assert.doesNotThrow(() => dispatchLifecycle(lifecycle, { type: "connected", reconnected: true }));
+        assert.equal(flatFired, 1, "a throwing onLifecycle must not starve the flat shim");
+    });
+
+    it("isolates a throwing flat callback: no propagation, onLifecycle already delivered", () => {
+        const union: string[] = [];
+        const lifecycle: AmqpLifecycleCallbacks = {
+            onLifecycle: (event) => union.push(event.type),
+            onDisconnected: () => {
+                throw new Error("user handler bug");
+            },
+        };
+
+        assert.doesNotThrow(() => dispatchLifecycle(lifecycle, { type: "disconnected", error: new Error("drop") }));
+        assert.deepEqual(union, ["disconnected"]);
     });
 });


### PR DESCRIPTION
## Summary

Implements #197 — the discriminated `onLifecycle` connection-lifecycle callback, the foundation of the 1.3.0 events-amqp cluster (see the "1.3.0 design pass" comment on the issue for the agreed shape). Includes the documented double-`onDisconnected` bugfix and several hardening fixes surfaced by a pre-PR adversarial review (27-agent, 8 angles; 10 confirmed findings fixed or scoped below).

## Type of change

- [x] New feature (non-breaking)
- [x] Bug fix (non-breaking) — documented behavior fixes, see below

## What changed

**New API (`@connectum/events-amqp`):**

- `lifecycle.onLifecycle(event)` — discriminated union (`type`: `connected {reconnected}` | `disconnected {error}` | `reconnecting {attempt, delay, error}` | `reconnect-failed {error}` | `setup-failed {initial, attempt, error}` | `blocked {reason}` | `unblocked`). `blocked`/`unblocked` (RabbitMQ flow control) are surfaced for the first time, union-only.
- Flat callbacks become a compatibility shim over the same dispatch, `@deprecated` since 1.3.0 (removal not before 2.0); when both are set, flat fires after `onLifecycle`.
- Setting `onLifecycle` enables the startup validation probe (documented cost: one extra short-lived connection + a topology pass; recovery required) so `setup-failed {initial: true}` is delivered at boot.
- `AmqpLifecycleEvent` exported from the barrel; `dispatchLifecycle` exported non-barrel for cross-runtime unit tests (precedent: #194 helpers).

**Behavior fixes (documented in the changeset):**

- **Double `onDisconnected` fixed**: a socket-level cut fired it twice (raw `error` re-emit + recovery `disconnect`); now exactly once per drop on both surfaces. Disconnect-counter metrics roughly halve. Pinned by two integration tests (graceful 320 close via `close_all_connections` and a Toxiproxy socket-level cut — the latter red-ran at 2 ≠ 1 against the old code).
- **`recovery: false` contract fix**: `disconnected` now fires once per loss on connection `close` (preceding `error` kept as cause) — including a server-forced graceful close, which previously produced no event; own `disconnect()` and failed-setup discards emit nothing.

**Hardening (from the adversarial review):**

- Callback exceptions are isolated in dispatch — a throwing `onLifecycle` could previously propagate into amqplib's recovery internals (closing a healthy connection or skipping reconnect scheduling) and starve the flat shim.
- The startup probe connection now carries an `error` listener (a broker drop mid-probe could crash the process via an unhandled `error`).
- `reconnected` flag is ordering-independent (first delivery = initial), no longer reliant on amqplib's emit-before-resolve ordering.
- Stale `reconnectAttempt` no longer leaks across `connect()` incarnations.

**Documented scope limitation:** per-retry events of the *initial* connect loop (broker unreachable at `connect()` time) are not surfaced — they precede the lifecycle wiring. Tracked in #198 (the adapter-owned bounded initial phase will deliver them).

## Test plan

- [x] Unit 44/44 on node, bun, esbuild (`test:unit`, `test:bun`, `test:esbuild`) — new: union payload mapping, shim order, exception isolation ×2, flag progression
- [x] Integration (Docker testcontainers + Toxiproxy) 18/18 — new: exactly-once lifecycle under graceful close, exactly-once under socket-level cut (TDD red→green on the double-fire), union sequence with `reconnected` flags, `recovery: false` graceful-close contract
- [x] Full monorepo: build 18/18, typecheck 33/33, test 33/33, lint 15/15
- [x] Pre-PR adversarial review: 8 finder angles → 17 verified findings → 7 fixed in code, 3 fixed in docs, 2 deferred by design (initial-window → #198), 2 declined deliberately (test explicitness over DRY; planned version literals)

## Parity coverage

- [x] Parity N/A: this PR changes broker-adapter lifecycle callbacks only; no RPC-observable behaviour is affected (no service/transport code touched).

## Related issues / changes

Closes #197.

- Design pass: the "1.3.0 design pass (2026-07-04)" comment on #197
- Scope follow-up: #198 (initial-window observability), #213 (cross-adapter lifecycle parity)
- Companion docs-site PR in Connectum-Framework/docs follows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a single, structured lifecycle callback for connection events, including connect, disconnect, reconnect, setup failure, and broker block/unblock states.
  * Improved startup validation so setup problems can be reported more reliably during connection.

* **Bug Fixes**
  * Fixed duplicate disconnect notifications.
  * Made lifecycle events more consistent during reconnection and non-recovery connection loss.
  * Reduced the chance of unexpected connection crashes during startup checks.

* **Documentation**
  * Expanded connection recovery guidance and clarified deprecated legacy callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->