### PR TITLE
feat(events-amqp): programmable FakeAmqpAdapter via ./testing subpath (#203)

### DIFF
--- a/.changeset/witty-badgers-pretend.md
+++ b/.changeset/witty-badgers-pretend.md
@@ -1,0 +1,10 @@
+---
+"@connectum/events-amqp": minor
+---
+
+feat: programmable `FakeAmqpAdapter` test double via `@connectum/events-amqp/testing` (#203)
+
+- New subpath export `@connectum/events-amqp/testing` with `FakeAmqpAdapter` — model AMQP failure semantics in unit tests without a broker: FIFO publish outcomes (`control.nextPublish` with the real typed error classes, incl. `AmqpPublishTimeoutError` — the state-UNKNOWN outcome no real broker reproduces deterministically), deterministic connection lifecycle (`dropConnection`/`completeRecovery`/`exhaustRecovery`/`failSetup`/`block`), wildcard + competing-consumer delivery with a settlement result (`{ delivered, acked, nacked, requeued, failed }`), and a `published` record of bus-facing publishes.
+- Parity by construction and by pinning: lifecycle events go through the real adapter's dispatch (canonical union ordering, deprecated flat shim, exception isolation); the state machine mirrors the real adapter (`already connected` from live/recovering/retries-exhausted states; mid-recovery `subscribe()` parks and settles with the recovery outcome; `setup-failed`/fail-fast gate on `AmqpTopologyError` like the real probe); incoming envelope headers honored and stripped like the real consumer; handler rejections swallowed like the real nack-on-error path; `instanceof` holds across the subpath boundary (tsup `splitting: true` — shared error-class chunk, pinned by a dist-level test).
+- Runtime-pure: the subpath pulls neither `amqplib` nor `node:test` into the consumer graph (only `@connectum/events` + `node:crypto`).
+- Documented divergences: no timing simulation (recovery advances via explicit control calls); settlement is recorded, not broker-driven (re-deliver with `attempt + 1` to model redelivery); no wire-level envelope on `published`; report-and-proceed on a non-fail-fast startup setup failure.

--- a/packages/events-amqp/README.md
+++ b/packages/events-amqp/README.md
@@ -453,6 +453,40 @@ await adapter.publish('inbound', body);
 
 > **Clean wire for external contracts.** By default the adapter stamps EventBus *envelope* metadata on every frame: the `x-event-id` and `x-published-at` headers, an auto-generated `messageId`, an auto `timestamp`, and — on mandatory publishes with the default `correlationHeader: true` — a private `x-connectum-publish-id` header. A consumer validating an external contract would see fields it never defined. Set **`publisherOptions.externalContract: true`** (as above) to suppress the whole envelope: the frame then carries only `contentType`, `persistent`/deliveryMode, `mandatory`, and exactly the headers you pass via `PublishOptions.metadata`. In this mode mandatory publishes use single-flight correlation, so no `x-connectum-publish-id` reaches the wire (`correlationHeader` is ignored). Note: `correlationHeader: false` alone removes only the publish-id header — the rest of the envelope still ships, so it is **not** a clean wire on its own. When the contract requires a specific `messageId`/`timestamp`, set them per publish via `PublishOptions.messageId` / `PublishOptions.timestamp` (a caller-supplied value is used as-is; the AMQP `timestamp` property is Unix epoch seconds).
 
+## Testing
+
+A programmable test double ships via the **`@connectum/events-amqp/testing`** subpath (since 1.3.0) — model AMQP failure semantics in unit tests without a broker and without `amqplib` in the runtime graph:
+
+```typescript
+import { FakeAmqpAdapter } from '@connectum/events-amqp/testing';
+import { AmqpPublishNackError, AmqpPublishTimeoutError } from '@connectum/events-amqp';
+
+const fake = FakeAmqpAdapter({ lifecycle: { onLifecycle: (e) => log.push(e) } });
+const bus = createEventBus({ adapter: fake, routes: [eventRoutes] });
+await bus.start();
+
+// Inject publish outcomes (FIFO; empty queue = ack). This includes
+// AmqpPublishTimeoutError — the state-UNKNOWN outcome that no real broker
+// (or even Toxiproxy) reproduces deterministically:
+fake.control.nextPublish(new AmqpPublishNackError('nacked'), new AmqpPublishTimeoutError('no outcome'));
+await assert.rejects(() => bus.publish(OrderSchema, order), AmqpPublishNackError);
+await assert.rejects(() => bus.publish(OrderSchema, order), AmqpPublishTimeoutError);
+
+// Drive the connection lifecycle deterministically:
+fake.control.dropConnection();     // disconnected → reconnecting (publishes fail fast; subscribes PARK)
+fake.control.failSetup();          // the next recovery re-assert fails (setup-failed for topology errors)
+fake.control.completeRecovery();   // …consume it, then heal on the next call
+fake.control.completeRecovery();   // connected { reconnected: true }, parked subscribes complete
+
+// Deliver events (wildcards + competing-consumer groups) and assert settlement:
+const result = await fake.control.deliver('order.created', payload);
+// result: { delivered, acked, nacked, requeued, failed }
+```
+
+Parity contract: lifecycle events go through the real adapter's dispatch (union ordering, the deprecated flat shim, and exception isolation match by construction); errors are the real typed classes — `instanceof` holds across the subpath boundary (shared build chunk, pinned by a dist test); the state machine mirrors the real adapter (`connect()` on a live/recovering/retries-exhausted adapter throws `already connected`; a mid-recovery `subscribe()` parks and settles with the recovery outcome; `setup-failed` and fail-fast gate on `AmqpTopologyError` exactly like the real probe); incoming envelope headers (`x-event-id`, `x-published-at`) are honored and stripped like the real consumer.
+
+Documented divergences: no timing (recovery advances only via explicit `control` calls; `reconnecting.delay` is `0`); handler `ack`/`nack` calls are recorded in the `deliver()` result but do not drive redelivery — re-deliver explicitly with `attempt + 1` (handler rejections are swallowed and counted as `failed`, like the real nack-on-error consumer); `control.published` records the bus-facing call, not the wire envelope; a queued topology `failSetup` at `connect()` without fail-fast reports and proceeds instead of blocking forever. For the generic happy path prefer `MemoryAdapter` from `@connectum/events`; for real-broker semantics see the integration suite.
+
 ## Dependencies
 
 ### External

--- a/packages/events-amqp/package.json
+++ b/packages/events-amqp/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "files": [
@@ -61,6 +65,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
+    "@bufbuild/protobuf": "catalog:",
     "@connectum/events": "workspace:^",
     "@exodus/test": "catalog:",
     "@testcontainers/toxiproxy": "^12.0.4",

--- a/packages/events-amqp/src/testing.ts
+++ b/packages/events-amqp/src/testing.ts
@@ -1,0 +1,451 @@
+/**
+ * Programmable AMQP test double — the `@connectum/events-amqp/testing` subpath (#203).
+ *
+ * `FakeAmqpAdapter` models the REAL adapter's observable contracts without a
+ * broker and without importing `amqplib` at runtime:
+ *
+ * - the typed error taxonomy (`AmqpConnectionError`, `AmqpTopologyError`, …) —
+ *   inject outcomes per publish via {@link FakeAmqpControl.nextPublish},
+ *   including `AmqpPublishTimeoutError`: the state-UNKNOWN outcome that no
+ *   real broker (or even Toxiproxy) reproduces deterministically;
+ * - the canonical lifecycle union ({@link AmqpLifecycleCallbacks.onLifecycle})
+ *   INCLUDING the deprecated flat-callback shim — events go through the real
+ *   adapter's dispatch, so ordering, shim payloads, and exception isolation
+ *   match the real adapter by construction;
+ * - the state machine: `connect()` on a live or recovering (or dead
+ *   retries-exhausted) adapter throws `already connected` like the real one;
+ *   a mid-recovery `subscribe()` PARKS and settles with the recovery outcome;
+ *   the probe-then-recover `connect()` semantics gate on `AmqpTopologyError`
+ *   exactly like the real probe.
+ *
+ * Deliberately NOT modeled (documented divergences):
+ * - timing: there is no backoff — recovery advances only via explicit
+ *   {@link FakeAmqpControl.completeRecovery} / {@link FakeAmqpControl.exhaustRecovery}
+ *   calls, and `reconnecting.delay` is always `0`;
+ * - a queued topology `failSetup` at `connect()` WITHOUT fail-fast reports
+ *   `setup-failed { initial: true }` and then connects anyway (the real
+ *   adapter would keep retrying inside recovery); a NON-topology queued
+ *   failure at `connect()` is consumed silently and the connect proceeds
+ *   (the real adapter treats it as transient and blocks in recovery);
+ * - broker-driven settlement: handler `ack`/`nack` calls are RECORDED (see
+ *   the {@link FakeAmqpControl.deliver} result) but do not drive redelivery —
+ *   re-deliver explicitly with a higher `attempt` to model it. Handler
+ *   rejections are swallowed exactly like the real consumer (which nacks for
+ *   redelivery instead of propagating);
+ * - the wire-level envelope: {@link FakeAmqpControl.published} records the
+ *   bus-facing call as the adapter received it. Wire fidelity is the real
+ *   adapter's integration-tested domain. Incoming envelope headers ARE
+ *   handled with parity: `deliver()` honors `x-event-id`/`x-published-at`
+ *   and strips the internal keys from handler-visible metadata.
+ *
+ * @module testing
+ */
+
+import { randomUUID } from "node:crypto";
+import type { AdapterContext, EventAdapter, EventSubscription, PublishOptions, RawEvent, RawEventHandler, RawSubscribeOptions } from "@connectum/events";
+import { matchPattern } from "@connectum/events";
+import { dispatchLifecycle } from "./AmqpAdapter.ts";
+import type { AmqpTopologyObject } from "./errors.ts";
+import { AmqpConnectionError, AmqpTopologyError } from "./errors.ts";
+import type { AmqpLifecycleCallbacks } from "./types.ts";
+
+/** Options for {@link FakeAmqpAdapter}. */
+export interface FakeAmqpAdapterOptions {
+    /** The same lifecycle surface as the real adapter (union + flat shim). */
+    readonly lifecycle?: AmqpLifecycleCallbacks;
+    /**
+     * Mirror of the real option: a topology `failSetup(...)` queued before
+     * `connect()` rejects it with the typed error instead of report-and-proceed.
+     */
+    readonly failFastOnInitialSetupError?: boolean;
+}
+
+/** One publish outcome: `"ack"` resolves; an `Error` rejects the publish with it. */
+export type FakePublishOutcome = "ack" | Error;
+
+/** A recorded successful publish, as the adapter received it from the bus. */
+export interface FakePublishedRecord {
+    readonly eventType: string;
+    readonly payload: Uint8Array;
+    readonly options?: PublishOptions;
+}
+
+/** Settlement summary of one {@link FakeAmqpControl.deliver} call. */
+export interface FakeDeliveryResult {
+    /** Handlers invoked (one per matching fan-out sub + one per distinct group). */
+    readonly delivered: number;
+    /** Handlers that called `ack()`. */
+    readonly acked: number;
+    /** Handlers that called `nack(false)`. */
+    readonly nacked: number;
+    /** Handlers that called `nack(true)` — model redelivery by delivering again with `attempt + 1`. */
+    readonly requeued: number;
+    /** Handlers that rejected (swallowed, like the real consumer's nack-on-error path). */
+    readonly failed: number;
+}
+
+/** Deterministic control surface of the fake. */
+export interface FakeAmqpControl {
+    /**
+     * Queue a setup failure. An `AmqpTopologyError` (the default) follows the
+     * real gating: `setup-failed { initial: true, attempt: 0 }` at `connect()`
+     * (typed rejection under `failFastOnInitialSetupError`), or
+     * `setup-failed { initial: false, attempt }` at the next
+     * {@link completeRecovery}. A NON-topology error follows the real gating
+     * too: no `setup-failed` event — at `connect()` it is consumed silently,
+     * at `completeRecovery` it only schedules the next `reconnecting`.
+     */
+    failSetup(error?: Error, object?: AmqpTopologyObject): void;
+    /**
+     * Sever the connection: dispatches `disconnected { error }` then
+     * `reconnecting { attempt: 1, delay: 0 }` and parks in the recovering
+     * state — publishes fail fast with `AmqpConnectionError`, exactly like
+     * the real adapter's recovery window; new `subscribe()` calls PARK.
+     */
+    dropConnection(error?: Error): void;
+    /**
+     * Advance a pending recovery: consumes a queued `failSetup` (reported per
+     * its gating, stays recovering) or, with nothing queued, completes with
+     * `connected { reconnected: true }` and settles parked subscribes.
+     */
+    completeRecovery(): void;
+    /**
+     * Terminal outcome: `reconnect-failed { error }`. The dead adapter fails
+     * publishes fast, rejects parked subscribes typed, and deactivates all
+     * subscriptions (the cycle died — so did its consumers). Reconnect
+     * requires `disconnect()` first, like the real retries-exhausted state.
+     */
+    exhaustRecovery(error?: Error): void;
+    /** Broker flow control: `blocked { reason }` / `unblocked` (union-only events). */
+    block(reason?: string): void;
+    unblock(): void;
+    /**
+     * Queue FIFO outcomes for upcoming `publish()` calls. An empty queue means
+     * `"ack"`. Use the real error classes (`AmqpPublishNackError`,
+     * `AmqpConnectionError`, `AmqpPublishTimeoutError` — the state-UNKNOWN
+     * outcome only this fake reproduces deterministically, …).
+     */
+    nextPublish(...outcomes: FakePublishOutcome[]): void;
+    /** Successfully acked publishes, in order. */
+    readonly published: readonly FakePublishedRecord[];
+    /**
+     * Deliver an event to matching subscriptions (NATS-style wildcard
+     * matching, one consumer per distinct group — competing-consumer parity;
+     * requires the connected state, like a real broker). Internal envelope
+     * keys (`x-event-id`, `x-published-at`, `x-connectum-publish-id`) are
+     * honored and stripped from handler-visible metadata, mirroring the real
+     * consumer. Resolves with the settlement summary once every handler
+     * settles; handler rejections are swallowed (counted in `failed`).
+     */
+    deliver(eventType: string, payload: Uint8Array, options?: { readonly metadata?: Record<string, string>; readonly attempt?: number }): Promise<FakeDeliveryResult>;
+}
+
+/** The fake adapter: a drop-in {@link EventAdapter} plus its {@link FakeAmqpControl}. */
+export interface FakeAmqpAdapterInstance extends EventAdapter {
+    readonly control: FakeAmqpControl;
+}
+
+const CONNECTION_STATE = {
+    CREATED: "created",
+    CONNECTED: "connected",
+    RECOVERING: "recovering",
+    DEAD: "dead",
+    CLOSED: "closed",
+} as const;
+type ConnectionState = (typeof CONNECTION_STATE)[keyof typeof CONNECTION_STATE];
+
+const INTERNAL_HEADERS = ["x-event-id", "x-published-at", "x-connectum-publish-id"] as const;
+
+interface FakeSubscription {
+    readonly patterns: string[];
+    readonly handler: RawEventHandler;
+    readonly group: string | null;
+    active: boolean;
+}
+
+interface ParkedSubscribe {
+    readonly register: () => EventSubscription;
+    readonly resolve: (sub: EventSubscription) => void;
+    readonly reject: (err: Error) => void;
+}
+
+/**
+ * Create a programmable AMQP adapter test double.
+ *
+ * @example
+ * ```typescript
+ * import { FakeAmqpAdapter } from '@connectum/events-amqp/testing';
+ * import { AmqpPublishTimeoutError } from '@connectum/events-amqp';
+ *
+ * const fake = FakeAmqpAdapter();
+ * const bus = createEventBus({ adapter: fake, routes: [eventRoutes] });
+ * await bus.start();
+ *
+ * // The state-UNKNOWN outcome, untestable against a real broker:
+ * fake.control.nextPublish(new AmqpPublishTimeoutError('no outcome (UNKNOWN)'));
+ * await assert.rejects(() => bus.publish(OrderSchema, order), AmqpPublishTimeoutError);
+ *
+ * fake.control.dropConnection();          // disconnected → reconnecting
+ * fake.control.completeRecovery();        // connected { reconnected: true }
+ * ```
+ */
+export function FakeAmqpAdapter(options: FakeAmqpAdapterOptions = {}): FakeAmqpAdapterInstance {
+    const lifecycle = options.lifecycle;
+
+    let state: ConnectionState = CONNECTION_STATE.CREATED;
+    let reassertAttempt = 0;
+    const pendingSetupFailures: Array<{ error: Error }> = [];
+    const publishOutcomes: FakePublishOutcome[] = [];
+    const published: FakePublishedRecord[] = [];
+    const subscriptions: FakeSubscription[] = [];
+    const parkedSubscribes: ParkedSubscribe[] = [];
+
+    const queuedSetupFailure = (): { error: Error } | undefined => pendingSetupFailures.shift();
+
+    const registerSubscription = (patterns: string[], handler: RawEventHandler, group: string | null): EventSubscription => {
+        const sub: FakeSubscription = { patterns, handler, group, active: true };
+        subscriptions.push(sub);
+        return {
+            async unsubscribe(): Promise<void> {
+                sub.active = false;
+            },
+        };
+    };
+
+    const control: FakeAmqpControl = {
+        failSetup(error?: Error, object?: AmqpTopologyObject): void {
+            const err =
+                error ??
+                new AmqpTopologyError(
+                    "Topology check failed (missing broker object): NOT_FOUND",
+                    object !== undefined
+                        ? { cause: Object.assign(new Error("NOT_FOUND"), { code: 404 }), object }
+                        : { cause: Object.assign(new Error("NOT_FOUND"), { code: 404 }) },
+                );
+            pendingSetupFailures.push({ error: err });
+        },
+
+        dropConnection(error?: Error): void {
+            if (state !== CONNECTION_STATE.CONNECTED) {
+                throw new Error(`FakeAmqpAdapter.control.dropConnection(): adapter is '${state}', not 'connected'`);
+            }
+            const err = error ?? new Error("Connection closed: 320 (connection-forced)");
+            state = CONNECTION_STATE.RECOVERING;
+            reassertAttempt = 0;
+            dispatchLifecycle(lifecycle, { type: "disconnected", error: err });
+            reassertAttempt += 1;
+            dispatchLifecycle(lifecycle, { type: "reconnecting", attempt: reassertAttempt, delay: 0, error: err });
+        },
+
+        completeRecovery(): void {
+            if (state !== CONNECTION_STATE.RECOVERING) {
+                throw new Error(`FakeAmqpAdapter.control.completeRecovery(): adapter is '${state}', not 'recovering'`);
+            }
+            const failure = queuedSetupFailure();
+            if (failure) {
+                // Re-assert failed: mirrors connect-failed (+ reconnect-scheduled)
+                // of the real recovery. The setup-failed event is gated on
+                // AmqpTopologyError exactly like the real wiring; delay is 0
+                // (the fake does not model backoff).
+                if (failure.error instanceof AmqpTopologyError) {
+                    dispatchLifecycle(lifecycle, { type: "setup-failed", initial: false, attempt: reassertAttempt, error: failure.error });
+                }
+                reassertAttempt += 1;
+                dispatchLifecycle(lifecycle, { type: "reconnecting", attempt: reassertAttempt, delay: 0, error: failure.error });
+                return;
+            }
+            state = CONNECTION_STATE.CONNECTED;
+            dispatchLifecycle(lifecycle, { type: "connected", reconnected: true });
+            // Parked mid-recovery subscribes complete with the recovery, like
+            // the real adapter's waiter queue.
+            for (const parked of parkedSubscribes.splice(0)) {
+                parked.resolve(parked.register());
+            }
+        },
+
+        exhaustRecovery(error?: Error): void {
+            if (state !== CONNECTION_STATE.RECOVERING) {
+                throw new Error(`FakeAmqpAdapter.control.exhaustRecovery(): adapter is '${state}', not 'recovering'`);
+            }
+            state = CONNECTION_STATE.DEAD;
+            dispatchLifecycle(lifecycle, { type: "reconnect-failed", error: error ?? new Error("recovery exhausted") });
+            // The cycle died — so did its consumers and any parked subscribes
+            // (same typed error the real startConsumer remaps to).
+            for (const sub of subscriptions) {
+                sub.active = false;
+            }
+            for (const parked of parkedSubscribes.splice(0)) {
+                parked.reject(new AmqpConnectionError("Connection lost while establishing consumer channel", { cause: error }));
+            }
+        },
+
+        block(reason = "memory alarm"): void {
+            dispatchLifecycle(lifecycle, { type: "blocked", reason });
+        },
+
+        unblock(): void {
+            dispatchLifecycle(lifecycle, { type: "unblocked" });
+        },
+
+        nextPublish(...outcomes: FakePublishOutcome[]): void {
+            publishOutcomes.push(...outcomes);
+        },
+
+        get published(): readonly FakePublishedRecord[] {
+            return published;
+        },
+
+        async deliver(
+            eventType: string,
+            payload: Uint8Array,
+            deliverOptions?: { readonly metadata?: Record<string, string>; readonly attempt?: number },
+        ): Promise<FakeDeliveryResult> {
+            if (state !== CONNECTION_STATE.CONNECTED) {
+                // A real broker cannot deliver during a drop window or after a
+                // terminal reconnect-failed.
+                throw new Error(`FakeAmqpAdapter.control.deliver(): adapter is '${state}', not 'connected'`);
+            }
+            const rawMetadata = new Map<string, string>(Object.entries(deliverOptions?.metadata ?? {}));
+            const eventId = rawMetadata.get("x-event-id") ?? randomUUID();
+            const publishedAtHeader = rawMetadata.get("x-published-at");
+            const publishedAt = publishedAtHeader !== undefined ? new Date(publishedAtHeader) : new Date();
+            // The real consumer strips the internal envelope from
+            // handler-visible metadata.
+            for (const key of INTERNAL_HEADERS) {
+                rawMetadata.delete(key);
+            }
+            const event: RawEvent = {
+                eventId,
+                eventType,
+                payload,
+                publishedAt,
+                attempt: deliverOptions?.attempt ?? 1,
+                metadata: rawMetadata,
+            };
+
+            // Competing-consumer parity: one delivery per DISTINCT group, plus
+            // every group-less (fan-out) subscription.
+            const seenGroups = new Set<string>();
+            const targets: FakeSubscription[] = [];
+            for (const sub of subscriptions) {
+                if (!sub.active || !sub.patterns.some((pattern) => matchPattern(pattern, eventType))) {
+                    continue;
+                }
+                if (sub.group === null) {
+                    targets.push(sub);
+                } else if (!seenGroups.has(sub.group)) {
+                    seenGroups.add(sub.group);
+                    targets.push(sub);
+                }
+            }
+
+            let acked = 0;
+            let nacked = 0;
+            let requeued = 0;
+            let failed = 0;
+            // allSettled + swallowed rejections: the real consumer catches a
+            // throwing handler and nacks for redelivery instead of propagating.
+            const settlements = await Promise.allSettled(
+                targets.map((sub) =>
+                    sub.handler(
+                        event,
+                        async () => {
+                            acked += 1;
+                        },
+                        async (requeue?: boolean) => {
+                            if (requeue) {
+                                requeued += 1;
+                            } else {
+                                nacked += 1;
+                            }
+                        },
+                    ),
+                ),
+            );
+            for (const settlement of settlements) {
+                if (settlement.status === "rejected") {
+                    failed += 1;
+                }
+            }
+            return { delivered: targets.length, acked, nacked, requeued, failed };
+        },
+    };
+
+    const adapter: FakeAmqpAdapterInstance = {
+        name: "fake-amqp",
+        control,
+
+        async connect(_context?: AdapterContext): Promise<void> {
+            if (state === CONNECTION_STATE.CONNECTED || state === CONNECTION_STATE.RECOVERING || state === CONNECTION_STATE.DEAD) {
+                // Parity: the real adapter keeps `connection` non-null through
+                // the whole recovery window AND after a plain retries-exhausted
+                // reconnect-failed — reconnecting requires disconnect() first.
+                throw new AmqpConnectionError("AmqpAdapter: already connected");
+            }
+            const failure = queuedSetupFailure();
+            if (failure) {
+                if (failure.error instanceof AmqpTopologyError) {
+                    // Probe semantics (#200): a DETERMINISTIC startup failure
+                    // is observable and rejects typed under fail-fast.
+                    dispatchLifecycle(lifecycle, { type: "setup-failed", initial: true, attempt: 0, error: failure.error });
+                    if (options.failFastOnInitialSetupError) {
+                        throw failure.error;
+                    }
+                }
+                // Non-topology (transient) failure, or fail-fast off: the fake
+                // proceeds (documented divergence — the real adapter would
+                // block inside recovery).
+            }
+            state = CONNECTION_STATE.CONNECTED;
+            reassertAttempt = 0;
+            dispatchLifecycle(lifecycle, { type: "connected", reconnected: false });
+        },
+
+        async disconnect(): Promise<void> {
+            // Own disconnect is not a "loss": no disconnected event (parity
+            // with the real adapter). A fresh connect() afterwards works.
+            state = CONNECTION_STATE.CLOSED;
+            for (const sub of subscriptions) {
+                sub.active = false;
+            }
+            subscriptions.length = 0;
+            for (const parked of parkedSubscribes.splice(0)) {
+                parked.reject(new AmqpConnectionError("Connection lost while establishing consumer channel"));
+            }
+        },
+
+        async publish(eventType: string, payload: Uint8Array, publishOptions?: PublishOptions): Promise<void> {
+            if (state !== CONNECTION_STATE.CONNECTED) {
+                // Same message as the real adapter's fail-fast path.
+                throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
+            }
+            const outcome = publishOutcomes.shift() ?? "ack";
+            if (outcome !== "ack") {
+                throw outcome;
+            }
+            published.push({ eventType, payload, ...(publishOptions !== undefined ? { options: publishOptions } : {}) });
+        },
+
+        async subscribe(patterns: string[], handler: RawEventHandler, subOptions?: RawSubscribeOptions): Promise<EventSubscription> {
+            const group = subOptions?.group ?? null;
+            if (state === CONNECTION_STATE.RECOVERING) {
+                // Parity: the real adapter accepts a mid-recovery subscribe —
+                // channel creation parks in the recovery wrapper's waiter
+                // queue and settles with the recovery outcome.
+                return new Promise<EventSubscription>((resolve, reject) => {
+                    parkedSubscribes.push({
+                        register: () => registerSubscription(patterns, handler, group),
+                        resolve,
+                        reject,
+                    });
+                });
+            }
+            if (state !== CONNECTION_STATE.CONNECTED) {
+                throw new AmqpConnectionError("AmqpAdapter: not connected (or recovery in progress)");
+            }
+            return registerSubscription(patterns, handler, group);
+        },
+    };
+
+    return adapter;
+}

--- a/packages/events-amqp/tests/unit/FakeAmqpAdapter.test.ts
+++ b/packages/events-amqp/tests/unit/FakeAmqpAdapter.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for the programmable AMQP test double (#203,
+ * `@connectum/events-amqp/testing`).
+ *
+ * The fake's contract is PARITY with the real adapter's observable surfaces:
+ * the canonical lifecycle union (via the real `dispatchLifecycle` — shim and
+ * isolation come along by construction), the typed error taxonomy, and the
+ * probe-then-recover `connect()` semantics.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createEventBus } from "@connectum/events";
+import { AmqpConnectionError, AmqpPublishNackError, AmqpTopologyError } from "../../src/errors.ts";
+import { FakeAmqpAdapter } from "../../src/testing.ts";
+import type { AmqpLifecycleEvent } from "../../src/types.ts";
+
+describe("FakeAmqpAdapter lifecycle parity", () => {
+    it("connect → drop → recover replays the canonical union sequence with correct reconnected flags", async () => {
+        const events: AmqpLifecycleEvent[] = [];
+        const flat: string[] = [];
+        const fake = FakeAmqpAdapter({
+            lifecycle: {
+                onLifecycle: (event) => events.push(event),
+                onConnected: () => flat.push("connected"),
+                onDisconnected: () => flat.push("disconnected"),
+            },
+        });
+
+        await fake.connect();
+        fake.control.dropConnection(new Error("dropped"));
+        fake.control.completeRecovery();
+
+        assert.deepEqual(
+            events.map((e) => e.type),
+            ["connected", "disconnected", "reconnecting", "connected"],
+        );
+        assert.deepEqual(
+            events.filter((e) => e.type === "connected"),
+            [
+                { type: "connected", reconnected: false },
+                { type: "connected", reconnected: true },
+            ],
+        );
+        // The flat shim fires too — the fake routes through the REAL dispatch.
+        assert.deepEqual(flat, ["connected", "disconnected", "connected"]);
+    });
+
+    it("failSetup + failFastOnInitialSetupError: connect() rejects typed after setup-failed{initial:true} (probe parity)", async () => {
+        const events: AmqpLifecycleEvent[] = [];
+        const fake = FakeAmqpAdapter({
+            failFastOnInitialSetupError: true,
+            lifecycle: { onLifecycle: (event) => events.push(event) },
+        });
+        fake.control.failSetup(undefined, { kind: "queue", name: "orders.q" });
+
+        await assert.rejects(
+            () => fake.connect(),
+            (err: unknown) => {
+                assert.ok(err instanceof AmqpTopologyError);
+                assert.deepEqual(err.object, { kind: "queue", name: "orders.q" });
+                return true;
+            },
+        );
+        assert.deepEqual(
+            events.map((e) => e.type),
+            ["setup-failed"],
+        );
+        assert.deepEqual(events[0], { type: "setup-failed", initial: true, attempt: 0, error: (events[0] as { error: Error }).error });
+    });
+
+    it("failSetup WITHOUT fail-fast: reported and connects anyway (documented divergence)", async () => {
+        const events: string[] = [];
+        const fake = FakeAmqpAdapter({ lifecycle: { onLifecycle: (event) => events.push(event.type) } });
+        fake.control.failSetup();
+
+        await fake.connect();
+        assert.deepEqual(events, ["setup-failed", "connected"]);
+    });
+
+    it("re-assert failure during recovery: setup-failed{initial:false, attempt} then the next reconnecting", async () => {
+        const events: AmqpLifecycleEvent[] = [];
+        const fake = FakeAmqpAdapter({ lifecycle: { onLifecycle: (event) => events.push(event) } });
+        await fake.connect();
+        fake.control.dropConnection();
+        fake.control.failSetup();
+        fake.control.completeRecovery(); // consumes the failure, stays recovering
+        fake.control.completeRecovery(); // heals
+
+        const types = events.map((e) => e.type);
+        assert.deepEqual(types, ["connected", "disconnected", "reconnecting", "setup-failed", "reconnecting", "connected"]);
+        const setupFailed = events.find((e) => e.type === "setup-failed") as { initial: boolean; attempt: number };
+        assert.equal(setupFailed.initial, false);
+        assert.equal(setupFailed.attempt, 1);
+        const reconnects = events.filter((e) => e.type === "reconnecting") as Array<{ attempt: number }>;
+        assert.deepEqual(
+            reconnects.map((r) => r.attempt),
+            [1, 2],
+            "attempt numbering is 1-based and consecutive",
+        );
+    });
+
+    it("exhaustRecovery: terminal reconnect-failed; the dead adapter fails publishes fast (message parity)", async () => {
+        const events: string[] = [];
+        const fake = FakeAmqpAdapter({ lifecycle: { onLifecycle: (event) => events.push(event.type) } });
+        await fake.connect();
+        fake.control.dropConnection();
+        fake.control.exhaustRecovery();
+
+        assert.deepEqual(events, ["connected", "disconnected", "reconnecting", "reconnect-failed"]);
+        await assert.rejects(
+            () => fake.publish("t", new Uint8Array([1])),
+            (err: unknown) => err instanceof AmqpConnectionError && /not connected \(or recovery in progress\)/.test((err as Error).message),
+        );
+    });
+
+    it("blocked/unblocked surface as union-only events", async () => {
+        const union: string[] = [];
+        let flatFired = 0;
+        const fake = FakeAmqpAdapter({
+            lifecycle: {
+                onLifecycle: (event) => union.push(event.type),
+                onConnected: () => {
+                    flatFired += 1;
+                },
+            },
+        });
+        await fake.connect();
+        fake.control.block("disk alarm");
+        fake.control.unblock();
+
+        assert.deepEqual(union, ["connected", "blocked", "unblocked"]);
+        assert.equal(flatFired, 1, "flat callbacks see only their own events");
+    });
+});
+
+describe("FakeAmqpAdapter state machine parity", () => {
+    it("double connect() throws 'already connected'; RECOVERING and DEAD also refuse (real: connection stays non-null)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+        await assert.rejects(() => fake.connect(), /already connected/);
+
+        fake.control.dropConnection();
+        await assert.rejects(() => fake.connect(), /already connected/, "connect() during recovery mirrors the real non-null connection");
+
+        fake.control.exhaustRecovery();
+        await assert.rejects(() => fake.connect(), /already connected/, "a plain retries-exhausted adapter requires disconnect() first");
+
+        await fake.disconnect();
+        await fake.connect(); // CLOSED → fresh connect works, like the real adapter
+    });
+
+    it("a mid-recovery subscribe PARKS and completes with the recovery (real waiter-queue parity)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+        fake.control.dropConnection();
+
+        const got: string[] = [];
+        const parked = fake.subscribe(["evt"], async (event) => {
+            got.push(event.eventType);
+        });
+        let settled = false;
+        parked.then(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+        assert.equal(settled, false, "the subscribe is parked while recovering");
+
+        fake.control.completeRecovery();
+        await parked;
+        await fake.control.deliver("evt", new Uint8Array());
+        assert.deepEqual(got, ["evt"], "the parked subscription became active with the recovery");
+    });
+
+    it("a parked subscribe rejects typed when recovery exhausts (real startConsumer remap parity)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+        fake.control.dropConnection();
+
+        const parked = fake.subscribe(["evt"], async () => undefined);
+        fake.control.exhaustRecovery();
+
+        await assert.rejects(
+            () => parked,
+            (err: unknown) => err instanceof AmqpConnectionError && /establishing consumer channel/.test((err as Error).message),
+        );
+    });
+
+    it("unsubscribe() deactivates; disconnect() clears; exhaustRecovery() kills consumers", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        const got: string[] = [];
+        const sub = await fake.subscribe(["evt"], async () => {
+            got.push("hit");
+        });
+        await sub.unsubscribe();
+        const afterUnsub = await fake.control.deliver("evt", new Uint8Array());
+        assert.equal(afterUnsub.delivered, 0, "an unsubscribed handler is not invoked");
+
+        await fake.subscribe(["evt"], async () => {
+            got.push("hit2");
+        });
+        fake.control.dropConnection();
+        fake.control.exhaustRecovery();
+        await fake.disconnect();
+        await fake.connect();
+        const afterDeath = await fake.control.deliver("evt", new Uint8Array());
+        assert.equal(afterDeath.delivered, 0, "subscriptions do not survive a dead cycle (the real fatal/exhausted teardown)");
+    });
+
+    it("deliver() requires the connected state (a real broker cannot deliver into a drop window)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+        fake.control.dropConnection();
+        await assert.rejects(() => fake.control.deliver("evt", new Uint8Array()), /'recovering', not 'connected'/);
+    });
+
+    it("non-topology failSetup follows the real gating: no setup-failed event anywhere", async () => {
+        const events: string[] = [];
+        const fake = FakeAmqpAdapter({ failFastOnInitialSetupError: true, lifecycle: { onLifecycle: (event) => events.push(event.type) } });
+
+        fake.control.failSetup(new Error("ECONNRESET mid-setup"));
+        await fake.connect(); // consumed silently, no fail-fast (transient class)
+        assert.deepEqual(events, ["connected"], "a non-topology startup failure emits no setup-failed and does not fail fast");
+
+        fake.control.dropConnection();
+        fake.control.failSetup(new Error("ECONNRESET again"));
+        fake.control.completeRecovery();
+        assert.deepEqual(
+            events.filter((e) => e === "setup-failed"),
+            [],
+            "a non-topology re-assert failure schedules the next attempt without setup-failed",
+        );
+        assert.equal(events.filter((e) => e === "reconnecting").length, 2, "the failed re-assert scheduled another attempt");
+    });
+});
+
+describe("FakeAmqpAdapter delivery settlement", () => {
+    it("records ack/nack/requeue/failed; handler rejections are swallowed (real consumer parity)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        await fake.subscribe(["evt"], async (_e, ack) => ack(), { group: "acker" });
+        await fake.subscribe(["evt"], async (_e, _ack, nack) => nack(false), { group: "nacker" });
+        await fake.subscribe(["evt"], async (_e, _ack, nack) => nack(true), { group: "requeuer" });
+        await fake.subscribe(["evt"], async () => {
+            throw new Error("handler bug");
+        }, { group: "thrower" });
+
+        const result = await fake.control.deliver("evt", new Uint8Array());
+        assert.deepEqual(result, { delivered: 4, acked: 1, nacked: 1, requeued: 1, failed: 1 });
+    });
+
+    it("strips internal envelope headers and honors x-published-at (real consumer parity)", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        let seen: { eventId: string; publishedAt: string; keys: string[] } | null = null;
+        await fake.subscribe(["evt"], async (event) => {
+            seen = { eventId: event.eventId, publishedAt: event.publishedAt.toISOString(), keys: [...event.metadata.keys()] };
+        });
+        await fake.control.deliver("evt", new Uint8Array(), {
+            metadata: {
+                "x-event-id": "fixed-id",
+                "x-published-at": "2026-01-02T03:04:05.000Z",
+                "x-connectum-publish-id": "corr",
+                k: "v",
+            },
+        });
+
+        assert.deepEqual(seen, { eventId: "fixed-id", publishedAt: "2026-01-02T03:04:05.000Z", keys: ["k"] });
+    });
+});
+
+describe("FakeAmqpAdapter publish outcomes", () => {
+    it("FIFO outcomes: queued errors reject in order, empty queue acks and records", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        fake.control.nextPublish(new AmqpPublishNackError("nacked"), new AmqpConnectionError("blip"));
+
+        await assert.rejects(() => fake.publish("t", new Uint8Array([1])), AmqpPublishNackError);
+        await assert.rejects(() => fake.publish("t", new Uint8Array([2])), AmqpConnectionError);
+        await fake.publish("t", new Uint8Array([3]), { metadata: { source: "test" } });
+
+        assert.equal(fake.control.published.length, 1, "only acked publishes are recorded");
+        assert.equal(fake.control.published[0]?.eventType, "t");
+        assert.deepEqual(fake.control.published[0]?.options, { metadata: { source: "test" } });
+    });
+
+    it("publish during the recovery window fails fast with the real adapter's message", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+        fake.control.dropConnection();
+
+        await assert.rejects(
+            () => fake.publish("t", new Uint8Array([1])),
+            (err: unknown) => err instanceof AmqpConnectionError && /not connected \(or recovery in progress\)/.test((err as Error).message),
+        );
+    });
+});
+
+describe("FakeAmqpAdapter delivery", () => {
+    it("matches NATS-style wildcards and applies competing-consumer group semantics", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        const got: string[] = [];
+        const record = (name: string): Parameters<typeof fake.subscribe>[1] => {
+            return async (event) => {
+                got.push(`${name}:${event.eventType}`);
+            };
+        };
+
+        await fake.subscribe(["order.>"], record("g1a"), { group: "g1" });
+        await fake.subscribe(["order.>"], record("g1b"), { group: "g1" }); // same group — competes, only one gets it
+        await fake.subscribe(["order.*"], record("g2"), { group: "g2" });
+        await fake.subscribe(["order.created"], record("fanout")); // no group — always delivered
+
+        await fake.control.deliver("order.created", new Uint8Array([1]));
+
+        assert.equal(got.filter((g) => g.startsWith("g1")).length, 1, "one delivery per distinct group");
+        assert.ok(got.includes("g2:order.created"));
+        assert.ok(got.includes("fanout:order.created"));
+    });
+
+    it("passes metadata through and honors x-event-id", async () => {
+        const fake = FakeAmqpAdapter();
+        await fake.connect();
+
+        let seen: { eventId: string; meta: string | undefined } | null = null;
+        await fake.subscribe(["evt"], async (event) => {
+            seen = { eventId: event.eventId, meta: event.metadata.get("k") };
+        });
+        await fake.control.deliver("evt", new Uint8Array(), { metadata: { "x-event-id": "fixed-id", k: "v" } });
+
+        assert.deepEqual(seen, { eventId: "fixed-id", meta: "v" });
+    });
+});
+
+describe("FakeAmqpAdapter with the real EventBus", () => {
+    it("is a drop-in EventAdapter: bus start/publish/stop against the fake", async () => {
+        const { create } = await import("@bufbuild/protobuf");
+        const { StructSchema } = await import("@bufbuild/protobuf/wkt");
+
+        const fake = FakeAmqpAdapter();
+        const bus = createEventBus({ adapter: fake });
+        await bus.start();
+
+        // The bus resolves the topic (typeName fallback) and hands the
+        // serialized payload to the fake — the record proves interface
+        // fidelity end-to-end.
+        await bus.publish(StructSchema, create(StructSchema, {}));
+        assert.equal(fake.control.published.length, 1);
+        assert.equal(fake.control.published[0]?.eventType, StructSchema.typeName);
+
+        await bus.stop();
+    });
+});

--- a/packages/events-amqp/tests/unit/dist-parity.test.ts
+++ b/packages/events-amqp/tests/unit/dist-parity.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Pin the packaging invariant of the dual-entry build (#203): the /testing
+ * subpath and the main barrel must share ONE copy of the error classes.
+ * Without tsup `splitting: true` each bundle gets its own errors.ts copy and
+ * `instanceof` breaks across the boundary in the PUBLISHED package — the
+ * exact failure this test guards against. Runs against dist/ (built before
+ * tests by the turbo pipeline).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("dist packaging parity (#203)", () => {
+    it("errors thrown by dist/testing.js are instanceof the classes exported by dist/index.js", async () => {
+        const testing = await import("../../dist/testing.js");
+        const barrel = await import("../../dist/index.js");
+
+        const fake = testing.FakeAmqpAdapter();
+        await assert.rejects(
+            () => fake.publish("x", new Uint8Array()),
+            (err: unknown) => {
+                assert.ok(err instanceof barrel.AmqpConnectionError, "instanceof must hold across the subpath boundary (shared chunk, not a duplicated class)");
+                return true;
+            },
+        );
+    });
+});

--- a/packages/events-amqp/tsup.config.ts
+++ b/packages/events-amqp/tsup.config.ts
@@ -1,13 +1,18 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/testing.ts"],
     format: ["esm"],
     dts: true,
     sourcemap: true,
     clean: true,
     minify: false,
-    splitting: false,
+    // Shared chunks are REQUIRED with the dual entry: without splitting each
+    // bundle gets its own COPY of errors.ts, and `instanceof` breaks between
+    // `@connectum/events-amqp` and the `/testing` subpath (the fake would
+    // throw class objects different from the barrel's) — pinned by
+    // tests/unit/dist-parity.test.ts.
+    splitting: true,
     // Keep the node: prefix on builtin imports — required for node:test/sqlite and portable to Deno/Bun.
     removeNodeProtocol: false,
 });

--- a/packages/events/README.md
+++ b/packages/events/README.md
@@ -458,7 +458,7 @@ const bus = createEventBus({ adapter: MemoryAdapter(), routes: [eventRoutes] });
 **Test doubles:**
 
 - `MemoryAdapter` (exported here) — in-process pub/sub for the generic happy path: routing, handlers, middleware, DLQ flows.
-- Broker-specific failure semantics (typed AMQP error taxonomy, recovery/lifecycle behavior) cannot be modeled generically — a programmable `FakeAmqpAdapter` will ship via the `@connectum/events-amqp/testing` subpath (tracked in [#203](https://github.com/Connectum-Framework/connectum/issues/203)).
+- Broker-specific failure semantics (typed AMQP error taxonomy, recovery/lifecycle behavior) cannot be modeled generically — use the programmable `FakeAmqpAdapter` from the `@connectum/events-amqp/testing` subpath (since 1.3.0; see the [events-amqp Testing section](../events-amqp/README.md#testing)).
 - For real-broker integration semantics, see each adapter package's testing notes.
 
 ## Exports Summary

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@bufbuild/buf':
       specifier: ^1.70.0
       version: 1.70.0
+    '@bufbuild/protobuf':
+      specifier: ^2.12.1
+      version: 2.12.1
     '@bufbuild/protoc-gen-es':
       specifier: ^2.12.1
       version: 2.12.1
@@ -317,6 +320,9 @@ importers:
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 2.5.0
+      '@bufbuild/protobuf':
+        specifier: 'catalog:'
+        version: 2.12.1
       '@connectum/events':
         specifier: workspace:^
         version: link:../events

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@bufbuild/buf':
       specifier: ^1.70.0
       version: 1.70.0
-    '@bufbuild/protobuf':
-      specifier: ^2.12.1
-      version: 2.12.1
     '@bufbuild/protoc-gen-es':
       specifier: ^2.12.1
       version: 2.12.1
@@ -321,7 +318,7 @@ importers:
         specifier: 'catalog:'
         version: 2.5.0
       '@bufbuild/protobuf':
-        specifier: 'catalog:'
+        specifier: ^2.12.1
         version: 2.12.1
       '@connectum/events':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

Ships the programmable **`FakeAmqpAdapter`** test double via the new **`@connectum/events-amqp/testing`** subpath — the last PR of the 1.3.0 events-resilience cluster. Placement per the design pass on #203: broker-specific failure semantics (typed error taxonomy, recovery/lifecycle behavior) cannot be modeled generically, so the fake lives in the AMQP package, not `@connectum/testing` (which would grow an amqplib dependency) and not `@connectum/events` (`MemoryAdapter` already covers the generic happy path).

Closes #203

## What's included

**The fake (`src/testing.ts`, new subpath export):**

- `FakeAmqpAdapter(options?)` → `{ ...EventAdapter, control: FakeAmqpControl }`; accepts `lifecycle` callbacks and `failFastOnInitialSetupError`, mirroring the real adapter's option names.
- **FIFO publish outcomes** — `control.nextPublish(...errors)` queues typed rejections (`AmqpPublishNackError`, `AmqpPublishTimeoutError`, …); an empty queue acks and records to `control.published`. Makes #195's retry policies unit-testable, including the state-UNKNOWN timeout outcome no real broker reproduces deterministically.
- **Deterministic lifecycle** — `dropConnection()` / `completeRecovery()` / `exhaustRecovery()` / `failSetup(error)` / `block()`/`unblock()`. Events are emitted through the real adapter's `dispatchLifecycle`, so the canonical #197 union ordering, the deprecated flat shim, and exception isolation match by construction.
- **State-machine parity** — `connect()` on a live/recovering/retries-exhausted fake throws `already connected` exactly like the real non-null-connection guard; a mid-recovery `subscribe()` **parks** and settles with the recovery outcome (resolves on `completeRecovery`, rejects typed on `exhaustRecovery`); `setup-failed` and fail-fast gate on `instanceof AmqpTopologyError`, mirroring the real probe classification.
- **Delivery with settlement** — `control.deliver()` supports NATS-style wildcards + competing-consumer groups, strips internal envelope headers (`x-event-id`, `x-published-at`) like the real consumer, swallows handler rejections (the real nack-on-error path), and returns `{ delivered, acked, nacked, requeued, failed }`.
- Runtime-pure: the subpath pulls neither `amqplib` nor `node:test` into the consumer graph.

**Packaging:**

- Dual tsup entry (`index` + `testing`) with `splitting: true` — **required**: without shared chunks each bundle gets its own copy of `errors.ts` and `instanceof` breaks between the subpath and the barrel in the published package. Pinned by the new `tests/unit/dist-parity.test.ts`, which asserts `instanceof` across `dist/testing.js` × `dist/index.js`.

**Docs:**

- README **Testing** section: parity contract, documented divergences (no timing simulation; settlement recorded, not broker-driven; report-and-proceed on non-fail-fast startup setup failure), `MemoryAdapter` vs fake vs integration guidance.
- `@connectum/events` README: the #203 forward reference flipped to present tense.

## Change type

- [x] New feature (minor, `@connectum/events-amqp`)
- [ ] Breaking change

## Validation

- Unit: 74/74 across node / bun / esbuild (three suites: adapter, fake, dist-parity).
- Integration: 12/12 against a live RabbitMQ 4 broker, plus the full recovery matrix 32/32 (`RUN_RECOVERY_TESTS=1`, testcontainers + Toxiproxy) — both against the **chunked** dist produced by `splitting: true`.
- Monorepo build/typecheck/test and lint green (15 packages).
- Pre-PR adversarial review: 11 confirmed findings (state-machine parity gaps, the `splitting` packaging break, settlement semantics) — all addressed; the packaging fix verified against the built artifacts.

## Related

- Design pass: #203 (comment thread)
- Cluster: #195 #196 #197 #198 #201 #202 #204 (all shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Sp8jYmRXyvUmsErDuNJvt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new testing subpath for AMQP users, including a fake adapter for deterministic publish, delivery, and connection lifecycle simulation.
  * Expanded packaging to expose the new testing entry alongside the main library.
* **Documentation**
  * Added guidance and examples for using the new test double, including expected behaviors and known differences from a real broker.
* **Tests**
  * Added coverage for adapter behavior, delivery handling, and package build parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->