### PR TITLE
feat(events): named EventAdapterFactory type + DI/testing guidance (#204)

### DIFF
--- a/.changeset/calm-doves-inject.md
+++ b/.changeset/calm-doves-inject.md
@@ -1,0 +1,9 @@
+---
+"@connectum/events": minor
+---
+
+feat: named `EventAdapterFactory` type + official DI/testing guidance (#204)
+
+- New exported `EventAdapterFactory` (`() => EventAdapter`) — the previously inline factory shape of `createBroadcastSubscribers`' `adapter` option, now a named public type (per-adapter named types are deliberately not added).
+- README gains a "Dependency Injection and Testing" section: the primary pattern is injecting an `EventAdapter` instance at the composition root (a configured test double does not fit a zero-argument factory without a wrapper); the factory is the secondary pattern for per-consumer connections (broadcast reactors). Test-double guidance: `MemoryAdapter` for the generic happy path; broker-specific failure semantics via the upcoming `@connectum/events-amqp/testing` fake (#203).
+- Types + docs only — zero runtime change.

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -299,10 +299,11 @@ await Promise.all(buses.map((bus) => bus.start()));
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `adapter` | `EventAdapter \| (() => EventAdapter)` | required | One shared adapter instance (fine for `MemoryAdapter` in tests) OR a factory invoked once per reactor (use for real brokers so each bus gets its own connection / durable consumer) |
+| `adapter` | `EventAdapter \| EventAdapterFactory` | required | One shared adapter instance (fine for `MemoryAdapter` in tests) OR an `EventAdapterFactory` invoked once per reactor (use for real brokers so each bus gets its own connection / durable consumer) |
 | `reactors` | `BroadcastReactor[]` | required | The independent reactors -- each becomes its own EventBus with its own group |
 | `handlerTimeout` | `number` | `30000` | Shared per-bus handler timeout in ms |
 | `drainTimeout` | `number` | `30000` | Shared per-bus drain timeout in ms |
+| `drainPublishTimeout` | `number` | `undefined` | Shared per-bus opt-in publish drain budget at `stop()` (ms). Since 1.3.0 |
 | `signal` | `AbortSignal` | `undefined` | Shared abort signal for graceful shutdown |
 
 **`BroadcastReactor`:**
@@ -437,6 +438,29 @@ const bus = createEventBus({
 });
 ```
 
+## Dependency Injection and Testing
+
+**Primary pattern — inject an `EventAdapter` instance.** Construct the adapter at your composition root and pass it in; a test swaps it for a double without touching the wiring:
+
+```typescript
+// Composition root (production):
+const adapter = NatsAdapter({ servers: process.env.NATS_URL! });
+const bus = createEventBus({ adapter, routes: [eventRoutes] });
+```
+
+```typescript
+// Test: the same wiring, a different instance.
+const bus = createEventBus({ adapter: MemoryAdapter(), routes: [eventRoutes] });
+```
+
+**Secondary pattern — `EventAdapterFactory`** (`() => EventAdapter`, exported since 1.3.0): a zero-argument factory for the places where each consumer needs its OWN broker connection — `createBroadcastSubscribers` invokes it once per reactor. Prefer the instance elsewhere: a test double with its own configuration does not fit a zero-argument factory signature without a wrapper closure.
+
+**Test doubles:**
+
+- `MemoryAdapter` (exported here) — in-process pub/sub for the generic happy path: routing, handlers, middleware, DLQ flows.
+- Broker-specific failure semantics (typed AMQP error taxonomy, recovery/lifecycle behavior) cannot be modeled generically — a programmable `FakeAmqpAdapter` will ship via the `@connectum/events-amqp/testing` subpath (tracked in [#203](https://github.com/Connectum-Framework/connectum/issues/203)).
+- For real-broker integration semantics, see each adapter package's testing notes.
+
 ## Exports Summary
 
 | Export | Kind | Description |
@@ -455,6 +479,7 @@ const bus = createEventBus({
 | `resolveTopicName` | function | Topic name resolution from proto |
 | `matchPattern` | function | NATS-style wildcard matching |
 | `EventAdapter` | type | Adapter interface |
+| `EventAdapterFactory` | type | Zero-arg factory producing a fresh adapter (per-reactor connections; since 1.3.0) |
 | `EventBus` | type | EventBus interface |
 | `EventBusOptions` | type | Options for `createEventBus()` |
 | `BroadcastSubscribersOptions` | type | Options for `createBroadcastSubscribers()` |

--- a/packages/events/src/broadcast.ts
+++ b/packages/events/src/broadcast.ts
@@ -17,7 +17,7 @@
 
 import type { EventBusLike } from "@connectum/core";
 import { createEventBus } from "./EventBus.ts";
-import type { EventAdapter, EventBus, EventRoute, MiddlewareConfig } from "./types.ts";
+import type { EventAdapter, EventAdapterFactory, EventBus, EventRoute, MiddlewareConfig } from "./types.ts";
 
 /** One independent broadcast reactor: its consumer group + routes. */
 export interface BroadcastReactor {
@@ -37,7 +37,7 @@ export interface BroadcastSubscribersOptions {
      * once per reactor (use this for real brokers so each reactor bus gets its
      * own connection / durable consumer).
      */
-    readonly adapter: EventAdapter | (() => EventAdapter);
+    readonly adapter: EventAdapter | EventAdapterFactory;
     /** The independent reactors — each becomes its own EventBus with its own group. */
     readonly reactors: BroadcastReactor[];
     /** Shared per-bus handler timeout (ms). */
@@ -63,7 +63,7 @@ export interface BroadcastSubscribersOptions {
  * @example
  * ```typescript
  * const buses = createBroadcastSubscribers({
- *   adapter: () => new NatsAdapter({ servers, stream: 'orders' }),
+ *   adapter: () => NatsAdapter({ servers, stream: 'orders' }),
  *   reactors: [
  *     { group: 'pricing', routes: [pricingRoutes] },
  *     { group: 'audit',   routes: [auditRoutes] },

--- a/packages/events/src/index.ts
+++ b/packages/events/src/index.ts
@@ -41,6 +41,7 @@ export type {
     AdapterContext,
     DlqOptions,
     EventAdapter,
+    EventAdapterFactory,
     EventBus,
     EventBusOptions,
     EventContext,

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -132,6 +132,21 @@ export interface EventAdapter {
     subscribe(patterns: string[], handler: RawEventHandler, options?: RawSubscribeOptions): Promise<EventSubscription>;
 }
 
+/**
+ * A zero-argument factory producing a fresh {@link EventAdapter}.
+ *
+ * Used where each consumer needs its OWN broker connection — e.g.
+ * `createBroadcastSubscribers` invokes it once per reactor so every reactor
+ * bus gets an independent connection / durable consumer.
+ *
+ * DI guidance: for wiring a service, prefer injecting an `EventAdapter`
+ * INSTANCE (constructed at the composition root) — a test double with its own
+ * configuration does not fit a zero-argument factory signature without a
+ * wrapper closure. Reach for the factory only where per-consumer connections
+ * are the point. Since 1.3.0.
+ */
+export type EventAdapterFactory = () => EventAdapter;
+
 // =============================================================================
 // EVENT CONTEXT
 // =============================================================================


### PR DESCRIPTION
## Summary

Implements #204 per the "1.3.0 design pass" comment — the last types+docs slice before the cluster's final PR (#203). Zero runtime change.

## Type of change

- [x] New feature (non-breaking)
- [x] Documentation / chore / internal

## What changed

- **`EventAdapterFactory`** (`() => EventAdapter`) exported from `@connectum/events` — the previously inline factory shape of `createBroadcastSubscribers`' `adapter` option, now a named public type (source-compatible; per-adapter named types deliberately NOT added, per the user-approved decision).
- **README "Dependency Injection and Testing"**: instance injection as the primary pattern (a configured test double does not fit a zero-arg factory without a wrapper); the factory as the secondary pattern for per-consumer connections; `MemoryAdapter` for the generic happy path; forward reference to the #203 fake (future tense — it has not shipped yet).
- Adjacent doc fixes from the pre-PR review: broadcast options table uses the named type and gains the `drainPublishTimeout` row missed in #220; the `createBroadcastSubscribers` JSDoc example no longer calls the factory function with `new`.

## Adversarial pre-PR review

2 angles → 7 verified findings, all addressed (present-tense claim about an unshipped subpath; duplicate `const` in one fence; stale inline shape in the broadcast table; `new NatsAdapter` in the JSDoc example; missing `drainPublishTimeout` row; docs-site companion recorded below).

## Test plan

- [x] Full monorepo: build, typecheck, test 33/33 (events 155/155), lint 15/15; bun 17/17 suites, esbuild 118/118
- [x] Type-surface: `EventAdapterFactory` in the barrel d.ts; broadcast option assignability unchanged

## Parity coverage

- [x] Parity N/A: types + documentation only.

## Related issues / changes

Closes #204.

- Design pass: the "1.3.0 design pass (2026-07-04)" comment on #204
- Forward: #203 (PR I — the testing story's second half)
- Companion docs-site PR in Connectum-Framework/docs follows (adapter row spelling + Type Exports row)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new adapter factory type for event broadcasts, enabling cleaner dependency injection and separate connections per subscriber.
  * Updated broadcast configuration to accept this factory type alongside a direct adapter instance.

* **Documentation**
  * Expanded the API docs with guidance on dependency injection and testing.
  * Documented the new publish drain timeout option and updated the exported API reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->