### PR TITLE
feat(events-amqp): publishRetry — opt-in bounded retry for connection-class publish failures (#195)

### DIFF
--- a/.changeset/brave-owls-persist.md
+++ b/.changeset/brave-owls-persist.md
@@ -1,0 +1,11 @@
+---
+"@connectum/events-amqp": minor
+---
+
+feat: `publishRetry` — opt-in bounded publish retry for connection-class outcomes (#195)
+
+- New top-level `publishRetry: boolean | AmqpPublishRetryOptions`: a `publish()` failing with `AmqpConnectionError` (publish during a recovery window; in-flight confirm lost to a drop) retries in place — a short broker blip becomes a transparent delay instead of an instant rejection. Backoff mirrors the recovery formula; `maxRetries` defaults to a bounded `5`. `AmqpPublishTimeoutError` joins only via `retryOnTimeout: true`.
+- The auto-retry boundary is the exported **`isAutoRetriablePublishError`** — deliberately narrower than the at-least-once republish matrix (a broker nack is republish-safe by policy but never auto-retried inline; deterministic outcomes never retry). Docs distinguish the two boundaries explicitly.
+- At-least-once framing documented honestly: a retry after an in-flight confirm loss may duplicate; `x-event-id`/`messageId` stay stable across attempts (incl. `externalContract`) as the consumer-side dedup anchor.
+- Shutdown-aware and drain-covered: the loop aborts promptly on `disconnect()` (interruptible backoff) and lives inside the `adapter.publish()` promise, so the bus-level `drainPublishTimeout` covers retries automatically. Under single-flight correlation, retries hold the chain (ordering preserved; head-of-line blocking documented). The publish channel is re-resolved per attempt.
+- Default off — publish behavior unchanged unless opted in.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -128,6 +128,7 @@ function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter
 | `treatTopologyErrorAsFatal` | `boolean` | `false` | Stop the reconnect cycle on **deterministic** topology drift during steady-state recovery (AMQP reply code `404`/`406` on the cause) instead of retrying forever; reports terminal `reconnect-failed` after `setup-failed`. Transient causes (`320`/`541`/`405`, connection drops) stay in recovery. Since 1.3.0 |
 | `lifecycle` | `AmqpLifecycleCallbacks` | `undefined` | Connection lifecycle callbacks |
 | `publishTimeoutMs` | `number` | `30000` | Per-publish broker-outcome deadline |
+| `publishRetry` | `boolean \| AmqpPublishRetryOptions` | `false` | Opt-in bounded retry for **connection-class** publish failures (`AmqpConnectionError`; timeouts only via `retryOnTimeout`) — a broker blip becomes a transparent delay instead of an instant rejection. At-least-once; ids stay stable across attempts. See [Publish Retry](#publish-retry). Since 1.3.0 |
 
 ### AmqpExchangeOptions
 
@@ -296,9 +297,30 @@ Event metadata is transmitted as AMQP message headers. Internal headers (`x-even
 The adapter publishes on a confirm channel with **per-message confirms**: every `publish()` resolves when the broker acks that specific message and rejects when the broker nacks it. There is no batching and no `waitForConfirms()` -- each publish has its own outcome.
 
 - A publish with no broker outcome (ack/nack/return/connection loss) within `publishTimeoutMs` (default 30000 ms) rejects with `AmqpPublishTimeoutError`. The message state is then UNKNOWN -- it may or may not have been routed; an at-least-once producer should republish.
-- A publish during a disconnected window (or while recovery is in progress) fails fast with `AmqpConnectionError`. In-flight publishes at the moment of a connection loss also reject with `AmqpConnectionError`.
+- A publish during a disconnected window (or while recovery is in progress) fails fast with `AmqpConnectionError` — unless the opt-in [`publishRetry`](#publish-retry) is enabled, which retries connection-class failures in place. In-flight publishes at the moment of a connection loss also reject with `AmqpConnectionError` (retried under the same opt-in).
 
 > **Note**: confirms are always per-message — every `publish()` resolves on its own broker ack (or rejects with a typed error). There is no fire-and-forget mode. (The legacy `sync` flag was removed from `PublishOptions` ahead of the first stable release.)
+
+### Publish Retry
+
+Opt-in (`publishRetry: true` or an `AmqpPublishRetryOptions` object, since 1.3.0): a `publish()` that fails with a **connection-class** outcome — publishing during a recovery window, or an in-flight confirm lost to a drop — is retried in place (the caller's promise stays pending) instead of rejecting immediately.
+
+```typescript
+publishRetry: {
+  maxRetries: 5,        // retries after the first attempt (default 5 — bounded, unlike recovery)
+  initialDelay: 100,    // backoff mirrors the recovery formula (cap-before-jitter)
+  retryOnTimeout: false, // opt-in: also retry AmqpPublishTimeoutError (state UNKNOWN — raises duplicate likelihood)
+  onRetry: ({ attempt, delay, routingKey }) => metrics.increment('amqp.publish_retry'),
+}
+```
+
+- **The auto-retry boundary is `isAutoRetriablePublishError` (exported)** and is deliberately **narrower** than the at-least-once *republish* matrix below: a broker `nack` is republish-safe by policy but is an explicit refusal — it is never auto-retried inline. Deterministic outcomes (unroutable, serialization, topology) never retry.
+- **At-least-once, full stop**: a retry after an in-flight confirm loss (state UNKNOWN) may duplicate on the broker. `x-event-id` / `messageId` stay **stable across attempts** (incl. `externalContract` with caller-supplied ids), so consumer-side dedup keys on them.
+- **Worst-case latency**: each attempt is bounded by `publishTimeoutMs` (default 30s) — at defaults a single `publish()` can be held for minutes, far beyond typical 30s RPC timeouts. Bound the budget via `maxRetries`/`publishTimeoutMs`; there is deliberately no second overall-deadline knob.
+- **Shutdown-aware**: the loop aborts promptly on `disconnect()` (also when the adapter has been terminally stopped by `treatTopologyErrorAsFatal` — no budget is burned against a dead cycle), and — living inside the `adapter.publish()` promise — is automatically covered by the bus-level `drainPublishTimeout`.
+- **Single-flight interaction** (`mandatory: true` with `correlationHeader: false`; `externalContract` forces the latter but single-flight still requires `mandatory`): retries **hold the chain** — ordering is preserved at the cost of head-of-line blocking during backoff. In this headerless mode a late `basic.return` from an abandoned timed-out attempt may mark the current one — prefer the default header correlation when combining `mandatory` with `retryOnTimeout`.
+- **Deterministic channel-close is not retried**: a broker reply with a `404`/`406` code that killed the publish *channel* (e.g. a publish to a missing exchange under `topologyMode: "skip"`) surfaces immediately with the broker reply as `cause` — the connection stays up, recovery never recreates the channel, so retrying cannot heal.
+- The publish channel is re-resolved on every attempt, so a recovery swap mid-loop is picked up automatically (a *connection*-level recovery; see the previous bullet for channel-only closes).
 
 ### Mandatory Publishing and basic.return Correlation
 

--- a/packages/events-amqp/src/AmqpAdapter.ts
+++ b/packages/events-amqp/src/AmqpAdapter.ts
@@ -164,6 +164,26 @@ function buildConnectOptions(socketOptions: Record<string, unknown> | undefined,
     return opts;
 }
 
+/**
+ * The publish AUTO-RETRY boundary (#195): which publish failures the opt-in
+ * `publishRetry` retries inline.
+ *
+ * Deliberately NARROWER than the at-least-once REPUBLISH matrix in the error
+ * taxonomy (`errors.ts`): a broker nack is republish-safe by policy but is an
+ * explicit refusal — hammering it in a tight loop is not a retry strategy.
+ * Connection-class outcomes (`AmqpConnectionError`: publish during recovery,
+ * in-flight confirm lost to a drop) are retriable; a timeout
+ * (`AmqpPublishTimeoutError`, state UNKNOWN) joins only via
+ * `retryOnTimeout: true`. Deterministic outcomes (unroutable, serialization,
+ * topology) never retry.
+ */
+export function isAutoRetriablePublishError(err: unknown, options?: { readonly retryOnTimeout?: boolean }): boolean {
+    if (err instanceof AmqpConnectionError) {
+        return true;
+    }
+    return options?.retryOnTimeout === true && err instanceof AmqpPublishTimeoutError;
+}
+
 /** AMQP reply codes that identify DETERMINISTIC topology drift (vs a transient failure). */
 const FATAL_TOPOLOGY_REPLY_CODES: ReadonlySet<number> = new Set([404, 406]);
 
@@ -450,6 +470,29 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
     // mandatory correlation so no `x-connectum-publish-id` header reaches the
     // wire — `correlationHeader` is ignored in this mode.
     const externalContract = options.publisherOptions?.externalContract ?? false;
+    // Opt-in bounded publish retry (#195): null = disabled (bit-for-bit).
+    const publishRetryRaw = options.publishRetry;
+    const publishRetry =
+        publishRetryRaw === undefined || publishRetryRaw === false
+            ? null
+            : (() => {
+                  const o = publishRetryRaw === true ? {} : publishRetryRaw;
+                  const rawBudget = o.maxRetries;
+                  // Infinity is honored (retry until disconnect() aborts),
+                  // mirroring recovery's maxRetries semantics.
+                  const maxRetries =
+                      rawBudget === Number.POSITIVE_INFINITY
+                          ? Number.POSITIVE_INFINITY
+                          : typeof rawBudget === "number" && Number.isFinite(rawBudget)
+                            ? Math.max(0, Math.floor(rawBudget))
+                            : 5;
+                  return {
+                      maxRetries,
+                      backoff: { initialDelay: o.initialDelay ?? 100, maxDelay: o.maxDelay ?? 30_000, factor: o.factor ?? 2, jitter: o.jitter ?? 0.2 },
+                      retryOnTimeout: o.retryOnTimeout === true,
+                      onRetry: o.onRetry,
+                  };
+              })();
     const correlationHeader = externalContract ? false : (options.publisherOptions?.correlationHeader ?? true);
     const lifecycle = options.lifecycle;
 
@@ -467,6 +510,11 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
      * uses to tell a connection loss from a broker nack.
      */
     const closedPublishChannels = new WeakSet<amqp.ConfirmChannel>();
+    // Root cause of a channel-level failure (e.g. 404 closing the channel on a
+    // publish to a missing exchange). Confirm callbacks only see amqplib's
+    // generic Error("channel closed") — this map preserves the broker reply
+    // (with its code) for diagnosability and for the publish-retry gate.
+    const publishChannelErrors = new WeakMap<amqp.ConfirmChannel, Error>();
 
     /** Pending mandatory publishes awaiting confirm (publish-id → return flag). */
     const pendingReturns = new Map<string, PendingReturn>();
@@ -634,10 +682,13 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             }
         });
 
-        ch.on("error", () => {
+        ch.on("error", (err: Error) => {
             // Channel-level errors surface through the connection lifecycle
-            // and through rejected confirm callbacks; nothing to do here, but
-            // the listener prevents unhandled 'error' crashes.
+            // and through rejected confirm callbacks; the listener also
+            // prevents unhandled 'error' crashes. Record the root cause (the
+            // broker reply carries the code, e.g. 404) — the confirm callback
+            // only ever sees a generic "channel closed".
+            publishChannelErrors.set(ch, err);
         });
 
         publishChannel = ch;
@@ -1170,8 +1221,11 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
         },
 
         async publish(eventType: string, payload: Uint8Array, publishOptions?: PublishOptions): Promise<void> {
-            const ch = publishChannel;
-            if (!ch || closing) {
+            // With retry disabled the entry guard is the historical fail-fast;
+            // with retry enabled a disconnected window is a RETRIABLE state
+            // (the whole point of #195), so the guard moves into each attempt.
+            const chAtEntry = publishChannel;
+            if (publishRetry === null && (!chAtEntry || closing)) {
                 throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
             }
 
@@ -1215,10 +1269,19 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
             // default; single-flight serialization when the header is disabled.
             // Frame ordering alone is NOT reliable — returns carry no
             // deliveryTag and confirms of other messages may interleave.
-            const publishId: string | null = mandatory ? eventId : null;
-            if (mandatory && correlationHeader) {
-                headers[PUBLISH_ID_HEADER] = eventId;
-            }
+            // The correlation id is PER ATTEMPT under publishRetry: a late
+            // basic.return from an abandoned (timed-out) attempt must never
+            // poison the next attempt's pending record. It is private wire
+            // correlation — the dedup identity (x-event-id / messageId) stays
+            // stable across attempts.
+            let attemptSerial = 0;
+            const nextPublishId = (): string | null => {
+                if (!mandatory) {
+                    return null;
+                }
+                attemptSerial += 1;
+                return attemptSerial === 1 ? eventId : `${eventId}#${attemptSerial}`;
+            };
 
             // messageId / timestamp: a caller-supplied value (PublishOptions)
             // always wins; otherwise auto-populate in normal mode and OMIT in
@@ -1235,7 +1298,13 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 ...(resolvedTimestamp !== undefined ? { timestamp: resolvedTimestamp } : {}),
             };
 
-            const doPublish = async (): Promise<void> => {
+            const doPublish = async (ch: amqp.ConfirmChannel): Promise<void> => {
+                const publishId = nextPublishId();
+                if (publishId !== null && correlationHeader) {
+                    // Restamped per attempt (publishProps.headers references
+                    // this object; amqplib serializes at publish time).
+                    headers[PUBLISH_ID_HEADER] = publishId;
+                }
                 const pending: PendingReturn = { returned: false };
                 if (publishId !== null) {
                     pendingReturns.set(publishId, pending);
@@ -1270,9 +1339,13 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                                         // have swapped publishChannel) is a connection loss,
                                         // not a broker nack — classify by the structural
                                         // close signal, with the text regex as a fallback.
+                                        // A channel-level root cause (broker reply with its
+                                        // code, e.g. 404) replaces amqplib's generic
+                                        // "channel closed" for diagnosability and the
+                                        // publish-retry determinism gate.
                                         reject(
                                             classifyConfirmError({
-                                                err,
+                                                err: (closedPublishChannels.has(ch) ? publishChannelErrors.get(ch) : undefined) ?? err,
                                                 closing,
                                                 channelClosed: closedPublishChannels.has(ch),
                                                 channelSwapped: publishChannel !== ch,
@@ -1287,7 +1360,8 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                                 });
                             });
                         } catch (err) {
-                            settle(() => reject(new AmqpConnectionError(`Publish failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err })));
+                            const rootCause = publishChannelErrors.get(ch) ?? err;
+                            settle(() => reject(new AmqpConnectionError(`Publish failed: ${err instanceof Error ? err.message : String(err)}`, { cause: rootCause })));
                             return;
                         }
 
@@ -1302,17 +1376,81 @@ export function AmqpAdapter(options: AmqpAdapterOptions): EventAdapter {
                 }
             };
 
+            // Bounded retry loop (#195): strictly for the auto-retry boundary
+            // (isAutoRetriablePublishError), aborting on closing. eventId /
+            // messageId / timestamp were resolved ONCE above, so every attempt
+            // re-sends the identical message (consumer-side dedup anchor);
+            // only the private return-correlation id differs per attempt.
+            const runPublish = async (): Promise<void> => {
+                if (publishRetry === null) {
+                    // Bit-for-bit legacy path: single attempt on the channel
+                    // captured at entry, no re-checks at slot-execution time
+                    // (a queued single-flight publish that starts during a
+                    // disconnect() race is attempted, exactly as before).
+                    return doPublish(chAtEntry as amqp.ConfirmChannel);
+                }
+                for (let attempt = 0; ; attempt += 1) {
+                    try {
+                        // Re-resolve the CURRENT channel per attempt (recovery
+                        // may have swapped it between retries).
+                        const ch = publishChannel;
+                        if (!ch || closing) {
+                            throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
+                        }
+                        return await doPublish(ch);
+                    } catch (err) {
+                        if (closing || attempt >= publishRetry.maxRetries || !isAutoRetriablePublishError(err, publishRetry)) {
+                            throw err;
+                        }
+                        // Deterministic channel-close: a broker reply with a
+                        // 404/406 code killed the CHANNEL (e.g. a publish to a
+                        // missing exchange under topologyMode "skip") — the
+                        // connection stays up, so recovery never recreates the
+                        // channel and retrying cannot heal. Same reply-code
+                        // philosophy as treatTopologyErrorAsFatal.
+                        const cause = err instanceof Error ? (err.cause as { code?: unknown } | null | undefined) : undefined;
+                        if (typeof cause?.code === "number" && FATAL_TOPOLOGY_REPLY_CODES.has(cause.code)) {
+                            throw err;
+                        }
+                        // No connection object at all (fatal topology stop,
+                        // post-disconnect, never connected): no recovery cycle
+                        // exists to heal us — burn no budget.
+                        if (connection === null) {
+                            throw err;
+                        }
+                        const delay = computeRecoveryDelay(publishRetry.backoff, attempt + 1);
+                        try {
+                            publishRetry.onRetry?.({ attempt: attempt + 1, delay, error: err instanceof Error ? err : new Error(String(err)), routingKey });
+                        } catch {
+                            // Observability hooks must not break the retry loop.
+                        }
+                        // Interruptible backoff — disconnect()/drain must not
+                        // park behind a long delay (contract with #196).
+                        for (let waited = 0; waited < delay && !closing; waited += 100) {
+                            await new Promise<void>((resolve) => {
+                                globalThis.setTimeout(resolve, Math.min(100, delay - waited));
+                            });
+                        }
+                        if (closing) {
+                            throw err;
+                        }
+                    }
+                }
+            };
+
             // Confirms are always per-message: every publish resolves on its
             // own broker ack (or rejects with a typed error).
             if (mandatory && !correlationHeader) {
                 // Single-flight: serialize mandatory publishes so the headerless
-                // return frame is unambiguously the outstanding one.
-                const run = mandatoryChain.then(doPublish, doPublish);
+                // return frame is unambiguously the outstanding one. The WHOLE
+                // retry loop runs inside the slot (hold-the-chain): ordering is
+                // preserved at the cost of head-of-line blocking during backoff.
+                const run = mandatoryChain.then(runPublish, runPublish);
                 mandatoryChain = run.catch(() => undefined);
                 return run;
             }
 
-            return doPublish();
+            return runPublish();
         },
 
         async subscribe(patterns: string[], handler: RawEventHandler, subOptions?: RawSubscribeOptions): Promise<EventSubscription> {

--- a/packages/events-amqp/src/errors.ts
+++ b/packages/events-amqp/src/errors.ts
@@ -36,8 +36,11 @@ export class AmqpAdapterError extends Error {
 
 /**
  * Connection is absent, lost, or recovery is in progress / exhausted.
- * Publishes during a disconnected window fail fast with this error;
- * in-flight confirms are rejected with it on connection loss.
+ * Publishes during a disconnected window fail fast with this error (unless
+ * the opt-in `publishRetry` is enabled — connection-class failures are then
+ * retried in place within the AUTO-RETRY boundary, see
+ * `isAutoRetriablePublishError`); in-flight confirms are rejected with it on
+ * connection loss.
  */
 export class AmqpConnectionError extends AmqpAdapterError {}
 

--- a/packages/events-amqp/src/index.ts
+++ b/packages/events-amqp/src/index.ts
@@ -24,7 +24,7 @@
  * @mergeModuleWith <project>
  */
 
-export { AmqpAdapter, toAmqpPattern } from "./AmqpAdapter.ts";
+export { AmqpAdapter, isAutoRetriablePublishError, toAmqpPattern } from "./AmqpAdapter.ts";
 export type { AmqpTopologyObject } from "./errors.ts";
 export { AmqpAdapterError, AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "./errors.ts";
 export type {
@@ -36,6 +36,7 @@ export type {
     AmqpLifecycleCallbacks,
     AmqpLifecycleEvent,
     AmqpPublisherOptions,
+    AmqpPublishRetryOptions,
     AmqpQueueDeclaration,
     AmqpQueueOptions,
     AmqpQueueOverride,

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -191,6 +191,58 @@ export interface AmqpAdapterOptions {
     readonly treatTopologyErrorAsFatal?: boolean;
 
     /**
+     * Opt-in bounded publish retry for CONNECTION-CLASS outcomes (since 1.3.0).
+     *
+     * When enabled, a `publish()` that fails with `AmqpConnectionError` —
+     * publishing during a recovery window, or an in-flight confirm lost to a
+     * connection drop — is retried in place (the caller's promise stays
+     * pending) instead of rejecting immediately: a short broker blip becomes
+     * a transparent delay. `true` = defaults; an object tunes the budget.
+     *
+     * The retry boundary is {@link isAutoRetriablePublishError} — deliberately
+     * NARROWER than the at-least-once republish matrix in the error taxonomy:
+     * a broker `nack` is republish-safe by policy but is NOT auto-retried
+     * inline (it is an explicit broker refusal, e.g. an over-capacity queue —
+     * hammering it in a tight loop helps nobody). `AmqpPublishTimeoutError`
+     * joins the boundary only with `retryOnTimeout: true`.
+     *
+     * Semantics — read before enabling:
+     * - **At-least-once, full stop.** A retried publish whose previous attempt
+     *   was lost IN FLIGHT (confirm never arrived: state UNKNOWN) may
+     *   duplicate on the broker. `x-event-id` / `messageId` stay STABLE across
+     *   attempts (also with `externalContract` — a caller-supplied id is
+     *   reused as-is), so consumer-side dedup keys on them.
+     * - **Worst-case latency**: each attempt is bounded by `publishTimeoutMs`
+     *   (default 30s), so `maxRetries: 5` can hold a single `publish()` for
+     *   several minutes worst-case — far beyond typical 30s RPC timeouts.
+     *   There is deliberately no second overall-deadline knob: bound the
+     *   budget via `maxRetries`/`publishTimeoutMs`.
+     * - **Shutdown-aware**: the loop aborts on `disconnect()` (throws the last
+     *   connection error) and, living inside the `adapter.publish()` promise,
+     *   is automatically covered by the bus-level `drainPublishTimeout`.
+     * - **Single-flight** (`mandatory: true` with `correlationHeader: false`;
+     *   `externalContract` forces the latter but single-flight still requires
+     *   `mandatory`): retries hold the chain — ordering is preserved at the
+     *   cost of head-of-line blocking during backoff. In this headerless mode
+     *   a late `basic.return` from an abandoned timed-out attempt may mark the
+     *   current one (correlation is attempt-agnostic without the header) —
+     *   prefer the default header correlation when combining `mandatory` with
+     *   `retryOnTimeout`.
+     * - **Deterministic channel-close is not retried**: a broker reply with a
+     *   `404`/`406` code that killed the publish CHANNEL (e.g. a publish to a
+     *   missing exchange under `topologyMode: "skip"`) surfaces immediately
+     *   with the broker reply as `cause` — the connection stays up, recovery
+     *   never recreates the channel, so retrying cannot heal.
+     *
+     * Backoff mirrors the recovery formula (same knob names and semantics,
+     * incl. cap-before-jitter), but the DEFAULT budget differs: `maxRetries`
+     * here defaults to **5** (bounded), not `Infinity`.
+     *
+     * @default undefined (disabled — behavior unchanged)
+     */
+    readonly publishRetry?: boolean | AmqpPublishRetryOptions;
+
+    /**
      * Connection lifecycle callbacks. Connection errors are surfaced here —
      * not just logged.
      */
@@ -399,6 +451,39 @@ export type AmqpLifecycleEvent =
     | { readonly type: "setup-failed"; readonly initial: boolean; readonly attempt: number; readonly error: Error }
     | { readonly type: "blocked"; readonly reason: string }
     | { readonly type: "unblocked" };
+
+/**
+ * Tuning for the opt-in bounded publish retry
+ * ({@link AmqpAdapterOptions.publishRetry}). Backoff knobs mirror
+ * {@link AmqpRecoveryOptions} (same names, same cap-before-jitter semantics)
+ * — but `maxRetries` defaults to a BOUNDED `5` here, not `Infinity`.
+ */
+export interface AmqpPublishRetryOptions {
+    /** Retries after the first attempt (N retries = N+1 attempts). `Infinity` is honored — retry until `disconnect()` aborts. @default 5 */
+    readonly maxRetries?: number;
+    /** First retry delay in ms. @default 100 */
+    readonly initialDelay?: number;
+    /** Base delay cap in ms; jitter applies on top of the capped base. @default 30000 */
+    readonly maxDelay?: number;
+    /** Exponential backoff factor. @default 2 */
+    readonly factor?: number;
+    /** Symmetric jitter factor (0..1). @default 0.2 */
+    readonly jitter?: number;
+    /**
+     * Also retry `AmqpPublishTimeoutError` (no broker outcome within
+     * `publishTimeoutMs`). The message state at a timeout is UNKNOWN, so this
+     * raises the duplicate likelihood — enable only with consumer-side dedup.
+     * @default false
+     */
+    readonly retryOnTimeout?: boolean;
+    /**
+     * Observability hook, invoked once per scheduled retry. MUST NOT throw
+     * (exceptions are isolated). Scoped here deliberately — publish retries
+     * are per-operation events, not connection lifecycle, so they do not join
+     * {@link AmqpLifecycleEvent}.
+     */
+    readonly onRetry?: (info: { readonly attempt: number; readonly delay: number; readonly error: Error; readonly routingKey: string }) => void;
+}
 
 /**
  * Connection lifecycle callbacks.

--- a/packages/events-amqp/src/types.ts
+++ b/packages/events-amqp/src/types.ts
@@ -459,7 +459,7 @@ export type AmqpLifecycleEvent =
  * — but `maxRetries` defaults to a BOUNDED `5` here, not `Infinity`.
  */
 export interface AmqpPublishRetryOptions {
-    /** Retries after the first attempt (N retries = N+1 attempts). `Infinity` is honored — retry until `disconnect()` aborts. @default 5 */
+    /** Retries after the first attempt (N retries = N+1 attempts). A negative value clamps to `0` (single attempt); `Infinity` is honored — retry until `disconnect()` aborts. @default 5 */
     readonly maxRetries?: number;
     /** First retry delay in ms. @default 100 */
     readonly initialDelay?: number;

--- a/packages/events-amqp/tests/integration/amqp-recovery.test.ts
+++ b/packages/events-amqp/tests/integration/amqp-recovery.test.ts
@@ -28,7 +28,7 @@ import { type CreatedProxy, type StartedToxiProxyContainer, ToxiProxyContainer }
 import { connect } from "amqplib";
 import { GenericContainer, Network, type StartedNetwork, type StartedTestContainer } from "testcontainers";
 import { AmqpAdapter, isConnectionLostError } from "../../src/AmqpAdapter.ts";
-import { AmqpConnectionError, AmqpPublishTimeoutError, AmqpTopologyError } from "../../src/errors.ts";
+import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpTopologyError } from "../../src/errors.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -322,6 +322,265 @@ describe("AMQP connection recovery (testcontainers)", { skip: RUN ? false : "RUN
             },
         );
         await adapter.disconnect().catch(() => undefined);
+    });
+
+    it("publishRetry: a publish during the recovery window retries and succeeds once recovery completes (#195)", { timeout: 60_000 }, async () => {
+        const retries: Array<{ attempt: number; delay: number }> = [];
+        const received: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.pubretry195",
+            exchangeType: "topic",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            publishRetry: { initialDelay: 50, maxDelay: 200, maxRetries: 30, onRetry: (info) => retries.push({ attempt: info.attempt, delay: info.delay }) },
+        });
+        await adapter.connect();
+        try {
+            await adapter.subscribe(
+                ["rec.pubretry195.evt"],
+                async (event, ack) => {
+                    received.push(event.eventId);
+                    await ack();
+                },
+                { group: "g" },
+            );
+
+            await dropConnections();
+            // Publish IMMEDIATELY into the recovery window: pre-#195 this threw
+            // AmqpConnectionError instantly; now it retries until recovery
+            // completes and the message lands.
+            await adapter.publish("rec.pubretry195.evt", new TextEncoder().encode("through-the-blip"));
+
+            assert.ok(retries.length >= 1, "at least one retry was scheduled during the recovery window");
+            assert.equal(retries[0]?.attempt, 1, "onRetry attempts are 1-based");
+            await waitFor(() => received.length === 1);
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("publishRetry: budget exhaustion during a live recovery cycle rethrows the LAST typed connection error (#195)", { timeout: 60_000 }, async () => {
+        const retries: number[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.pubretry195x",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            publishRetry: { initialDelay: 20, maxDelay: 40, jitter: 0, maxRetries: 2, onRetry: (info) => retries.push(info.attempt) },
+        });
+        await adapter.connect();
+        try {
+            // Broker app down: the recovery cycle stays ALIVE (wrapper keeps
+            // retrying), but every publish attempt fails — the bounded budget
+            // exhausts long before the broker returns.
+            await container.exec(["rabbitmqctl", "stop_app"]);
+            await sleep(1000); // let the drop propagate
+
+            await assert.rejects(
+                () => adapter.publish("rec.pubretry195x.evt", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpConnectionError,
+                "after the budget the last typed error surfaces",
+            );
+            assert.deepEqual(retries, [1, 2], "exactly maxRetries retries were attempted");
+        } finally {
+            await container.exec(["rabbitmqctl", "start_app"]).catch(() => undefined);
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("publishRetry: recovery:false fails fast — no cycle exists to heal, zero retries (#195)", { timeout: 30_000 }, async () => {
+        const retries: number[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.pubretry195nf",
+            recovery: false,
+            publishRetry: { initialDelay: 20, maxRetries: 5, onRetry: (info) => retries.push(info.attempt) },
+        });
+        await adapter.connect();
+        try {
+            await dropConnections();
+            await sleep(1000);
+
+            const startedAt = Date.now();
+            await assert.rejects(
+                () => adapter.publish("rec.pubretry195nf.evt", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpConnectionError,
+            );
+            assert.ok(Date.now() - startedAt < 1_000, "fail-fast: nothing will heal a non-recovering adapter");
+            assert.deepEqual(retries, [], "no budget burned when no recovery cycle exists");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("publishRetry: a broker nack is NOT auto-retried (boundary pin) (#195)", { timeout: 30_000 }, async () => {
+        // Over-capacity queue with reject-publish → deterministic nack.
+        const pre = await connect(url);
+        const preCh = await pre.createChannel();
+        await preCh.assertExchange("rec.nack195", "direct", { durable: true });
+        await preCh.assertQueue("rec.nack195.q", { durable: true, arguments: { "x-max-length": 1, "x-overflow": "reject-publish" } });
+        await preCh.bindQueue("rec.nack195.q", "rec.nack195", "k");
+        await preCh.close();
+        await pre.close();
+
+        const retries: number[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.nack195",
+            exchangeType: "direct",
+            topologyMode: "skip",
+            publishRetry: { initialDelay: 20, maxRetries: 5, onRetry: (info) => retries.push(info.attempt) },
+        });
+        await adapter.connect();
+        try {
+            // Fill the queue to capacity, then overflow → nack.
+            await adapter.publish("k", new Uint8Array([1]));
+            await assert.rejects(
+                () => adapter.publish("k", new Uint8Array([2])),
+                (err: unknown) => err instanceof AmqpPublishNackError,
+                "the nack surfaces immediately",
+            );
+            assert.deepEqual(retries, [], "a nack never enters the retry loop");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("publishRetry + single-flight: retries hold the chain — ordering preserved (#195)", { timeout: 60_000 }, async () => {
+        const received: string[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.chain195",
+            exchangeType: "topic",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            publisherOptions: { mandatory: true, correlationHeader: false },
+            publishRetry: { initialDelay: 50, maxDelay: 200, maxRetries: 30 },
+        });
+        await adapter.connect();
+        try {
+            await adapter.subscribe(
+                ["rec.chain195.evt"],
+                async (event, ack) => {
+                    received.push(new TextDecoder().decode(event.payload));
+                    await ack();
+                },
+                { group: "g" },
+            );
+
+            await dropConnections();
+            // A enters the retry loop inside its single-flight slot; B queues
+            // behind it. Hold-the-chain: B must not start (or land) before A.
+            const a = adapter.publish("rec.chain195.evt", new TextEncoder().encode("A"));
+            const b = adapter.publish("rec.chain195.evt", new TextEncoder().encode("B"));
+            await Promise.all([a, b]);
+
+            await waitFor(() => received.length === 2);
+            assert.deepEqual(received, ["A", "B"], "ordering across the retrying slot is preserved");
+        } finally {
+            await adapter.disconnect();
+        }
+    });
+
+    it("publishRetry: a deterministic channel-close (404) is NOT retried and surfaces the broker reply as cause (#195)", { timeout: 30_000 }, async () => {
+        const retries: number[] = [];
+        const adapter = AmqpAdapter({
+            url,
+            // Never declared anywhere; skip mode publishes into the void and
+            // the broker kills the CHANNEL with reply 404.
+            exchange: "rec.nochannel195",
+            topologyMode: "skip",
+            publishRetry: { initialDelay: 200, maxDelay: 400, jitter: 0, maxRetries: 10, onRetry: (info) => retries.push(info.attempt) },
+        });
+        await adapter.connect();
+        try {
+            const startedAt = Date.now();
+            await assert.rejects(
+                () => adapter.publish("rec.nochannel195.evt", new Uint8Array([1])),
+                (err: unknown) => {
+                    assert.ok(err instanceof AmqpConnectionError, "surfaces as a connection-class error");
+                    const cause = (err as Error).cause as { code?: number } | undefined;
+                    assert.equal(cause?.code, 404, "the broker reply (404) is preserved as the root cause, not amqplib's generic 'channel closed'");
+                    return true;
+                },
+            );
+            const took = Date.now() - startedAt;
+            assert.ok(took < 2_000, `a deterministic channel-close must not burn the retry budget (took ${took}ms)`);
+            assert.deepEqual(retries, [], "zero retries for a deterministic channel-close");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("publishRetry does not burn budget against a fatal topology stop (#195 × #201)", { timeout: 60_000 }, async () => {
+        const pre = await connect(url);
+        const preCh = await pre.createChannel();
+        await preCh.assertExchange("rec.fatalretry", "topic", { durable: true });
+        await preCh.assertQueue("rec.fatalretry.q", { durable: true });
+        await preCh.close();
+        await pre.close();
+
+        const events: Array<{ type: string }> = [];
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.fatalretry",
+            recovery: { initialDelay: 100, maxDelay: 500 },
+            topology: { queues: [{ name: "rec.fatalretry.q", durable: true }] },
+            topologyMode: "check",
+            treatTopologyErrorAsFatal: true,
+            publishRetry: { initialDelay: 200, maxDelay: 400, maxRetries: 30 },
+            lifecycle: { onLifecycle: (event) => events.push(event) },
+        });
+        await adapter.connect();
+        try {
+            const admin = await connect(url);
+            const adminCh = await admin.createChannel();
+            await adminCh.deleteQueue("rec.fatalretry.q");
+            await adminCh.close();
+            await admin.close();
+
+            await dropConnections();
+            await waitFor(() => events.some((e) => e.type === "reconnect-failed"), 30_000);
+
+            // The cycle is terminally dead — the retry loop must recognize it
+            // (connection === null) instead of burning 30 retries of backoff.
+            const startedAt = Date.now();
+            await assert.rejects(
+                () => adapter.publish("rec.fatalretry.evt", new Uint8Array([1])),
+                (err: unknown) => err instanceof AmqpConnectionError,
+            );
+            assert.ok(Date.now() - startedAt < 2_000, "no budget burn against a dead recovery cycle");
+        } finally {
+            await adapter.disconnect().catch(() => undefined);
+        }
+    });
+
+    it("publishRetry: disconnect() during the backoff aborts the loop promptly with the last typed error (#195)", { timeout: 60_000 }, async () => {
+        const adapter = AmqpAdapter({
+            url,
+            exchange: "rec.abortretry195",
+            recovery: { initialDelay: 30_000, maxDelay: 60_000 }, // recovery parked far away — the wrapper stays alive
+            publishRetry: { initialDelay: 4000, maxDelay: 8000, jitter: 0, maxRetries: 5 },
+        });
+        await adapter.connect();
+        try {
+            await container.exec(["rabbitmqctl", "stop_app"]);
+            await sleep(1000);
+
+            const publishing = adapter.publish("rec.abortretry195.evt", new Uint8Array([1]));
+            publishing.catch(() => undefined); // observer: the rejection is asserted below
+            await sleep(300); // let the first attempt fail and enter the 4s backoff
+
+            const abortStartedAt = Date.now();
+            await adapter.disconnect();
+            await assert.rejects(
+                () => publishing,
+                (err: unknown) => err instanceof AmqpConnectionError,
+            );
+            const latency = Date.now() - abortStartedAt;
+            assert.ok(latency < 2_000, `disconnect() must interrupt the retry backoff promptly (took ${latency}ms of a 4000ms delay)`);
+        } finally {
+            await container.exec(["rabbitmqctl", "start_app"]).catch(() => undefined);
+            await adapter.disconnect().catch(() => undefined);
+        }
     });
 
     it("initialConnectMaxRetries: unreachable broker → per-attempt reconnecting events, terminal reconnect-failed, typed rejection (#198)", { timeout: 30_000 }, async () => {

--- a/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/AmqpAdapter.test.ts
@@ -1,8 +1,19 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
-import { AmqpAdapter, classifyConfirmError, computeRecoveryDelay, dispatchLifecycle, isConnectionLostError, isDeterministicTopologyDrift, toAmqpPattern, trackChannelClose, wireRecoveryLifecycle } from "../../src/AmqpAdapter.ts";
-import { AmqpConnectionError, AmqpPublishNackError, AmqpTopologyError } from "../../src/errors.ts";
+import {
+    AmqpAdapter,
+    classifyConfirmError,
+    computeRecoveryDelay,
+    dispatchLifecycle,
+    isAutoRetriablePublishError,
+    isConnectionLostError,
+    isDeterministicTopologyDrift,
+    toAmqpPattern,
+    trackChannelClose,
+    wireRecoveryLifecycle,
+} from "../../src/AmqpAdapter.ts";
+import { AmqpConnectionError, AmqpPublishNackError, AmqpPublishTimeoutError, AmqpSerializationError, AmqpTopologyError, AmqpUnroutableError } from "../../src/errors.ts";
 import type { AmqpLifecycleCallbacks, AmqpLifecycleEvent } from "../../src/types.ts";
 
 describe("isConnectionLostError", () => {
@@ -541,8 +552,24 @@ describe("dispatchLifecycle", () => {
     it("is a no-op without a lifecycle object", () => {
         assert.doesNotThrow(() => dispatchLifecycle(undefined, { type: "unblocked" }));
     });
+});
 
-    it("computeRecoveryDelay replicates amqplib's formula: cap-before-jitter, symmetric offset (#198 pin)", () => {
+describe("isAutoRetriablePublishError", () => {
+    it("the AUTO-RETRY boundary is narrower than the republish matrix (#195)", () => {
+        assert.equal(isAutoRetriablePublishError(new AmqpConnectionError("recovery in progress")), true, "connection-class = retriable");
+        assert.equal(isAutoRetriablePublishError(new AmqpPublishTimeoutError("no outcome")), false, "timeout NOT retriable by default (state UNKNOWN)");
+        assert.equal(isAutoRetriablePublishError(new AmqpPublishTimeoutError("no outcome"), { retryOnTimeout: true }), true, "timeout joins the boundary only via opt-in");
+        assert.equal(isAutoRetriablePublishError(new AmqpPublishNackError("nacked"), { retryOnTimeout: true }), false, "a nack is republish-safe by POLICY but never auto-retried");
+        assert.equal(isAutoRetriablePublishError(new AmqpUnroutableError("unroutable", "k"), { retryOnTimeout: true }), false, "deterministic: unroutable");
+        assert.equal(isAutoRetriablePublishError(new AmqpSerializationError("bad encode"), { retryOnTimeout: true }), false, "deterministic: serialization");
+        assert.equal(isAutoRetriablePublishError(new AmqpTopologyError("drift"), { retryOnTimeout: true }), false, "deterministic: topology");
+        assert.equal(isAutoRetriablePublishError(new Error("raw"), { retryOnTimeout: true }), false, "raw errors never gate a retry");
+    });
+
+});
+
+describe("computeRecoveryDelay", () => {
+    it("replicates amqplib's formula: cap-before-jitter, symmetric offset (#198 pin)", () => {
         const opts = { initialDelay: 100, maxDelay: 400, factor: 2, jitter: 0.2 };
         // random() = 0.5 → offset 0 → exact exponential base, capped at maxDelay.
         assert.equal(computeRecoveryDelay(opts, 1, () => 0.5), 100);
@@ -572,7 +599,10 @@ describe("dispatchLifecycle", () => {
         assert.equal(computeRecoveryDelay({ factor: Number.NaN, jitter: Number.NaN }, 2, () => 1), 240);
     });
 
-    it("isDeterministicTopologyDrift: 404/406 reply codes on the cause are fatal, everything else is not (#201)", () => {
+});
+
+describe("isDeterministicTopologyDrift", () => {
+    it("404/406 reply codes on the cause are fatal, everything else is not (#201)", () => {
         const withCode = (code: number) => new AmqpTopologyError("x", { cause: Object.assign(new Error("y"), { code }) });
         assert.equal(isDeterministicTopologyDrift(withCode(404)), true, "404 NOT_FOUND = deterministic drift");
         assert.equal(isDeterministicTopologyDrift(withCode(406)), true, "406 PRECONDITION_FAILED = deterministic drift");
@@ -594,6 +624,9 @@ describe("dispatchLifecycle", () => {
         );
     });
 
+});
+
+describe("AmqpTopologyError.object", () => {
     it("AmqpTopologyError carries the failing object's identity and the cause (#202)", () => {
         const cause = new Error("PRECONDITION_FAILED");
         const err = new AmqpTopologyError("Topology declaration failed", { cause, object: { kind: "queue", name: "orders.q" } });
@@ -625,6 +658,9 @@ describe("dispatchLifecycle", () => {
         assert.equal(Object.hasOwn(withObject, "cause"), false, "supplying only 'object' must not install an own 'cause'");
     });
 
+});
+
+describe("dispatchLifecycle exception isolation", () => {
     it("isolates a throwing onLifecycle: no propagation, flat shim still fires", () => {
         let flatFired = 0;
         const lifecycle: AmqpLifecycleCallbacks = {


### PR DESCRIPTION
## Summary

Implements #195 per the "1.3.0 design pass" comment — `publishRetry`: an opt-in bounded retry for connection-class publish failures. The last heavy PR of the cluster; builds on the contracts shipped in B (lifecycle), C/D (reply-code philosophy), E (`computeRecoveryDelay`), and F (closing/drain).

## Type of change

- [x] New feature (non-breaking)

## What changed

- **Top-level `publishRetry: boolean | AmqpPublishRetryOptions`** (default off — publish path bit-for-bit). A publish during a recovery window, or an in-flight confirm lost to a drop, retries in place: a broker blip becomes a transparent delay. `maxRetries` defaults to a bounded `5`; `Infinity` is honored (retry until `disconnect()`).
- **The auto-retry boundary is the exported `isAutoRetriablePublishError`** — deliberately narrower than the republish matrix (nack/unroutable/serialization/topology never retry; timeouts only via `retryOnTimeout`). Docs distinguish the two boundaries explicitly, and the previously unconditional "fails fast" claims (README, `errors.ts`) are now conditional on the opt-in.
- **Per-attempt return correlation**: the private `x-connectum-publish-id` is restamped per attempt, so a late `basic.return` from an abandoned timed-out attempt can no longer poison the next attempt's pending record (false `AmqpUnroutableError` on a delivered message). The dedup identity (`x-event-id`/`messageId`/`timestamp`) stays stable across attempts.
- **Determinism gates** (reply-code philosophy from #201): a `404`/`406` channel-only close (e.g. publish to a missing exchange under `topologyMode: "skip"`) is NOT retried — the channel-level root cause is now recorded and surfaces as `cause` (previously masked by amqplib's generic "channel closed"); `connection === null` (fatal topology stop, `recovery: false` after a drop, post-disconnect) aborts immediately — no budget burned against a cycle that cannot heal. Deep channel-heal follow-up filed as #221.
- **Hold-the-chain**: under single-flight (`mandatory` + `correlationHeader: false`) the whole retry loop runs inside one slot — ordering preserved; head-of-line blocking and the headerless-correlation caveat documented.
- **Shutdown-aware**: interruptible backoff aborts promptly on `disconnect()`; the loop lives inside the `adapter.publish()` promise, so the bus-level `drainPublishTimeout` covers it automatically.

## Adversarial pre-PR review

3 angles → 9 verified findings (0 refuted), all addressed. Two were **live-reproduced**: the 404 channel-close budget-burn (reproduced against RabbitMQ 4 — fixed with the reply-code gate + root-cause recording, pinned at 49ms/0 retries) and the cross-attempt `pendingReturns` poisoning (fixed with per-attempt correlation ids). Plus: bit-for-bit restoration of the retry-disabled single-flight path (no `closing` re-check at slot execution), `Infinity` budget honored, fatal-state abort, single-flight wording (the `mandatory` precondition), stale fail-fast claims, test `describe` re-homing.

## Test plan

- [x] Unit 54/54 on node, bun, esbuild — boundary pin (auto-retry ≠ republish matrix)
- [x] Integration 32/32 (Docker testcontainers) — 8 publishRetry scenarios: publish-through-recovery-blip; budget exhaustion during a LIVE recovery cycle (`stop_app`, retries `[1,2]`); `recovery: false` fail-fast (zero retries — nothing can heal); nack boundary pin; hold-the-chain ordering `["A","B"]`; deterministic 404 channel-close (49ms, `cause.code === 404`); no budget burn after a fatal topology stop; prompt backoff abort on `disconnect()`
- [x] Full monorepo: build, typecheck, test 33/33, lint 15/15

## Parity coverage

- [x] Parity N/A: broker-adapter publish policy only; no RPC-observable behaviour affected.

## Related issues / changes

Closes #195.

- Design pass: the "1.3.0 design pass (2026-07-04)" comment on #195
- Follow-up filed: #221 (publish-channel recreation after a transient channel-only close)
- Companion docs-site PR in Connectum-Framework/docs follows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional publish retry mode for AMQP publishing, with configurable retry limits and backoff.
  * Introduced a public helper to identify which publish failures can be retried automatically.

* **Bug Fixes**
  * Improved publish behavior during connection recovery so short broker interruptions can succeed after a brief delay.
  * Preserved message identity and publish ordering across retry attempts.
  * Ensured non-retryable failures, broker nacks, and shutdown cases still fail promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->