### PR TITLE
feat(events): drainPublishTimeout — opt-in symmetric publish drain on shutdown (#196)

### DIFF
--- a/.changeset/olive-pandas-drain.md
+++ b/.changeset/olive-pandas-drain.md
@@ -1,0 +1,11 @@
+---
+"@connectum/events": minor
+---
+
+feat: `drainPublishTimeout` — opt-in symmetric publish drain on shutdown (#196)
+
+- New `EventBusOptions.drainPublishTimeout`: during `stop()`, wait up to the budget for in-flight `publish()` promises (started before `stop()`) to settle, before the adapter disconnects and would fail their confirms. Bus-level (L1): zero adapter-contract changes — nats/kafka/redis/amqp get the drain for free.
+- Runs concurrently with the handler drain (`drainTimeout`) — shutdown waits for the slower of the two budgets, never their sum.
+- Tracked promises carry a no-op observer: a publish settling (even rejecting) after the deadline never becomes an `unhandledRejection`; the caller's own `publish()` promise is unaffected.
+- Default `undefined` (and `0`/negative) — disabled: `stop()` behavior stays bit-for-bit (pinned by a regression test).
+- Documented limitation: publishes issued from draining handlers are not covered — the stopping gate rejects them (relay-pattern design tracked in #212).

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -224,6 +224,7 @@ function createEventBus(options: EventBusOptions): EventBus
 | `signal` | `AbortSignal` | `undefined` | External abort signal |
 | `handlerTimeout` | `number` | `30000` | Per-handler timeout in ms |
 | `drainTimeout` | `number` | `30000` | Max ms to wait for in-flight handlers during shutdown |
+| `drainPublishTimeout` | `number` | `undefined` | Opt-in: max ms to wait for in-flight `publish()` promises during `stop()`, before the adapter disconnects. Runs concurrently with the handler drain. `undefined`/`0` = disabled (unchanged behavior). Since 1.3.0 |
 
 > **Publisher-only processes:** when a service publishes an event but does not subscribe to it (the usual split-microservices shape), it has no `routes`, so `publish()` would fall back to the message `typeName` — silently emitting to the wrong topic whenever the event declares a custom `(connectum.events.v1.event).topic`. List the event service descriptors in `publishes` so the declared topic is resolved from the proto option end-to-end, instead of hand-maintaining raw topic strings:
 >
@@ -408,7 +409,7 @@ Set `drainTimeout: 0` for immediate abort (skip drain).
 
 ### Publishers and Shutdown
 
-`stop()` drains **consumer handlers** only — in-flight `publish()` promises are not tracked by the bus, and `drainTimeout` does not cover them. An at-least-once producer must settle its publishes **before** stopping:
+`stop()` drains **consumer handlers**; in-flight `publish()` promises are not tracked by default (`drainTimeout` does not cover them — opt in via `drainPublishTimeout`, see below). An at-least-once producer must settle its publishes **before** stopping:
 
 ```typescript
 // Track publishes you must not lose:
@@ -426,7 +427,15 @@ await bus.stop();
 Two related boundaries:
 
 - **Publishing from a draining handler is rejected.** Once `stop()` begins, `publish()` throws — including from handlers that are still draining. Relay topologies (consume → transform → publish) therefore lose the in-flight tail at shutdown; the design discussion is tracked in [#212](https://github.com/Connectum-Framework/connectum/issues/212).
-- **An opt-in symmetric publish drain** (`drainPublishTimeout`) is planned — tracked in [#196](https://github.com/Connectum-Framework/connectum/issues/196).
+- **An opt-in symmetric publish drain** ships since 1.3.0: set `drainPublishTimeout` and `stop()` waits (up to that budget, concurrently with the handler drain — the slower of the two, never the sum) for publishes started before `stop()` to settle, before the adapter disconnects and would fail their confirms. Tracked promises carry a no-op observer, so a post-deadline settlement never becomes an `unhandledRejection`; the caller's own `publish()` promise still rejects/resolves as usual. The manual await-before-stop recipe above remains valid and is still the only option for publishes you must not lose past the drain budget.
+
+```typescript
+const bus = createEventBus({
+  adapter,
+  routes: [eventRoutes],
+  drainPublishTimeout: 10_000, // wait up to 10s for in-flight publishes at stop()
+});
+```
 
 ## Exports Summary
 

--- a/packages/events/src/EventBus.ts
+++ b/packages/events/src/EventBus.ts
@@ -80,7 +80,11 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
     let startPromise: Promise<void> | null = null;
     let stopPromise: Promise<void> | null = null;
     const drainTimeout = options.drainTimeout ?? 30_000;
+    // Opt-in (#196): undefined or <= 0 disables publish tracking entirely —
+    // default behavior stays bit-for-bit.
+    const drainPublishTimeout = options.drainPublishTimeout !== undefined && options.drainPublishTimeout > 0 ? options.drainPublishTimeout : undefined;
     const inFlight = new Set<Promise<void>>();
+    const inFlightPublishes = new Set<Promise<void>>();
     let drainController = new AbortController();
     let draining = false;
     const defaultSignal = options.signal;
@@ -284,31 +288,67 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
                     await Promise.allSettled(subscriptions.map((sub) => sub.unsubscribe()));
                     subscriptions.length = 0;
 
-                    // 2. Drain in-flight handlers with timeout
-                    if (inFlight.size > 0 && drainTimeout > 0) {
-                        const deadline = Date.now() + drainTimeout;
-
-                        while (inFlight.size > 0) {
-                            const remaining = deadline - Date.now();
-                            if (remaining <= 0) break;
-
+                    // 2. Drain in-flight handlers and (opt-in, #196) in-flight
+                    //    publishes CONCURRENTLY — shutdown waits for the
+                    //    slower of the two budgets, never their sum. The
+                    //    publish drain must finish before adapter.disconnect()
+                    //    below, which would fail the outstanding confirms.
+                    // The race timers MUST be cleared after each round: a
+                    // leftover ref'd timer would keep the event loop alive for
+                    // the full remaining budget after stop() already returned
+                    // (a SIGTERM'd process would linger until SIGKILL).
+                    const raceSettled = async (pending: Set<Promise<void>>, remaining: number): Promise<void> => {
+                        let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+                        try {
                             await Promise.race([
-                                Promise.allSettled([...inFlight]),
+                                Promise.allSettled([...pending]),
                                 new Promise<void>((resolve) => {
-                                    globalThis.setTimeout(resolve, remaining);
+                                    timer = globalThis.setTimeout(resolve, remaining);
                                 }),
                             ]);
+                        } finally {
+                            if (timer !== undefined) {
+                                globalThis.clearTimeout(timer);
+                            }
                         }
-                    }
+                    };
+                    const drainHandlers = async (): Promise<void> => {
+                        if (inFlight.size > 0 && drainTimeout > 0) {
+                            const deadline = Date.now() + drainTimeout;
 
-                    // 3. Force-abort remaining handlers if still in-flight
-                    if (inFlight.size > 0) {
-                        drainController.abort("Drain timeout exceeded");
-                        // Brief settle window for abort handlers
-                        await Promise.allSettled([...inFlight]);
-                    }
+                            while (inFlight.size > 0) {
+                                const remaining = deadline - Date.now();
+                                if (remaining <= 0) break;
+                                await raceSettled(inFlight, remaining);
+                            }
+                        }
+
+                        // 3. Force-abort remaining handlers at THIS drain's own
+                        //    deadline — it must not wait for a (possibly
+                        //    longer) publish drain, or the documented
+                        //    drainTimeout abort contract would break.
+                        if (inFlight.size > 0) {
+                            drainController.abort("Drain timeout exceeded");
+                            // Brief settle window for abort handlers
+                            await Promise.allSettled([...inFlight]);
+                        }
+                    };
+                    const drainPublishes = async (): Promise<void> => {
+                        if (drainPublishTimeout === undefined || inFlightPublishes.size === 0) {
+                            return;
+                        }
+                        const deadline = Date.now() + drainPublishTimeout;
+
+                        while (inFlightPublishes.size > 0) {
+                            const remaining = deadline - Date.now();
+                            if (remaining <= 0) break;
+                            await raceSettled(inFlightPublishes, remaining);
+                        }
+                    };
+                    await Promise.all([drainHandlers(), drainPublishes()]);
 
                     inFlight.clear();
+                    inFlightPublishes.clear();
                     await adapter.disconnect();
                 } finally {
                     started = false;
@@ -340,7 +380,24 @@ export function createEventBus(options: EventBusOptions): EventBus & EventBusLik
             }
             const eventType = declaredTopic ?? schema.typeName;
 
-            await adapter.publish(eventType, payload, publishOptions);
+            const publishPromise = adapter.publish(eventType, payload, publishOptions);
+            if (drainPublishTimeout !== undefined) {
+                inFlightPublishes.add(publishPromise);
+                // Removal observer with swallowed outcomes: a publish that
+                // settles after the drain deadline (or after the caller
+                // dropped its promise) must never surface as an
+                // unhandledRejection. The caller awaits the ORIGINAL promise
+                // below, so rejections still propagate to it unchanged.
+                publishPromise.then(
+                    () => {
+                        inFlightPublishes.delete(publishPromise);
+                    },
+                    () => {
+                        inFlightPublishes.delete(publishPromise);
+                    },
+                );
+            }
+            await publishPromise;
         },
     };
 }

--- a/packages/events/src/broadcast.ts
+++ b/packages/events/src/broadcast.ts
@@ -44,6 +44,8 @@ export interface BroadcastSubscribersOptions {
     readonly handlerTimeout?: number;
     /** Shared per-bus drain timeout (ms). */
     readonly drainTimeout?: number;
+    /** Shared per-bus opt-in publish drain budget at `stop()` (ms). Since 1.3.0. */
+    readonly drainPublishTimeout?: number;
     /** Shared abort signal for graceful shutdown. */
     readonly signal?: AbortSignal;
 }
@@ -92,6 +94,7 @@ export function createBroadcastSubscribers(options: BroadcastSubscribersOptions)
             ...(reactor.middleware !== undefined ? { middleware: reactor.middleware } : {}),
             ...(options.handlerTimeout !== undefined ? { handlerTimeout: options.handlerTimeout } : {}),
             ...(options.drainTimeout !== undefined ? { drainTimeout: options.drainTimeout } : {}),
+            ...(options.drainPublishTimeout !== undefined ? { drainPublishTimeout: options.drainPublishTimeout } : {}),
             ...(options.signal !== undefined ? { signal: options.signal } : {}),
         }),
     );

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -351,6 +351,33 @@ export interface EventBusOptions {
      */
     drainTimeout?: number;
     /**
+     * Opt-in symmetric publish drain during `stop()`: maximum time in
+     * milliseconds to wait for in-flight `publish()` promises (started BEFORE
+     * `stop()` was called) to settle, before the adapter is disconnected.
+     *
+     * Runs concurrently with the handler drain (`drainTimeout`) — shutdown
+     * waits for the slower of the two, not their sum. Tracked promises carry
+     * a no-op observer, so a publish that settles (even rejects) after the
+     * deadline never becomes an `unhandledRejection`; the caller's own
+     * `publish()` promise is unaffected (rejections still propagate to it).
+     *
+     * NOT covered: publishes issued from inside handlers (including the DLQ
+     * republish) — those are governed by the handler drain and its post-abort
+     * settle window; new `publish()` calls after `stop()` begins are rejected
+     * by the stopping gate (the relay-pattern design is tracked in
+     * https://github.com/Connectum-Framework/connectum/issues/212).
+     *
+     * Budget note: `createServer`'s `shutdown.timeout` bounds the transport
+     * phase, not the shutdown hooks that stop the bus — a large value here
+     * extends total process shutdown accordingly; size it below your
+     * orchestrator's kill grace period.
+     *
+     * Default: `undefined` — disabled: `stop()` behavior is unchanged and
+     * in-flight publishes race the adapter disconnect exactly as before.
+     * `0` (or negative) also disables waiting. Available since 1.3.0.
+     */
+    drainPublishTimeout?: number;
+    /**
      * Reject a `publish()` whose topic cannot be resolved instead of silently
      * falling back to the message `typeName`.
      *

--- a/packages/events/tests/unit/drain-publish.test.ts
+++ b/packages/events/tests/unit/drain-publish.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the opt-in symmetric publish drain (`drainPublishTimeout`, #196).
+ *
+ * Uses a controllable fake adapter (deferred publish promises) so the tests
+ * pin the BUS-level drain semantics without any broker:
+ * - default (unset): bit-for-bit — stop() does not wait for pending publishes
+ * - set: stop() waits for pending publishes to settle BEFORE disconnect
+ * - set: a never-settling publish releases stop() at the deadline
+ * - the stopping gate still rejects publishes issued during stop()
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { create } from "@bufbuild/protobuf";
+import { EventOptionsSchema } from "../../gen/connectum/events/v1/options_pb.js";
+import { createEventBus } from "../../src/EventBus.ts";
+import type { EventAdapter, EventSubscription, RawEvent, RawEventHandler } from "../../src/types.ts";
+
+/** A minimal valid message instance for publish(). */
+const eventMsg = () => create(EventOptionsSchema, {});
+
+interface Deferred {
+    resolve: () => void;
+    reject: (err: Error) => void;
+}
+
+/**
+ * Fake adapter whose publish() promises settle only when the test says so.
+ * Records the order of `publish-settled` / `disconnect` for assertions.
+ */
+function makeControlledAdapter(order: string[]) {
+    const pending: Deferred[] = [];
+    const adapter: EventAdapter = {
+        name: "controlled",
+        connect: async () => undefined,
+        disconnect: async () => {
+            order.push("disconnect");
+        },
+        publish: () =>
+            new Promise<void>((resolve, reject) => {
+                pending.push({
+                    resolve: () => {
+                        order.push("publish-settled");
+                        resolve();
+                    },
+                    reject: (err: Error) => {
+                        order.push("publish-rejected");
+                        reject(err);
+                    },
+                });
+            }),
+        subscribe: async (): Promise<EventSubscription> => ({
+            unsubscribe: async () => undefined,
+        }),
+    };
+    return { adapter, pending };
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("drainPublishTimeout (#196)", () => {
+    it("default (unset): stop() does NOT wait for a pending publish — bit-for-bit regression pin", async () => {
+        const order: string[] = [];
+        const { adapter, pending } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter });
+        await bus.start();
+
+        const publishSettled = bus.publish(EventOptionsSchema, eventMsg()).catch(() => undefined);
+        await sleep(10); // let publish reach the adapter
+
+        await bus.stop();
+        assert.deepEqual(order, ["disconnect"], "stop() must not wait for the pending publish by default");
+
+        // Settle afterwards — must not throw or become unhandled.
+        pending[0]?.resolve();
+        await publishSettled;
+    });
+
+    it("set: stop() waits for the pending publish to settle before disconnect", async () => {
+        const order: string[] = [];
+        const { adapter, pending } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter, drainPublishTimeout: 5_000 });
+        await bus.start();
+
+        const publishSettled = bus.publish(EventOptionsSchema, eventMsg());
+        await sleep(10);
+
+        const stopping = bus.stop();
+        // The publish settles 50ms into the drain window.
+        setTimeout(() => pending[0]?.resolve(), 50);
+        await stopping;
+
+        assert.deepEqual(order, ["publish-settled", "disconnect"], "disconnect must come after the drained publish");
+        await publishSettled;
+    });
+
+    it("set: a rejecting publish also counts as settled (and never becomes unhandled)", async () => {
+        const order: string[] = [];
+        const { adapter, pending } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter, drainPublishTimeout: 5_000 });
+        await bus.start();
+
+        const publishSettled = bus.publish(EventOptionsSchema, eventMsg()).catch((err: unknown) => {
+            order.push(`caller-saw:${(err as Error).message}`);
+        });
+        await sleep(10);
+
+        const stopping = bus.stop();
+        setTimeout(() => pending[0]?.reject(new Error("nacked")), 50);
+        await stopping;
+        await publishSettled;
+
+        assert.deepEqual(order, ["publish-rejected", "caller-saw:nacked", "disconnect"], "rejection settles the drain and still reaches the caller");
+    });
+
+    it("set: a never-settling publish releases stop() at the deadline", async () => {
+        const order: string[] = [];
+        const { adapter } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter, drainPublishTimeout: 120 });
+        await bus.start();
+
+        void bus.publish(EventOptionsSchema, eventMsg()).catch(() => undefined);
+        await sleep(10);
+
+        const startedAt = Date.now();
+        await bus.stop();
+        const took = Date.now() - startedAt;
+
+        assert.ok(took >= 100, `stop() must hold for the drain window (took ${took}ms)`);
+        assert.ok(took < 2_000, `stop() must release at the deadline, not hang (took ${took}ms)`);
+        assert.deepEqual(order, ["disconnect"], "disconnect proceeds after the deadline");
+    });
+
+    it("stopping gate: publish() during stop() still throws (drain does not admit new publishes)", async () => {
+        const order: string[] = [];
+        const { adapter } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter, drainPublishTimeout: 100 });
+        await bus.start();
+
+        void bus.publish(EventOptionsSchema, eventMsg()).catch(() => undefined);
+        await sleep(10);
+
+        const stopping = bus.stop();
+        await assert.rejects(
+            () => bus.publish(EventOptionsSchema, eventMsg()),
+            /not started/i,
+            "the stopping gate is unchanged — new publishes are rejected during stop()",
+        );
+        await stopping;
+    });
+
+    it("combined drains: handler force-abort fires at ITS deadline while the publish drain still holds stop() (slower-of, not sum)", async () => {
+        // Adapter that captures the wrapped handler (so the test can put a
+        // handler in flight) and whose publish never settles.
+        let capturedHandler: RawEventHandler | null = null;
+        const adapter: EventAdapter = {
+            name: "combined",
+            connect: async () => undefined,
+            disconnect: async () => undefined,
+            publish: () => new Promise<void>(() => undefined),
+            subscribe: async (_patterns, handler): Promise<EventSubscription> => {
+                capturedHandler = handler;
+                return { unsubscribe: async () => undefined };
+            },
+        };
+
+        const fakeMethod = {
+            localName: "simpleEvent",
+            input: Object.create(EventOptionsSchema, { typeName: { value: EventOptionsSchema.typeName, writable: false, enumerable: true } }),
+            proto: { options: undefined },
+            // biome-ignore lint/suspicious/noExplicitAny: minimal fake descriptor for route registration
+        } as any;
+        // biome-ignore lint/suspicious/noExplicitAny: minimal fake descriptor for route registration
+        const fakeService = { typeName: "test.v1.DrainService", methods: [fakeMethod] } as any;
+
+        let abortObservedAt = 0;
+        const bus = createEventBus({
+            adapter,
+            drainTimeout: 100,
+            drainPublishTimeout: 500,
+            routes: [
+                (router) => {
+                    router.service(fakeService, {
+                        // Handler hangs until the drain force-abort fires.
+                        simpleEvent: async (_msg: unknown, ctx: { signal: AbortSignal }) => {
+                            await new Promise<void>((resolve) => {
+                                ctx.signal.addEventListener(
+                                    "abort",
+                                    () => {
+                                        abortObservedAt = Date.now();
+                                        resolve();
+                                    },
+                                    { once: true },
+                                );
+                            });
+                        },
+                        // biome-ignore lint/suspicious/noExplicitAny: route map against a fake descriptor
+                    } as any);
+                },
+            ],
+        });
+        await bus.start();
+
+        assert.ok(capturedHandler, "subscribe must have captured the wrapped handler");
+        const rawEvent: RawEvent = {
+            eventId: "evt-drain-combined",
+            eventType: EventOptionsSchema.typeName,
+            payload: new Uint8Array(),
+            publishedAt: new Date(),
+            attempt: 1,
+            metadata: new Map(),
+        };
+        // In-flight handler (not awaited) + in-flight publish (never settles).
+        const handlerDone = (capturedHandler as RawEventHandler)(
+            rawEvent,
+            async () => undefined,
+            async () => undefined,
+        );
+        void bus.publish(EventOptionsSchema, eventMsg()).catch(() => undefined);
+        await sleep(10);
+
+        const stopStartedAt = Date.now();
+        await bus.stop();
+        const stopTook = Date.now() - stopStartedAt;
+        await handlerDone;
+
+        assert.ok(abortObservedAt > 0, "the hung handler must have been force-aborted");
+        const abortLatency = abortObservedAt - stopStartedAt;
+        assert.ok(abortLatency < 350, `force-abort must fire at the HANDLER drain deadline (~100ms), not after the publish drain (fired at ${abortLatency}ms)`);
+        assert.ok(stopTook >= 450, `stop() must still hold for the publish budget (took ${stopTook}ms)`);
+        assert.ok(stopTook < 2_000, `stop() must be slower-of, never the sum (took ${stopTook}ms)`);
+    });
+
+    it("0 disables waiting (same as unset)", async () => {
+        const order: string[] = [];
+        const { adapter, pending } = makeControlledAdapter(order);
+        const bus = createEventBus({ adapter, drainPublishTimeout: 0 });
+        await bus.start();
+
+        const publishSettled = bus.publish(EventOptionsSchema, eventMsg()).catch(() => undefined);
+        await sleep(10);
+
+        await bus.stop();
+        assert.deepEqual(order, ["disconnect"], "0 must not enable tracking or waiting");
+        pending[0]?.resolve();
+        await publishSettled;
+    });
+});


### PR DESCRIPTION
## Summary

Implements #196 per the "1.3.0 design pass" comment — `drainPublishTimeout`: an opt-in symmetric publish drain at `stop()`, in `@connectum/events` (L1). Zero adapter-contract changes: all four broker adapters get the drain for free. The docs half (the await-before-stop recipe) shipped earlier in #214; this is the option itself.

## Type of change

- [x] New feature (non-breaking)

## What changed

- **`EventBusOptions.drainPublishTimeout`** (default `undefined`; `0`/negative also disable — `stop()` stays bit-for-bit, pinned by a regression test). When set, `stop()` waits up to the budget for in-flight `publish()` promises (started before `stop()`) to settle BEFORE `adapter.disconnect()` fails their confirms.
- **Concurrent drains**: publish drain runs alongside the handler drain — shutdown waits for the slower budget, never the sum. The handler force-abort fires at the handler drain's OWN deadline (moved inside `drainHandlers` — see review notes).
- **No leaked handles**: race timers are cleared after every round (`raceSettled` helper, applied to the pre-existing handler loop too).
- **No `unhandledRejection`**: tracked promises carry a removal observer with swallowed outcomes; the caller's own `publish()` promise keeps its normal outcome.
- **`createBroadcastSubscribers`** forwards the new knob (`BroadcastSubscribersOptions.drainPublishTimeout`).
- Documented boundaries: handler-issued publishes (incl. the DLQ republish) are governed by the handler drain + its post-abort settle window, not this option (#212 — observation about the unbounded settle window recorded there); `createServer`'s `shutdown.timeout` does not bound the bus-stopping hook — sizing note added.

## Adversarial pre-PR review

3 angles → 7 verified findings (2 refuted), all addressed. Two were **empirically confirmed behavioral defects** in the draft and are fixed + pinned:
- a leftover ref'd race timer kept the event loop alive for the full remaining budget after `stop()` returned (a SIGTERM'd pod would linger until SIGKILL) → timers cleared; the new suite runs in ~1.1s wall vs 5.2s pre-fix;
- the handler force-abort was deferred behind a longer publish drain, breaking the documented `drainTimeout` contract → abort moved to its own deadline; pinned by a combined-drain test (abort at ~100ms while `stop()` holds for the 500ms publish budget).
Plus: broadcast helper parity, README self-contradiction, server-budget note, DLQ transitive-coverage clarification, combined-drain test gap.

## Test plan

- [x] Unit 7/7 in the new `drain-publish.test.ts` (default bit-for-bit pin; settle-before-disconnect; rejection settles the drain and reaches the caller; deadline release; stopping gate; `0` = disabled; combined drains slower-of pin) — suite wall time ~1.1s (no lingering handles)
- [x] Events package 155/155 (node), 17/17 suites (bun), 118/118 (esbuild)
- [x] Full monorepo: build, typecheck, test 33/33, lint 15/15

## Parity coverage

- [x] Parity N/A: EventBus shutdown semantics only; no RPC-observable behaviour affected.

## Related issues / changes

Closes #196.

- Design pass: the "1.3.0 design pass (2026-07-04)" comment on #196
- Docs half shipped in #214 (recipe); relay-pattern design: #212 (settle-window observation added)
- Companion docs-site PR in Connectum-Framework/docs follows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional publish-drain timeout for event bus shutdown, letting `stop()` wait briefly for in-flight publish calls to finish before disconnecting.
  * Broadcast subscriptions now support the same shutdown setting.

* **Bug Fixes**
  * Preserved current shutdown behavior when the setting is unset, `0`, or negative.
  * Prevented late publish settlements from surfacing as unhandled promise rejections.

* **Documentation**
  * Updated shutdown guidance and option docs with examples and clearer behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->