### PR TITLE
feat(events-amqp): machine-readable object on AmqpTopologyError (#202)

### DIFF
--- a/.changeset/tidy-lions-search.md
+++ b/.changeset/tidy-lions-search.md
@@ -1,0 +1,9 @@
+---
+"@connectum/events-amqp": minor
+---
+
+feat: machine-readable `object` on `AmqpTopologyError` (#202)
+
+- New `AmqpTopologyObject` discriminated union — `{ kind: 'exchange' | 'queue', name }` or `{ kind: 'binding', source, destination, destinationType, routingKey }` (a binding has no name of its own) — exposed as `AmqpTopologyError.object` and exported from the barrel.
+- Populated structurally at every broker declare/check/consume site (`applyTopology` check and assert modes per object, subscribe-path queue declaration/bindings/check-mode verification, consume failures), so CI drift checks and observability never parse broker-reply text. `object.kind` says *what* was being declared; *why* it failed stays with the error class and `cause`. One documented exception: the config-validation error for a malformed binding declaration (neither `queue` nor `exchange` set) carries no `object` — its destination is exactly the missing piece.
+- `AmqpTopologyError` constructor now takes an options-bag `{ cause?, object? }`. Construction stays bit-for-bit compatible: message-only instances install no own `cause`/`object` keys (pinned by unit tests), so spread clones and own-property log serializers see no new keys unless an object is actually supplied.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -357,6 +357,18 @@ Every terminal publish/topology outcome is distinguishable by error class -- wha
 >
 > \* `AmqpConnectionError` covers both a **pre-send** failure (publishing while disconnected, or a synchronous publish failure -- the message is never sent) and an **in-flight** loss (the connection drops while awaiting the confirm -- state genuinely UNKNOWN). Both are republish-safe; UNKNOWN is the conservative label.
 
+Since 1.3.0, `AmqpTopologyError` also carries a machine-readable **`object`** identifying the failing topology object -- `{ kind: 'exchange' | 'queue', name }` or `{ kind: 'binding', source, destination, destinationType, routingKey }` (a binding has no name of its own). It is populated structurally at the declare/check/consume site, so CI drift checks and observability never parse broker-reply text. `object.kind` says *what* was being declared; *why* it failed stays with the error class and `cause`.
+
+```typescript
+try {
+  await bus.start();
+} catch (err) {
+  if (err instanceof AmqpTopologyError && err.object?.kind === 'queue') {
+    console.error(`Topology drift: queue '${err.object.name}' rejected by the broker`, err.cause);
+  }
+}
+```
+
 ## External AMQP Contract
 
 A complete recipe for integrating with an externally defined AMQP contract (AsyncAPI-style): direct exchange, named durable queue with DLQ arguments, JSON `contentType`, mandatory routing, and per-message confirms. The application serializes JSON itself and publishes through the adapter directly:

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -13,6 +13,7 @@
 import { randomUUID } from "node:crypto";
 import type { AdapterContext, EventAdapter, EventSubscription, PublishOptions, RawEvent, RawEventHandler, RawSubscribeOptions } from "@connectum/events";
 import type amqp from "amqplib";
+import type { AmqpTopologyObject } from "./errors.ts";
 import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
 import type { AmqpAdapterOptions, AmqpLifecycleCallbacks, AmqpLifecycleEvent, AmqpQueueOverride } from "./types.ts";
 import { AmqpTopologyMode } from "./types.ts";
@@ -371,8 +372,25 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
     const subscriptionRecords: SubscriptionRecord[] = [];
 
     /** Wrap a broker/channel error into AmqpTopologyError with context. */
-    function topologyError(message: string, cause: unknown): AmqpTopologyError {
-        return new AmqpTopologyError(`${message}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause });
+    function topologyError(message: string, cause: unknown, object?: AmqpTopologyObject): AmqpTopologyError {
+        const text = `${message}: ${cause instanceof Error ? cause.message : String(cause)}`;
+        return object !== undefined ? new AmqpTopologyError(text, { cause, object }) : new AmqpTopologyError(text, { cause });
+    }
+
+    /**
+     * Run one topology operation; a failure is wrapped into AmqpTopologyError
+     * carrying the identity of the object being declared/verified — known
+     * structurally at the call site, so consumers never parse broker-reply text.
+     */
+    async function topologyOp<T>(message: string, object: AmqpTopologyObject, op: () => Promise<T>): Promise<T> {
+        try {
+            return await op();
+        } catch (err) {
+            if (err instanceof AmqpTopologyError) {
+                throw err;
+            }
+            throw topologyError(message, err, object);
+        }
     }
 
     /**
@@ -390,56 +408,84 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
         const topo = options.topology;
 
         if (topologyMode === AmqpTopologyMode.CHECK) {
+            const CHECK_MSG = "Topology check failed (missing broker object)";
+            // Outer catch preserves the pre-1.3.0 guarantee that ANY throw in
+            // this block (incl. loop headers / property reads on a pathological
+            // topology object) surfaces as AmqpTopologyError; the per-op
+            // wrappers add the failing object's identity on top.
             try {
-                await ch.checkExchange(exchange);
+                await topologyOp(CHECK_MSG, { kind: "exchange", name: exchange }, () => ch.checkExchange(exchange));
                 for (const ex of topo?.exchanges ?? []) {
-                    await ch.checkExchange(ex.name);
+                    await topologyOp(CHECK_MSG, { kind: "exchange", name: ex.name }, () => ch.checkExchange(ex.name));
                 }
                 for (const q of topo?.queues ?? []) {
-                    await ch.checkQueue(q.name);
+                    await topologyOp(CHECK_MSG, { kind: "queue", name: q.name }, () => ch.checkQueue(q.name));
                 }
             } catch (err) {
-                throw topologyError("Topology check failed (missing broker object)", err);
+                if (err instanceof AmqpTopologyError) {
+                    throw err;
+                }
+                throw topologyError(CHECK_MSG, err);
             }
             return;
         }
 
-        // assert mode
+        // assert mode — one topologyOp per declared object, so a failure
+        // carries the failing object's identity (#202). The outer catch
+        // preserves the pre-1.3.0 guarantee that ANY throw in this block
+        // surfaces as AmqpTopologyError.
+        const ASSERT_MSG = "Topology declaration failed";
         try {
-            await ch.assertExchange(exchange, exchangeType, {
-                durable: options.exchangeOptions?.durable ?? true,
-                autoDelete: options.exchangeOptions?.autoDelete ?? false,
-            });
+            await topologyOp(ASSERT_MSG, { kind: "exchange", name: exchange }, () =>
+                ch.assertExchange(exchange, exchangeType, {
+                    durable: options.exchangeOptions?.durable ?? true,
+                    autoDelete: options.exchangeOptions?.autoDelete ?? false,
+                }),
+            );
 
             for (const ex of topo?.exchanges ?? []) {
-                await ch.assertExchange(ex.name, ex.type, {
-                    durable: ex.durable ?? true,
-                    autoDelete: ex.autoDelete ?? false,
-                    arguments: ex.arguments,
-                });
+                await topologyOp(ASSERT_MSG, { kind: "exchange", name: ex.name }, () =>
+                    ch.assertExchange(ex.name, ex.type, {
+                        durable: ex.durable ?? true,
+                        autoDelete: ex.autoDelete ?? false,
+                        arguments: ex.arguments,
+                    }),
+                );
             }
             for (const q of topo?.queues ?? []) {
-                await ch.assertQueue(q.name, {
-                    durable: q.durable ?? true,
-                    autoDelete: q.autoDelete ?? false,
-                    exclusive: q.exclusive ?? false,
-                    arguments: q.arguments,
-                });
+                await topologyOp(ASSERT_MSG, { kind: "queue", name: q.name }, () =>
+                    ch.assertQueue(q.name, {
+                        durable: q.durable ?? true,
+                        autoDelete: q.autoDelete ?? false,
+                        exclusive: q.exclusive ?? false,
+                        arguments: q.arguments,
+                    }),
+                );
             }
             for (const b of topo?.bindings ?? []) {
-                if (b.queue !== undefined) {
-                    await ch.bindQueue(b.queue, b.source, b.routingKey, b.arguments);
-                } else if (b.exchange !== undefined) {
-                    await ch.bindExchange(b.exchange, b.source, b.routingKey, b.arguments);
+                const queueDest = b.queue;
+                const exchangeDest = b.exchange;
+                if (queueDest !== undefined) {
+                    await topologyOp(ASSERT_MSG, { kind: "binding", source: b.source, destination: queueDest, destinationType: "queue", routingKey: b.routingKey }, () =>
+                        ch.bindQueue(queueDest, b.source, b.routingKey, b.arguments),
+                    );
+                } else if (exchangeDest !== undefined) {
+                    await topologyOp(ASSERT_MSG, { kind: "binding", source: b.source, destination: exchangeDest, destinationType: "exchange", routingKey: b.routingKey }, () =>
+                        ch.bindExchange(exchangeDest, b.source, b.routingKey, b.arguments),
+                    );
                 } else {
-                    throw new Error(`Binding for source '${b.source}' must declare either 'queue' or 'exchange'`);
+                    // Config-validation error: the binding's destination is the
+                    // missing piece, so no AmqpTopologyObject identity is
+                    // representable — this is the one adapter-thrown
+                    // AmqpTopologyError without `object` (documented).
+                    throw topologyError(ASSERT_MSG, new Error(`Binding for source '${b.source}' must declare either 'queue' or 'exchange'`));
                 }
             }
         } catch (err) {
             if (err instanceof AmqpTopologyError) {
                 throw err;
             }
-            throw topologyError("Topology declaration failed", err);
+            throw topologyError(ASSERT_MSG, err);
         }
     }
 
@@ -518,11 +564,17 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
         if (topologyMode === AmqpTopologyMode.ASSERT && declaredInTopology) {
             try {
                 for (const amqpPattern of record.patterns.map(toAmqpPattern)) {
-                    await ch.bindQueue(queueName, exchange, amqpPattern);
+                    await topologyOp(
+                        `Failed to bind topology-declared queue '${queueName}'`,
+                        { kind: "binding", source: exchange, destination: queueName, destinationType: "queue", routingKey: amqpPattern },
+                        () => ch.bindQueue(queueName, exchange, amqpPattern),
+                    );
                 }
             } catch (err) {
                 await ch.close().catch(() => undefined);
-                throw topologyError(`Failed to bind topology-declared queue '${queueName}'`, err);
+                // Pre-1.3.0, ANY throw here (incl. pattern mapping) was wrapped;
+                // preserve that error-class contract.
+                throw err instanceof AmqpTopologyError ? err : topologyError(`Failed to bind topology-declared queue '${queueName}'`, err, { kind: "queue", name: queueName });
             }
         } else if (topologyMode === AmqpTopologyMode.ASSERT) {
             // Build queue arguments: global defaults + per-override arguments
@@ -547,26 +599,34 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             const exclusive = options.consumerOptions?.exclusive ?? false;
 
             try {
-                await ch.assertQueue(queueName, {
-                    durable: group ? queueDurable : false,
-                    autoDelete: isAutoGroup,
-                    exclusive: isAutoGroup ? exclusive : false,
-                    arguments: Object.keys(queueArgs).length > 0 ? queueArgs : undefined,
-                });
+                await topologyOp(`Failed to declare queue '${queueName}'`, { kind: "queue", name: queueName }, () =>
+                    ch.assertQueue(queueName, {
+                        durable: group ? queueDurable : false,
+                        autoDelete: isAutoGroup,
+                        exclusive: isAutoGroup ? exclusive : false,
+                        arguments: Object.keys(queueArgs).length > 0 ? queueArgs : undefined,
+                    }),
+                );
 
                 for (const amqpPattern of record.patterns.map(toAmqpPattern)) {
-                    await ch.bindQueue(queueName, exchange, amqpPattern);
+                    await topologyOp(
+                        `Failed to declare queue '${queueName}'`,
+                        { kind: "binding", source: exchange, destination: queueName, destinationType: "queue", routingKey: amqpPattern },
+                        () => ch.bindQueue(queueName, exchange, amqpPattern),
+                    );
                 }
             } catch (err) {
                 await ch.close().catch(() => undefined);
-                throw topologyError(`Failed to declare queue '${queueName}'`, err);
+                // Pre-1.3.0, ANY throw here (incl. pattern mapping) was wrapped;
+                // preserve that error-class contract.
+                throw err instanceof AmqpTopologyError ? err : topologyError(`Failed to declare queue '${queueName}'`, err, { kind: "queue", name: queueName });
             }
         } else if (topologyMode === AmqpTopologyMode.CHECK) {
             try {
-                await ch.checkQueue(queueName);
+                await topologyOp(`Queue '${queueName}' does not exist (topologyMode: "check")`, { kind: "queue", name: queueName }, () => ch.checkQueue(queueName));
             } catch (err) {
                 await ch.close().catch(() => undefined);
-                throw topologyError(`Queue '${queueName}' does not exist (topologyMode: "check")`, err);
+                throw err;
             }
         }
         // skip mode: no checks — a missing queue fails on consume below.
@@ -639,7 +699,7 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             );
         } catch (err) {
             await ch.close().catch(() => undefined);
-            throw topologyError(`Failed to consume from queue '${queueName}'`, err);
+            throw topologyError(`Failed to consume from queue '${queueName}'`, err, { kind: "queue", name: queueName });
         }
 
         record.channel = ch;

--- a/packages/events-amqp/src/errors.ts
+++ b/packages/events-amqp/src/errors.ts
@@ -65,11 +65,48 @@ export class AmqpPublishNackError extends AmqpAdapterError {}
 export class AmqpPublishTimeoutError extends AmqpAdapterError {}
 
 /**
+ * Machine-readable identity of the topology object a declaration or
+ * verification failed on. A binding has no name of its own — it is identified
+ * by its endpoints and routing key — hence the discriminated shape.
+ */
+export type AmqpTopologyObject =
+    | { readonly kind: "exchange" | "queue"; readonly name: string }
+    | {
+          readonly kind: "binding";
+          readonly source: string;
+          readonly destination: string;
+          readonly destinationType: "queue" | "exchange";
+          readonly routingKey: string;
+      };
+
+/**
  * Topology declaration or verification failed: missing exchange/queue in
  * `check`/`skip` mode, or a conflicting redeclare (PRECONDITION_FAILED) in
  * `assert` mode.
+ *
+ * `object` identifies the failing topology object structurally (known at the
+ * declare/check site — no broker-reply text parsing needed for CI drift
+ * checks or observability). `object.kind` says WHAT was being declared;
+ * failure classification (WHY it failed) stays with the error class and
+ * `cause`.
  */
-export class AmqpTopologyError extends AmqpAdapterError {}
+export class AmqpTopologyError extends AmqpAdapterError {
+    // `declare` keeps the field type-only: a real class field would install an
+    // enumerable own `object: undefined` on EVERY instance (visible to spread
+    // clones and own-props log serializers) before the constructor body runs.
+    declare readonly object?: AmqpTopologyObject;
+
+    constructor(message: string, options?: { cause?: unknown; object?: AmqpTopologyObject }) {
+        // Forward options as-is: Error's InstallErrorCause installs an own
+        // `cause` only when the key is PRESENT, so message-only construction
+        // stays bit-for-bit identical to the pre-1.3.0 class (no own `cause`).
+        super(message, options);
+        if (options?.object !== undefined) {
+            // Own property appears only when an object is actually supplied.
+            (this as { object?: AmqpTopologyObject }).object = options.object;
+        }
+    }
+}
 
 /** Payload encoding/decoding failed in a custom serialization hook. */
 export class AmqpSerializationError extends AmqpAdapterError {}

--- a/packages/events-amqp/src/index.ts
+++ b/packages/events-amqp/src/index.ts
@@ -25,6 +25,7 @@
  */
 
 export { AmqpAdapter, toAmqpPattern } from "./AmqpAdapter.ts";
+export type { AmqpTopologyObject } from "./errors.ts";
 export { AmqpAdapterError, AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
 export type {
     AmqpAdapterOptions,

--- a/packages/events-amqp/tests/integration/amqp-recovery.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-recovery.test.ts
@@ -313,7 +313,13 @@ describe("AMQP connection recovery (testcontainers)", { skip: RUN ? false : "RUN
 
         await assert.rejects(
             () => adapter.connect(),
-            (err: unknown) => err instanceof AmqpTopologyError,
+            (err: unknown) => {
+                assert.ok(err instanceof AmqpTopologyError);
+                // #202: the failing object is identified structurally, not by
+                // parsing the broker reply text.
+                assert.deepEqual(err.object, { kind: "queue", name: "rec.contract.q" });
+                return true;
+            },
         );
         await adapter.disconnect().catch(() => undefined);
     });

--- a/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
@@ -492,6 +492,37 @@ describe("dispatchLifecycle", () => {
         assert.doesNotThrow(() => dispatchLifecycle(undefined, { type: "unblocked" }));
     });
 
+    it("AmqpTopologyError carries the failing object's identity and the cause (#202)", () => {
+        const cause = new Error("PRECONDITION_FAILED");
+        const err = new AmqpTopologyError("Topology declaration failed", { cause, object: { kind: "queue", name: "orders.q" } });
+        assert.deepEqual(err.object, { kind: "queue", name: "orders.q" });
+        assert.equal(err.cause, cause);
+        assert.equal(err.name, "AmqpTopologyError");
+    });
+
+    it("AmqpTopologyError binding identity uses endpoints, not a name (#202)", () => {
+        const err = new AmqpTopologyError("Topology declaration failed", {
+            object: { kind: "binding", source: "orders", destination: "orders.q", destinationType: "queue", routingKey: "order.*" },
+        });
+        assert.deepEqual(err.object, { kind: "binding", source: "orders", destination: "orders.q", destinationType: "queue", routingKey: "order.*" });
+    });
+
+    it("AmqpTopologyError stays backward-compatible with message-only and cause-only construction (#202)", () => {
+        assert.equal(new AmqpTopologyError("x").object, undefined);
+        const withCause = new AmqpTopologyError("x", { cause: new Error("y") });
+        assert.equal(withCause.object, undefined);
+        assert.ok(withCause.cause instanceof Error);
+    });
+
+    it("AmqpTopologyError message-only construction installs NO own cause/object keys (#202 — bit-for-bit compat)", () => {
+        const bare = new AmqpTopologyError("x");
+        assert.equal(Object.hasOwn(bare, "cause"), false, "no own 'cause' key without a supplied cause (InstallErrorCause checks key presence)");
+        assert.equal(Object.hasOwn(bare, "object"), false, "no own 'object' key without a supplied object (declare field must not emit)");
+        const withObject = new AmqpTopologyError("x", { object: { kind: "queue", name: "q" } });
+        assert.equal(Object.hasOwn(withObject, "object"), true);
+        assert.equal(Object.hasOwn(withObject, "cause"), false, "supplying only 'object' must not install an own 'cause'");
+    });
+
     it("isolates a throwing onLifecycle: no propagation, flat shim still fires", () => {
         let flatFired = 0;
         const lifecycle: AmqpLifecycleCallbacks = {


### PR DESCRIPTION
## Summary

Implements #202 — a machine-readable `object` on `AmqpTopologyError` identifying the failing topology object structurally (no broker-reply text parsing). Shape per the "1.3.0 design pass" comment on the issue: a discriminated `AmqpTopologyObject` union, because a binding has no name of its own. Practical prerequisite for #201's reply-code fatal gate (PR D).

## Type of change

- [x] New feature (non-breaking)

## What changed

- **`AmqpTopologyObject`** union: `{ kind: 'exchange' | 'queue', name }` | `{ kind: 'binding', source, destination, destinationType, routingKey }`; exported from the barrel.
- **`AmqpTopologyError.object`** (optional), options-bag constructor `{ cause?, object? }`. The field uses a `declare`-only declaration and conditional assignment, and options are forwarded straight to `Error` — so message-only construction installs **no own `cause`/`object` keys** (bit-for-bit with 1.2.0; pinned by a unit test using `Object.hasOwn`).
- Populated at every broker declare/check/consume site via a new per-operation `topologyOp` wrapper: `applyTopology` (check + assert, per object incl. e2e bindings), subscribe-path queue declaration / bindings / check-mode verification, and consume failures. Outer safety-net catches preserve the pre-1.3.0 guarantee that *any* throw in those blocks (incl. pattern mapping and pathological topology objects) still surfaces as `AmqpTopologyError` with the same message texts.
- Documented exception: the config-validation error for a malformed binding declaration (neither `queue` nor `exchange`) carries no `object` — its destination is exactly the missing piece.

## Adversarial pre-PR review

3 finder angles → 7 verified findings, **all addressed**: own-`cause`-key regression on message-only construction (fixed — forward options as-is), enumerable `object: undefined` class field on every instance (fixed — `declare` field), pattern-mapping throws escaping unwrapped in two subscribe branches (fixed — error-class contract restored), loop-header/property-read throws escaping `applyTopology` unwrapped (fixed — outer safety nets), malformed-binding overclaim (fixed — documented exception in changeset), docs-site taxonomy drift (recorded — companion docs PR follows, as with #216).

## Test plan

- [x] Unit 48/48 on node, bun, esbuild — new: object/cause preservation, binding identity, backward-compat incl. `Object.hasOwn` own-keys pin
- [x] Integration 18/18 (Docker testcontainers) — the live 406 PRECONDITION_FAILED test now asserts `err.object` deep-equals `{ kind: 'queue', name: 'rec.contract.q' }`
- [x] Full monorepo: build, typecheck, test 33/33, lint 15/15

## Parity coverage

- [x] Parity N/A: broker-adapter error metadata only; no RPC-observable behaviour affected.

## Related issues / changes

Closes #202.

- Design pass: the "1.3.0 design pass (2026-07-04)" comment on #202
- Prerequisite for: #201 (PR D reply-code gate)
- Companion docs-site PR in Connectum-Framework/docs follows (taxonomy table + exports row)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `AmqpTopologyError` now includes structured, machine-readable details about the AMQP object involved in a failure.
  * Added support for identifying exchanges, queues, and bindings with consistent fields for easier troubleshooting.
  * Updated error reporting so topology-related failures surface clearer context in logs and checks.

* **Bug Fixes**
  * Improved topology mismatch handling to return structured error details instead of relying on broker reply text.
  * Preserved existing error behavior when no extra details are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->