### PR TITLE
docs(typedoc): include the events-amqp testing subpath in the API reference entry points (#203)

### DIFF
--- a/packages/events-amqp/typedoc.json
+++ b/packages/events-amqp/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/index.ts", "src/types.ts"],
+  "entryPoints": ["src/index.ts", "src/types.ts", "src/testing.ts"],
 
   "tsconfig": "../../tsconfig.json"
 }


### PR DESCRIPTION
## Summary

Follow-up to #224: the new `@connectum/events-amqp/testing` subpath was not listed in the package's TypeDoc `entryPoints`, so `pnpm docs:api` silently omitted the `FakeAmqpAdapter` API pages (the docs-repo pages were generated with this fix applied locally — without it, the next full regen would drop them again).

- `packages/events-amqp/typedoc.json`: `entryPoints` += `src/testing.ts`.

## Change type

- [x] Documentation / tooling (no runtime change)
- [ ] New feature
- [ ] Breaking change

## Test plan

- `pnpm docs:api` regenerates the API reference with 8 new `testing/` pages (`FakeAmqpAdapter`, `FakeAmqpControl`, options/result types) — verified locally; the generated pages shipped in Connectum-Framework/docs#63.
- CI: full pipeline green (docs-only change; no package behavior affected).

## Parity coverage

N/A — TypeDoc configuration only; no runtime or contract surface.

## Related

- #224 (the subpath this documents), #203 (the feature issue)
- Connectum-Framework/docs#63 (the docs companion generated with this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Sp8jYmRXyvUmsErDuNJvt
